### PR TITLE
docs: refine phase 1 feature specs

### DIFF
--- a/features/cicd-staging/spec.md
+++ b/features/cicd-staging/spec.md
@@ -34,7 +34,7 @@ Automated tests run against staging. The same image is promoted to production on
 ## Open Questions
 
 ### Environment Isolation
-- Separate GCP project for staging vs. same project with separate Cloud Run services?
+- **Decided:** same GCP project, separate Cloud Run service for staging (no separate GCP project)
 - Staging DB strategy: separate Cloud SQL instance, same instance with a separate database, or schema isolation?
 - How are staging secrets managed in GCP Secret Manager (separate secret names/versions vs. environment
   variable override)?

--- a/features/error-handling/spec.md
+++ b/features/error-handling/spec.md
@@ -3,42 +3,137 @@
 ## Background
 
 There is currently no consistent error handling strategy across the frontend or backend. API failures during
-gameplay have undefined behavior from the user's perspective. There is no 404 page. React error boundaries are
-not implemented. Session expiry during a game is not handled gracefully.
+gameplay have undefined behavior from the user's perspective. There is no 404 page. React error boundaries
+are not implemented. Session expiry during a game is not handled gracefully.
+
+## Design Principles
+
+These flow from the game-data-persistence model and apply to all discrete-move games:
+
+1. **Server is source of truth.** On any error, desync, or reconnect, the client re-fetches server state
+   and overwrites local state. The client never assumes its local game state is authoritative.
+2. **Games are always recoverable.** Since every valid move is persisted to DB (see game-data-persistence
+   spec), a disconnection or error does not lose game progress. The server can always reconstruct the last
+   valid state.
+3. **Errors are classified, not generic.** Transient errors (network blip, timeout, 503 cold start) trigger
+   retry-and-resync. Server-side failures (data corruption, invalid state, server offline) surface to the
+   user and reject the move without losing prior state.
+
+**Exception: real-time games (Pong and future equivalents).** Continuous-state games do not support session
+recovery. A disconnect resets to a new game. Error handling for real-time games is standardized separately
+in the websocket spec.
+
+**Dependency:** the session recovery model described here requires game-data-persistence to be implemented
+first. Until DB-backed sessions and write-on-every-move are in place, recovery is not possible.
 
 ## Scope
 
-Define and implement a consistent error handling layer across both frontend and backend:
-
 **Frontend:**
 - 404 / unknown route page
-- React error boundaries (catch rendering errors, show fallback UI)
-- API error states: failed requests, timeouts, unexpected response shapes
-- Mid-game error recovery: what happens when a move API call fails
+- React error boundaries with crash loop detection (see below)
+- Global notification service for indirect errors (see below)
+- Inline error display using the shared notification display component
+- API error classification: transient vs. server-side failure, with different UX responses
+- Mid-game error recovery: retry-and-resync for transient failures; move rejection with error message for
+  server-side failures
+- Session resume: "continue your last game?" prompt on login or game page navigation when an in-progress
+  session exists
 - Session expiry detection and prompt to re-authenticate
 
 **Backend:**
 - Consistent error response shape across all `/api/*` endpoints
-- Structured error logging (using `logging`, not `print`) with enough context to diagnose issues
-- Distinguish user errors (4xx) from server errors (5xx) clearly
+- On move validation failure or server error: return the last valid game state alongside the error, so the
+  client can resync without a separate request
+- Structured error logging with enough context to diagnose issues (GCP Cloud Logging only — alerting
+  configured separately in GCP if/when needed)
+- Clear 4xx vs 5xx distinction: user errors vs. server errors
+
+## Mid-Game Error Recovery Flow
+
+```
+Client sends move
+  └─ Transient error (timeout, network, 503)
+       ├─ Retry up to N times with backoff
+       ├─ On retry success: accept server-returned game state (source of truth)
+       └─ On retry exhaustion: push to global notification service, do not advance local state
+
+  └─ Server-side failure (4xx invalid move, 5xx corruption/offline)
+       ├─ Do not retry
+       ├─ Reject the move — local board reverts to last confirmed server state
+       └─ Show inline error; user can attempt the move again or navigate away
+
+  └─ Client reconnects after disconnect (any cause)
+       ├─ Re-fetch game state from server on reconnect
+       ├─ If in-progress session found: offer "continue your last game?" via global notification
+       └─ Server state overwrites any local state unconditionally
+```
+
+## Global Notification Service
+
+Handles errors and events that are not tied to a specific user action or component — session expiry, backend
+failures, connectivity errors surfaced after retry exhaustion, session resume prompts.
+
+**Store (Zustand):**
+- Queue of notification objects: `{ id, level, title, description, timer?, timestamp }`
+- Levels: `info | warning | error`
+- Dedup logic: if an identical notification (same level + title + description) is currently displayed
+  (pre-fade-out), ignore the new push — no cooldown counter needed, just check active set
+- Queue cap: maximum N notifications visible simultaneously; additional notifications wait and follow as
+  active ones fade out
+- Timer management: auto-dequeue after timer elapses; timeless notifications persist until dismissed
+
+**Renderer component (floating):**
+- Reads from Zustand store
+- Handles fade in / wait / fade out animation per notification
+- Stacking and follow-fade effect as notifications clear
+- Positioned as a top-level overlay, not within any game or page component
+
+**Display component (shared):**
+- The visual representation of a single notification (level, title, description)
+- Used by the floating renderer for global notifications
+- Also used directly with props for inline errors — no store involvement, no queue or dedup logic
+- Style may differ between floating and inline contexts; keeping them as separate usages of the same
+  base component allows independent styling without shared-state complexity
+
+**Inline errors** (direct component usage):
+- Form validation, move failures, login errors — shown in context, adjacent to the component that errored
+- Receive props directly; do not interact with the global store
+- No dedup or queue logic needed — inline errors are immediate and tied to a single user action
+
+## React Error Boundaries
+
+- Applied at the route/page level (not globally, not per-component)
+- Catch rendering errors and show a fallback UI with two options: "Reload page" and "Go home"
+- Crash loop detection via localStorage, keyed by route context:
+  - Increment crash counter on each boundary catch
+  - Reset counter on successful render (componentDidUpdate / useEffect)
+  - If counter exceeds threshold (e.g., 3): remove "Reload page" option, show "Go home" only
+  - This handles the case where a reload reproduces the crash deterministically
+- Error boundaries log to OTel (see observability spec)
+
+## Network Offline Detection
+
+Not implemented. For discrete-move games the user is idle between moves and the next API call either
+succeeds or enters the transient error retry path. For real-time games, WebSocket disconnect events handle
+connectivity loss. A proactive offline banner adds complexity for a case that is already covered.
 
 ## Known Requirements
 
-- Error responses from the backend must follow a consistent JSON shape (e.g., `{ "detail": "..." }`) — FastAPI
-  already does this by default via HTTPException, but all handlers must use it uniformly
+- Error responses from the backend must follow a consistent JSON shape:
+  `{ "detail": "...", "game_state": {...} }` — current game state included so clients can resync in one
+  round-trip
 - Frontend error states must not leave the user with a blank screen or a spinner that never resolves
 - Session expiry must redirect or prompt the user to log in — not silently fail
-- All frontend error boundaries must log to OTel (see otel-engagement spec)
+- All React error boundaries must log to OTel (see observability spec)
 - 404 page must be styled consistently with the rest of the site
+- Retry logic must be implemented in a shared API client utility, not duplicated per component
 
 ## Open Questions
 
-- Mid-game API failure: retry automatically, show an error and let the user retry, or abandon the game?
-- Should there be a global error toast/notification system, or are errors handled inline per component?
-- Network offline detection: should the site detect loss of connectivity and show a banner?
-- What is the retry strategy for transient failures (e.g., 503 from Cloud Run cold start)?
-- Should error boundary fallbacks offer a "reload" action, or navigate back to a safe page?
-- Backend: should unexpected 5xx errors notify anyone (email, Slack, PagerDuty) or just log to GCP?
+- Retry count and backoff interval for transient failures — what values are appropriate given Cloud Run
+  cold start latency (~1–2s)? (Implementation detail, to be decided during implementation)
+- Session cutoff for "continue your last game?" prompt — how old is too old to offer resume?
+  (Coordinate with game-data-persistence spec open questions)
 
 ## Test Cases
 

--- a/features/game-data-persistence/spec.md
+++ b/features/game-data-persistence/spec.md
@@ -2,58 +2,99 @@
 
 ## Background
 
-Currently game sessions are stored in-memory within each game module (e.g., `tic_tac_toe_game.sessions`). There
-is no persistent game history, move log, or outcome record. The `game_sessions` table exists in the DB schema
-but is unused. Each game has its own state shape and logic; this spec defines a shared abstraction layer that
-standardizes how game data is written to the database across all games.
+Game sessions are currently stored in-memory within each game module (e.g., `tic_tac_toe_game.sessions`).
+Some DB infrastructure already exists: per-game tables (`tic_tac_toe_games`, `checkers_games`), a generic
+`game_states` JSONB table, and an `ai_training_data` table. However, this schema grew organically and lacks
+a shared abstraction — some games write directly to DB, others do not, and the structure is not designed for
+ML training pipelines or long-term maintainability. The in-memory session model is also fundamentally
+incompatible with session recovery and server-authoritative game state (see Design Principles below).
+
+This spec covers the full scope: schema redesign, migration from existing tables, the persistence abstraction
+layer, and the data capture contract required for stats, analytics, and ML.
+
+## Design Principles
+
+These are non-negotiable constraints that flow from the ML training data requirement and the error handling
+model (see error-handling spec):
+
+1. **Write on every valid move.** Each player move and each AI response move is written to the DB
+   immediately after validation. The DB is the canonical game state — not in-memory session storage.
+2. **DB-backed sessions, not in-memory.** In-memory session dicts are replaced by DB lookups. Any request
+   carrying a valid session_id can reconstruct full game state from the DB alone.
+3. **Server is source of truth.** Clients always accept server state. On reconnect or desync, the client
+   re-fetches and overwrites local state.
+4. **Every valid board position is independently valuable.** ML models for these games need (position →
+   move → outcome) tuples. How a position was reached, whether the game completed, or how long ago it was
+   played is irrelevant — all positions are training candidates.
+5. **Games are resumable indefinitely.** Since state lives in the DB, a user can reconnect days, weeks, or
+   months later and continue a game in progress. A session cutoff policy (see Open Questions) determines
+   when a game is marked abandoned rather than in-progress.
+
+**Exception: real-time games (Pong and future equivalents).** Continuous-state games do not have discrete
+moves suitable for this model. Their game state is lost on disconnect; sessions reset. Data capture for
+real-time games requires a separate strategy defined in the websocket spec.
 
 ## Scope
 
-Design and implement a persistence abstraction layer that any game engine can use to record session lifecycle
-events and per-game state to the database. The game engines own their logic; this layer is the plumbing.
+1. **DB schema design** — audit existing tables, define a future-proof schema that accommodates per-game
+   state shapes, full move logs, and ML training data requirements
+2. **Schema maintainability** — versioned SQL migrations so the schema can evolve without data loss
+3. **Persistence abstraction layer** — a shared backend service all game engines call; game engines do not
+   touch the DB directly
+4. **Data capture contract** — define exactly what is captured at session start, each move (player + AI),
+   and session end to satisfy stats, OTel instrumentation, and ML pipelines
 
 ## Proposed Approach (to be confirmed in planning)
 
-- A shared backend utility/service that game engines call to record: session start, each move, session end +
-  outcome
-- Each game has its own DB table to accommodate different state shapes
-- The abstraction layer handles: connection management, transaction handling, error handling, OTel instrumentation
-- Game engines do not interact with the DB directly — all persistence goes through this layer
-- When the WebSocket feature is implemented, this layer hooks into WebSocket message handling rather than (or in
-  addition to) REST handlers
+- Audit existing tables — identify what to keep, migrate, or replace
+- Adopt versioned SQL migration files (`scripts/migrations/001_*.sql`) rather than a monolithic setup script
+- Replace in-memory session dicts with a `get_or_create_session(session_id)` DB lookup in each game engine
+- A shared `persistence_service.py`: `record_move(session_id, player, move, board_state_after, is_ai)`
+  called immediately after each validated move
+- Per-game tables with typed columns for queryability; a JSONB `move_log` column captures full move history
+  in a format reusable for ML pipelines
+- The abstraction layer handles: connection pooling, transaction handling, error handling, OTel spans
+- When the WebSocket feature is implemented, this layer hooks into WebSocket message handling in addition
+  to REST handlers
 
 ## Known Requirements
 
-- Must not block the game response — DB writes should not add latency to the player's move
-- Each game has a different state shape; the abstraction layer must accommodate per-game schemas without coupling
-  game logic to persistence logic
-- Must integrate with OTel (spans for DB write operations)
-- Data captured must be sufficient to: reconstruct/replay a game, compute win/loss/draw stats per user, and
-  support future ML model training data pipelines
+- Must not block game responses — DB writes are synchronous within the request but must not add perceptible
+  latency (connection pooling already in place via psycopg2 pool)
+- Must accommodate different per-game state shapes without coupling game logic to persistence logic
+- Must integrate with OTel (spans for DB write operations, per observability spec)
+- Data captured per move must be sufficient to:
+  - Reconstruct or replay any game from its move log
+  - Compute win/loss/draw/streak stats per user per game
+  - Produce (position, move, outcome) tuples for ML model training and evaluation
 - Must work with both REST and WebSocket game traffic (see websocket spec)
+- Schema changes must be applied via versioned migrations, not manual edits to setup-database.sql
+- This feature is a hard prerequisite for the error-handling session recovery model
 
 ## Open Questions
 
-### Architecture
-- Async vs. synchronous writes? Fire-and-forget (best-effort) vs. confirmed write before responding to client?
-- Should this be a Python class, a module of functions, or a FastAPI background task dependency?
-- Event-driven model (game engine emits events, layer subscribes) vs. direct call model (engine calls
-  persistence functions explicitly)?
-
 ### Schema Design
-- One generic `game_events` table (event type + JSON payload) vs. per-game tables with typed columns?
-- What is the minimum per-game schema? (session_id, user_id, game_id, started_at, ended_at, outcome,
-  move_count, move_log?)
-- How are in-memory sessions migrated to DB-backed sessions at launch?
+- Audit finding: which existing tables are worth keeping vs. replacing? (`game_states` JSONB is generic but
+  untyped; per-game tables have typed columns but no shared structure)
+- One shared `game_sessions` table with per-game typed tables for moves, or fully per-game schemas?
+- What is the canonical move log format? (Structured JSONB per move vs. encoded string like current
+  `move_sequence TEXT`)
+- What ML-specific fields are needed beyond game outcome + move log? (time-per-move, difficulty, board
+  evaluation score if available from the engine?)
 
-### Data Requirements
-- What data attributes are needed for ML model training vs. just stats?
-- Should individual moves be stored (full move log) or only final state?
-- Retention / archival policy for game history?
+### Session Lifecycle
+- What is the cutoff for marking a game abandoned vs. in-progress? (30 days? 1 year? User-configurable?)
+- Can a user have multiple in-progress games simultaneously across different game types?
+- What triggers the "continue your last game?" prompt — login, navigating to a game page, or both?
 
-### Multi-game Coordination
-- When multiple games are active simultaneously, how is connection pooling managed across concurrent writes?
-- Does each game get its own DB connection or share a pool?
+### Migration Strategy
+- How are existing in-memory sessions handled at cutover — dropped or flushed to DB first?
+- How are existing `tic_tac_toe_games` and `checkers_games` records migrated if schema changes?
+- Is Alembic appropriate here, or hand-written versioned SQL files sufficient?
+
+### Architecture
+- Async vs. synchronous writes? Given the write-on-every-move requirement, this tradeoff needs evaluation.
+- Python class, module of functions, or FastAPI background task dependency?
 
 ## Test Cases
 

--- a/features/observability/spec.md
+++ b/features/observability/spec.md
@@ -1,12 +1,16 @@
 # Observability Spec (OpenTelemetry)
 
 ## Goal
-Replace ad hoc `print()` calls with structured, correlated telemetry across
-traces, metrics, and logs. In production, data flows to GCP Cloud Trace and
-Cloud Monitoring. Locally, a console exporter provides the same signal without
-any GCP dependency.
+
+Capture two things:
+1. **User interaction patterns** — which endpoints are hit, in what sequence, by whom (user_id / session)
+2. **Website performance** — latency, error rates, throughput per route
+
+This is distinct from audit logging (security/compliance) and game data capture (ML training, stats) — those
+are separate concerns with separate specs. OTel is not the right tool for either of those.
 
 ## Stack
+
 | Concern | Package |
 |---------|---------|
 | Core SDK | `opentelemetry-sdk` |
@@ -16,75 +20,75 @@ any GCP dependency.
 | GCP metrics exporter | `opentelemetry-exporter-gcp-monitoring` |
 | Propagation | `opentelemetry-propagator-gcp` |
 
-## What Gets Instrumented Automatically
-- Every HTTP request/response (method, route, status, latency) — FastAPI instrumentation
-- Every SQL query (statement, duration, error) — psycopg2 instrumentation
+## What Gets Instrumented
+
+### Automatically (no code changes required)
+- Every HTTP request/response: method, route, status code, latency — via FastAPI instrumentation
+- Every SQL query: statement, duration, error — via psycopg2 instrumentation
 - Trace context propagation across service calls
 
-## What Gets Added Manually
-- Auth events: login success/failure, registration, Google OAuth, logout
-- Game events: game started, move made, game ended (with outcome)
-- Error events: any caught exception in API handlers
+### Manually (thin layer at the API router level only)
+Auto-instrumentation captures the request. Manual spans add structured attributes to make traces
+filterable and groupable in Cloud Trace. No instrumentation inside game engine files (`game_logic/*.py`).
+
+- **Auth events** (`auth.py`): already implemented — login, register, Google OAuth spans with
+  `auth.method`, `auth.user_id` attributes
+- **Game endpoints** (`games.py`): add `game.id`, `game.session_id`, `game.difficulty` attributes to the
+  auto-instrumented request span — enough to filter by game or session without duplicating spans. AI move
+  computation gets a child span (`game.ai.move`) with `game.id` and `compute_duration_ms` — it has real,
+  variable duration worth isolating and can fail independently of the request
+- **Error events**: caught exceptions in API handlers set `error.type` and `error.message` on the current
+  span
+
+### Metrics
+Aggregated signals for dashboards and alerting:
+- `game.sessions.started` — counter, labelled by game_id
+- `game.sessions.completed` — counter, labelled by game_id + outcome (win/loss/draw/abandoned)
+- `game.ai.compute_duration` — histogram, labelled by game_id (measures AI move time)
+- `auth.logins` — counter, labelled by method (local/google)
 
 ## Implementation
 
-### `src/backend/telemetry.py` (new file)
-Central setup module. Called once at app startup.
+### `src/backend/telemetry.py`
+Already implemented. Configures TracerProvider + MeterProvider with BatchSpanProcessor and
+environment-based exporters (GCP in production, console locally). No changes required.
 
-```python
-# Configures exporter based on ENVIRONMENT env var:
-# - production  → GCP Cloud Trace + Cloud Monitoring
-# - development → ConsoleSpanExporter (stdout, human-readable)
-# Returns a configured TracerProvider and MeterProvider.
-```
+### `src/backend/app.py`
+Already implemented. FastAPIInstrumentor and Psycopg2Instrumentor applied at startup. No changes required.
 
-### `src/backend/app.py` changes
-- Import and call `setup_telemetry()` before app creation
-- Add `FastAPIInstrumentor().instrument_app(app)`
-- Replace the three `print()` calls with `logging.getLogger(__name__)`
+### `src/backend/auth.py`
+Already implemented. Manual spans for login/register/google flows. No changes required.
 
-### `src/backend/auth_service.py` changes
-- Replace all `print()` with `logger = logging.getLogger(__name__)`
-- Add manual spans around login/register flows:
-  ```python
-  with tracer.start_as_current_span("auth.login") as span:
-      span.set_attribute("auth.method", "local")
-      span.set_attribute("auth.username", username)
-  ```
+### `src/backend/games.py`
+Add game-specific attributes to the current span at each endpoint — not new spans, just `span.set_attribute`
+calls using the active span from auto-instrumentation. Add metric instruments for session counters and AI
+compute duration histogram.
 
-### `src/backend/database.py` changes
-- Add `Psycopg2Instrumentor().instrument()` call in `init_db_pool()`
+## WebSocket
 
-### `requirements.txt` additions
-```
-opentelemetry-sdk
-opentelemetry-instrumentation-fastapi
-opentelemetry-instrumentation-psycopg2
-opentelemetry-exporter-gcp-trace
-opentelemetry-exporter-gcp-monitoring
-opentelemetry-propagator-gcp
-```
+When the WebSocket feature is implemented, the WebSocket spec must include OTel configuration equivalent to
+what FastAPI auto-instrumentation provides for HTTP: connection lifecycle events (open, close, error) and
+per-message latency, attributed by game_id and session_id. The goal is the same — interaction patterns and
+performance — so the same trace context model applies: bundle spans per game+session to build a coherent
+story across the connection lifecycle.
 
-## Local Development Behaviour
-When `ENVIRONMENT` is not `production`, all telemetry prints to stdout in a
-readable format. No GCP credentials required. Works inside docker-compose.
+## Local Development
+
+When `ENVIRONMENT` is not `production`, all telemetry prints to stdout in a readable format. No GCP
+credentials required.
 
 ## GCP Prerequisites
+
 - Cloud Trace API enabled
 - Cloud Monitoring API enabled
 - Service account has `roles/cloudtrace.agent` + `roles/monitoring.metricWriter`
-  (already included in the deploy checklist in `deploy.yml`)
 
 ## Test Cases
-| Tier | Name | What it checks |
-|------|------|---------------|
-| Unit | `unit/telemetry.test.py` | `setup_telemetry()` returns valid provider in dev mode without GCP creds |
-| API integration | `api/telemetry.spec.ts` | A request to any `/api/*` endpoint produces a trace span (console exporter in test env) |
-| Manual | Cloud Trace dashboard | After first production deploy, verify traces appear for login and game requests |
 
-## Open Questions / Risks
-- GCP exporters require ADC (Application Default Credentials) in the container.
-  Cloud Run provides these automatically via the attached service account — no
-  extra config needed.
-- If the React frontend later makes direct calls to third-party services, add
-  `opentelemetry-instrumentation-fetch` (JS) for end-to-end trace correlation.
+| Tier | Name | What it checks |
+|------|------|----------------|
+| Unit | `unit/telemetry.test.py` | `setup_telemetry()` returns valid provider in dev mode without GCP creds |
+| API integration | `api/telemetry.spec.ts` | Request to any `/api/*` endpoint produces a trace span with correct attributes (console exporter in test env) |
+| API integration | `api/telemetry.spec.ts` | Game endpoint span includes `game.id` and `game.session_id` attributes |
+| API integration | `api/telemetry.spec.ts` | Auth endpoint span includes `auth.method` attribute |
+| Manual | Cloud Trace dashboard | After first production deploy, verify traces appear and are filterable by game_id |

--- a/features/websocket/spec.md
+++ b/features/websocket/spec.md
@@ -35,11 +35,21 @@ future real-time features.
 ### Architecture
 - Should turn-based game moves (TTT, Connect4, Chess, Checkers, Dots & Boxes) migrate from REST to WebSocket,
   or remain as standard HTTP request/response calls? Pros and cons to be evaluated in planning session.
-- Server-authoritative vs. client-authoritative game state?
+- Server is always authoritative for game state — clients accept server state unconditionally on reconnect
+  or desync (consistent with error-handling and game-data-persistence specs).
 - One shared WebSocket connection per client, or one connection per active game session?
 - Message protocol: JSON envelope with type/payload fields, or game-specific schemas?
-- How does a WebSocket connection map to the existing in-memory game sessions on the backend?
+- How does a WebSocket connection map to DB-backed game sessions on the backend? (In-memory sessions are
+  replaced by DB-backed sessions per game-data-persistence spec — this applies to WebSocket connections too)
 - Should the backend emit unprompted messages (e.g., AI move response pushed after server computes it)?
+
+### Error Handling & Recovery
+Real-time games (Pong and future equivalents) do not support session recovery. A disconnect resets to a new
+game — continuous game state is intentionally not persisted between connections. Error handling for
+WebSocket connections must be standardized to the same degree as HTTP error handling (see error-handling
+spec): connection lifecycle events (open, close, error) must be classified, surfaced to the user
+consistently, and instrumented via OTel (see observability spec WebSocket note). The specific retry and
+reconnect strategy for real-time games is an open question for this spec's planning session.
 
 ### Infrastructure
 - FastAPI native WebSocket support vs. third-party library (e.g., Socket.IO, channels)?


### PR DESCRIPTION
## Summary
- Locked observability scope to API-level instrumentation; finalized span model, metrics, and test cases
- Defined error handling recovery model (server-as-source-of-truth, global notification service, crash loop detection)
- Established game-data-persistence design principles (write-on-every-move, DB-backed sessions, ML training data contract)
- Propagated consistent design principles across websocket spec
- Recorded first CI/CD staging decision (same GCP project, separate Cloud Run service)

## Test plan
- No code changes — spec/docs only
- CI tests will be skipped (features-only changes once gate job is implemented; for now, tests will run and pass as no runtime code was modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)