### PR TITLE
feat: automate DB migrations in Cloud Build via Cloud Run Job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ ./src/
 COPY --from=frontend-builder /app/dist/ ./dist/
+COPY alembic.ini ./
+COPY scripts/migrations/ ./scripts/migrations/
 
 WORKDIR /app/src/backend
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -24,7 +24,38 @@ steps:
       - '${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_ARTIFACT_REPO}/${_IMAGE_NAME}'
 
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'deploy-migration-job'
     entrypoint: gcloud
+    args:
+      - 'run'
+      - 'jobs'
+      - 'deploy'
+      - 'migrate-db'
+      - '--image=${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_ARTIFACT_REPO}/${_IMAGE_NAME}:$SHORT_SHA'
+      - '--region=${_REGION}'
+      - '--add-cloudsql-instances=${_CLOUDSQL_INSTANCE}'
+      - '--set-secrets=DB_HOST=DB_HOST:latest,DB_NAME=DB_NAME:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest'
+      - '--command=python'
+      - '--args=-m,alembic,-c,/app/alembic.ini,upgrade,head'
+      - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT}'
+      - '--max-retries=1'
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'run-migration'
+    entrypoint: gcloud
+    args:
+      - 'run'
+      - 'jobs'
+      - 'execute'
+      - 'migrate-db'
+      - '--region=${_REGION}'
+      - '--wait'
+    waitFor: ['deploy-migration-job']
+
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    id: 'deploy-service'
+    entrypoint: gcloud
+    waitFor: ['run-migration']
     args:
       - 'run'
       - 'deploy'


### PR DESCRIPTION
## Summary
- Add `alembic.ini` and `scripts/migrations/` to Docker image so `alembic upgrade head` is runnable inside the container
- Add `deploy-migration-job` step in `cloudbuild.yaml` to deploy/update a Cloud Run Job (`migrate-db`) with the new image and Cloud SQL access
- Add `run-migration` step that executes the job with `--wait`, blocking the deploy until migrations succeed
- Service deploy now has `waitFor: ['run-migration']` — schema changes are always applied before new code goes live

## Test plan
- [ ] Cloud Build run applies the migration job step without error
- [ ] `migrate-db` Cloud Run Job appears in GCP console after first run
- [ ] Subsequent deploys re-use the same job (idempotent `jobs deploy`)
- [ ] If migration fails, Cloud Build fails before service deploy (protecting prod)

🤖 Generated with [Claude Code](https://claude.com/claude-code)