### PR TITLE
fix: games list always empty due to queryFn context leak

### DIFF
--- a/src/frontend/src/pages/GamesPage.tsx
+++ b/src/frontend/src/pages/GamesPage.tsx
@@ -84,7 +84,7 @@ const PLACEHOLDER_GAMES: Game[] = [
 export default function GamesPage() {
     const { data: apiGames, isLoading } = useQuery({
         queryKey: ['games'],
-        queryFn: fetchGames,
+        queryFn: () => fetchGames(),
     });
     const games = apiGames?.length ? apiGames : PLACEHOLDER_GAMES;
 


### PR DESCRIPTION
## Summary
- Fixes the root cause of the games list disappearing: TanStack Query passes a `QueryFunctionContext` object as the first arg to `queryFn`. `fetchGames(category?)` was receiving it, serializing it to `[object Object]`, and filtering by that nonexistent category — returning zero rows every time. Wrapping with `() => fetchGames()` fixes it.
- Fallback: keeps `PLACEHOLDER_GAMES` as a safety net when the API returns empty (e.g. unreachable backend in dev), using an explicit length check instead of relying on the destructuring default which doesn't apply to `[]`.

## Test plan
- [ ] `/games` loads all 6 game cards on hard refresh
- [ ] Network tab shows `/api/games_list` with no `category` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)