### PR TITLE
fix: use --set-cloudsql-instances for gcloud run jobs deploy

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -33,7 +33,7 @@ steps:
       - 'migrate-db'
       - '--image=${_REGION}-docker.pkg.dev/${_PROJECT_ID}/${_ARTIFACT_REPO}/${_IMAGE_NAME}:$SHORT_SHA'
       - '--region=${_REGION}'
-      - '--add-cloudsql-instances=${_CLOUDSQL_INSTANCE}'
+      - '--set-cloudsql-instances=${_CLOUDSQL_INSTANCE}'
       - '--set-secrets=DB_HOST=DB_HOST:latest,DB_NAME=DB_NAME:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest'
       - '--command=python'
       - '--args=-m,alembic,-c,/app/alembic.ini,upgrade,head'


### PR DESCRIPTION
## Summary
- `--add-cloudsql-instances` is only valid for `gcloud run deploy` (services); `gcloud run jobs deploy` requires `--set-cloudsql-instances`

## Test plan
- [ ] Cloud Build `deploy-migration-job` step completes without flag error
- [ ] `migrate-db` job executes and applies Alembic migrations

🤖 Generated with [Claude Code](https://claude.com/claude-code)