### PR TITLE
fix: run alembic from /app in Cloud Run Job

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,8 +35,8 @@ steps:
       - '--region=${_REGION}'
       - '--set-cloudsql-instances=${_CLOUDSQL_INSTANCE}'
       - '--set-secrets=DB_HOST=DB_HOST:latest,DB_NAME=DB_NAME:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest'
-      - '--command=python'
-      - '--args=-m,alembic,-c,/app/alembic.ini,upgrade,head'
+      - '--command=bash'
+      - '--args=-c,cd /app && python -m alembic upgrade head'
       - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT}'
       - '--max-retries=1'
 


### PR DESCRIPTION
## Summary
- Cloud Run Job WORKDIR is `/app/src/backend`; `alembic.ini` has a relative `script_location = scripts/migrations` which resolved to `/app/src/backend/scripts/migrations` (doesn't exist)
- Switches job command to `bash -c 'cd /app && python -m alembic upgrade head'` so the path resolves against the correct root

## Test plan
- [ ] Cloud Build completes the `deploy-migration-job` and `run-migration` steps without error
- [ ] Cloud Run service deploys successfully after migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)