### PR TITLE
fix: persist GOOGLE_REDIRECT_URI and WEBSITE_URL in Cloud Build deploy

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,6 +6,7 @@ substitutions:
   _SERVICE_NAME: game-ai-website
   _CLOUDSQL_INSTANCE: halogen-episode-455311-t4:us-central1:game-database
   _ENVIRONMENT: production
+  _WEBSITE_URL: https://game-ai-website-w4453qrbcq-uc.a.run.app
 
 steps:
   - name: 'gcr.io/cloud-builders/docker'
@@ -65,7 +66,7 @@ steps:
       - '--platform=managed'
       - '--allow-unauthenticated'
       - '--add-cloudsql-instances=${_CLOUDSQL_INSTANCE}'
-      - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT}'
+      - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT},WEBSITE_URL=${_WEBSITE_URL},GOOGLE_REDIRECT_URI=${_WEBSITE_URL}/api/auth/google/callback'
       - >-
         --set-secrets=DB_HOST=DB_HOST:latest,DB_NAME=DB_NAME:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest
 

--- a/features/build-optimization/spec.md
+++ b/features/build-optimization/spec.md
@@ -1,0 +1,82 @@
+# Build Optimization Spec
+
+## Background
+
+Every push to main triggers a full GCP Cloud Build run: Docker build (including `npm ci` and
+`pip install` from scratch), push to Artifact Registry, migration job, and service deploy. The
+Docker build is the largest cost and time driver. Current build time is approximately 4–6 minutes
+end-to-end, billed at GCP Cloud Build compute rates.
+
+## Ideas to Explore
+
+### 1. Docker Layer Caching (low effort, immediate savings)
+
+Pull the `latest` image before building and pass it as `--cache-from`. On a cache hit (no changes
+to `package-lock.json` or `requirements.txt`), `npm ci` and `pip install` are skipped entirely,
+saving 2–3 minutes per build.
+
+```yaml
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: bash
+  args: ['-c', 'docker pull ${_REGION}-docker.pkg.dev/.../${_IMAGE_NAME}:latest || true']
+
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '--cache-from', '...latest', '-t', '...:$SHORT_SHA', '-t', '...:latest', '.']
+```
+
+**Tradeoff:** Adds a pull step (~10–20s). Cache miss on first build after dep changes — subsequent
+builds resume caching.
+
+### 2. Build on GitHub Actions, Push Image to Artifact Registry
+
+Run the Docker build in GitHub Actions CI (which has its own layer caching via
+`docker/build-push-action` with `cache-type=gha`). Authenticate to GCP from GitHub Actions using
+Workload Identity Federation (no long-lived service account key required), push the built image to
+Artifact Registry, then trigger a lightweight Cloud Build job that only runs the migration and
+deploy steps — skipping the build entirely.
+
+**Benefit:** GitHub Actions compute is free (within limits). Cloud Build billing is reduced to
+migration + deploy steps only (~1–2 min vs. 4–6 min).
+
+**Tradeoff:** More complex pipeline — two CI systems need to coordinate. Workload Identity
+Federation setup required. The build step on GH Actions is still on every push regardless of whether
+it would deploy (e.g., PRs that don't merge).
+
+### 3. Build Locally Before Pushing
+
+Developer builds and pushes the Docker image to Artifact Registry manually before pushing the
+branch. Cloud Build then only runs migration and deploy, similar to option 2.
+
+**Benefit:** No CI compute needed for build at all.
+
+**Tradeoff:** Discipline-dependent — easy to forget or push a stale image. Not automatable. Not
+suitable for a team workflow. Probably not the right long-term solution.
+
+### 4. Separate Base Image Layer
+
+Build a `base` image containing only OS deps, Python packages, and Node modules — published
+separately and only rebuilt when `requirements.txt` or `package-lock.json` change. The app image
+uses `FROM base` and only copies source. This is the most cache-efficient approach and works
+regardless of where the build runs.
+
+**Tradeoff:** Requires a separate Cloud Build trigger or GH Actions workflow to rebuild the base
+image on dep changes. More infrastructure to maintain.
+
+## Recommendation
+
+Start with **option 1** (Docker layer caching) — it's a 3-line change to `cloudbuild.yaml` with
+immediate savings and no architectural changes.
+
+**Option 2** (GH Actions build + Cloud Build deploy) is the most scalable approach once the
+project grows or build frequency increases enough to matter on cost.
+
+## Known Requirements
+
+- Must not break the existing migration → deploy sequence
+- GOOGLE_REDIRECT_URI and WEBSITE_URL must survive across any build pipeline changes (currently
+  set as env vars in the deploy step)
+- Staging environment (see cicd-staging spec) must be accounted for in whichever approach is chosen
+
+## Test Cases
+
+_To be defined during planning session._


### PR DESCRIPTION
## Summary
- Adds `_WEBSITE_URL` substitution to `cloudbuild.yaml` pointing to the production Cloud Run URL
- Sets `WEBSITE_URL` and `GOOGLE_REDIRECT_URI` as env vars on every deploy so they survive future Cloud Build runs (they were previously applied directly via `gcloud run services update` as a hotfix for the OAuth redirect_uri_mismatch)
- Adds `features/build-optimization/spec.md` with ideas to reduce Cloud Build cost (layer caching, GH Actions build, separate base image)

## Test plan
- [ ] Confirm `GOOGLE_REDIRECT_URI` is present after next Cloud Build deploy
- [ ] Manual: register `https://game-ai-website-w4453qrbcq-uc.a.run.app/api/auth/google/callback` in Google Cloud Console OAuth client, then test Google sign-in end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)