### PR TITLE
fix: allowlist scripts/migrations/ in .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -13,5 +13,6 @@ test-results/
 coverage/
 features/
 scripts/
+!scripts/migrations/
 environment.yml
 *.md


### PR DESCRIPTION
## Summary
- `scripts/` was excluded from the Docker build context via `.dockerignore`
- This prevented `COPY scripts/migrations/` in the Dockerfile from finding the Alembic migrations
- Added `!scripts/migrations/` negation rule to allowlist just the migrations directory

## Test plan
- [ ] Cloud Build docker step completes without COPY error
- [ ] `migrate-db` Cloud Run Job executes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)