### PR TITLE
fix: remove tailwind.config.js from Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM node:20-slim AS frontend-builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci
-COPY vite.config.ts tsconfig.json tsconfig.node.json tailwind.config.js postcss.config.js ./
+COPY vite.config.ts tsconfig.json tsconfig.node.json postcss.config.js ./
 COPY src/frontend/ ./src/frontend/
 RUN npm run build
 


### PR DESCRIPTION
## Summary
- `tailwind.config.js` was deleted in the tailwindcss v4 migration (#68) but the Dockerfile `COPY` command still referenced it, causing Cloud Build to fail at step 5/15

## Test plan
- [ ] Cloud Build succeeds past step 5/15
- [ ] Full build and deploy to Cloud Run succeeds