### PR TITLE
docs: add Connect4, Checkers, DaB, Chess game specs and fix observability gaps

### DIFF
--- a/features/game-checkers/spec.md
+++ b/features/game-checkers/spec.md
@@ -1,48 +1,539 @@
 # Game: Checkers
 
-**Status: ready**
+**Status: in-progress**
 
 ## Background
 
-Backend game logic is fully implemented in `src/backend/game_logic/checkers.py`, including king promotion and
-jump validation. REST API exists at `/api/game/checkers/start` and `/api/game/checkers/move`. The React page
-at `src/frontend/src/pages/games/CheckersPage.tsx` is currently a stub. This spec supersedes the Checkers
-section of the react-migration Phase 3 spec.
+Backend game logic is fully implemented in `src/backend/game_logic/checkers.py`, including king promotion,
+mandatory capture enforcement, and multi-jump chain generation. REST API stubs exist at
+`/api/game/checkers/start` and `/api/game/checkers/move` but are incompatible with the SSE architecture and
+will be retired. The React page at `src/frontend/src/pages/games/CheckersPage.tsx` is currently a stub.
+The game-data-persistence feature is complete and integrated. This spec supersedes the Checkers section of
+the react-migration Phase 3 spec and the open questions in the previous `features/game-checkers/spec.md`.
+Transport is resolved: SSE, not WebSocket.
 
-## Known Requirements
+## Resolved Design Decisions
 
-- **Mobile + desktop responsive**: 8x8 board must render cleanly on small screens; piece tap targets must be
-  large enough for mobile; game board is the primary focus above the fold; controls and status stack below
-- Connect to existing backend REST API for game start and moves
-- Move transport (REST vs. WebSocket) is an open question pending the websocket feature spec — see
-  `features/websocket/`
-- When the game-data-persistence feature is complete, session data capture must be integrated
-- **Frontend move validation**: the React client validates moves in real time (legal piece selection, valid
-  destinations) — UX layer only, not a security boundary
-- **Backend move validation (player)**: backend re-validates every player move server-side as redundancy
-  against frontend manipulation
-- **Backend move validation (AI)**: backend validates every AI-generated move; if invalid, retries until a
-  valid move is produced (configurable retry limit); client always receives a guaranteed-valid AI move
+- **Auth required**: No unauthenticated gameplay. Game pages display a login prompt blocking the game UI for
+  unauthenticated users. Any API call without a valid session returns 401; the client surfaces an
+  `AuthModal`, no silent retry.
+- **Transport**: Server-Sent Events for all server→client push. Client POSTs moves (202 Accepted, no state
+  in response); state updates arrive over SSE.
+- **One session per user per game**: Enforced by existing DB partial unique index. Starting a new game
+  explicitly closes any existing active session before creating a new one.
+- **No AI difficulty selection**: The AI difficulty parameter is removed entirely from the user-facing API.
+  The `games` table retains its `difficulty` column as game-level metadata only.
+- **Turn order and color**: Player selects their color before the game starts. `player_starts=true` →
+  player is Red (R/r), goes first (standard checkers convention). `player_starts=false` → player is Black
+  (B/b), AI is Red and goes first. Internally stored and passed as `player_starts: bool`, matching the
+  convention used by Tic-Tac-Toe and Connect 4. The `player_symbol` and `ai_symbol` fields in the state
+  reflect whichever assignment is active.
+- **Session ID ownership**: The client never stores `session_id` across page loads. It is received from
+  `/resume` or `/newgame` and used only to subscribe to the SSE stream. Move requests carry no
+  `session_id`; the server derives the active session from the authenticated user + game type.
+- **Multi-jump (interactive)**: Player submits each individual jump step as a separate POST. The server
+  sets `must_capture` to indicate the piece that must continue jumping. The SSE stream emits a move event
+  after each step. AI multi-jump chains are handled internally and emitted step-by-step with a 400ms delay
+  between steps.
+- **Move selection**: Tap piece to select; valid destinations highlight. No drag-and-drop.
+- **Legacy endpoints retired**: `/api/game/checkers/start` and the existing `/api/game/checkers/move`
+  (non-SSE) are removed. Additionally, the generic `POST /game/{game_id}/start` and
+  `POST /game/{game_id}/move` endpoints in `games.py` use the old bundled architecture and must return
+  `501` for `checkers` to prevent stale code paths.
 
-## Open Questions
+## Architecture
 
-### Gameplay
-- Should unauthenticated users be able to play, or is login required?
-- Player color selection (red vs. black / first vs. second)?
-- What difficulty levels are surfaced to the user?
-- Multi-jump sequences: does the UI handle chained jumps in a single turn, or does the backend handle that?
-- Session recovery on page refresh?
+### Abstractions (shared across all turn-based games)
 
-### UI / UX
-- Move selection model: tap piece to select, tap destination to move — or drag-and-drop?
-- How are valid moves highlighted on piece selection?
-- King promotion visual indicator?
-- AI "thinking" indicator between moves?
-- Win/loss outcome: modal, inline banner, or results screen?
+These live in `src/backend/game_engine/base.py` and are implemented per game.
 
-### Stats & Persistence
-- Win/loss stats on the game page? (Depends on game-data-persistence feature)
+**`GameEngine` (abstract base)**
+```
+validate_move(state, move) → bool
+apply_move(state, move) → GameState
+is_terminal(state) → tuple[bool, outcome | None]
+get_legal_moves(state) → list[Move]
+initial_state(player_starts: bool) → GameState
+```
+
+**`AIStrategy` (abstract base)**
+```
+generate_move(state) → tuple[Move, Optional[float]]
+    # Move may be invalid; no guarantee. float is engine_eval or None if strategy has no score.
+```
+
+**`MoveProcessor` (shared, game-agnostic)**
+```
+process_player_move(engine, state, move) → GameState | ValidationError
+process_ai_turn(engine, strategy, state, max_retries=5) → GameState
+```
+`process_ai_turn` loop:
+1. `move = strategy.generate_move(state)`
+2. If `engine.validate_move(state, move)`: break
+3. `log.warning("ai_invalid_move", attempt=n)` + OTel attribute `ai_invalid_move_count`
+4. After `max_retries` exhausted: `move = random.choice(engine.get_legal_moves(state))` (guaranteed valid)
+
+**`StatusBroadcaster` (shared)**
+```
+emit(event: StatusEvent) → None
+stream() → AsyncGenerator[StatusEvent]
+```
+- `min_interval`: 2.5 seconds between sends to client
+- First status held for ~0.5s (prevents flash for near-instant AI responses)
+- Heartbeat event every 30s (keeps stream alive through proxies)
+- Terminal event closes the stream
+
+### CheckersEngine (`src/backend/game_engine/checkers_engine.py`)
+
+Implements `GameEngine`. Wraps the existing logic in `src/backend/game_logic/checkers.py`.
+
+**Key behaviors:**
+- `apply_move` executes exactly one move (a single jump step OR a non-capture step). It does NOT bundle
+  the AI response in the same call.
+- After each `apply_move`, sets `last_move` and recomputes `must_capture` and `legal_pieces`.
+- `must_capture` is an `int` (board position) or `null`. When set, it is the position of the piece that
+  must continue jumping. `validate_move` rejects any move where `from != must_capture` or the move is not
+  a capture.
+- `legal_pieces` is a list of board positions for all player pieces that have legal moves. Respects
+  mandatory capture: if any capture is available, only pieces with captures are listed.
+- King promotion: `R` → `r` when reaching row 0; `B` → `b` when reaching row 7. Promotion ends the
+  multi-jump chain: `must_capture` is cleared even if the newly promoted king could otherwise continue.
+- `initial_state` returns the standard checkers starting position with `current_turn` set to `"player"`
+  if `player_starts=true`, else `"ai"`.
+
+**GameState shape:**
+```json
+{
+  "board": ["_", "B", "..."],
+  "current_turn": "player" | "ai",
+  "game_active": true,
+  "player_starts": true,
+  "player_symbol": "R",
+  "ai_symbol": "B",
+  "must_capture": null,
+  "last_move": null,
+  "legal_pieces": [40, 42, 45]
+}
+```
+
+`player_symbol` and `ai_symbol` are set by `initial_state` based on `player_starts`:
+- `player_starts=true`: `player_symbol="R"`, `ai_symbol="B"` (player is Red, goes first)
+- `player_starts=false`: `player_symbol="B"`, `ai_symbol="R"` (player is Black, AI is Red and goes first)
+
+`last_move` shape (set after every `apply_move`):
+```json
+{"from": 40, "to": 33, "captured": [36], "is_king_promotion": false}
+```
+
+Board positions: row-major, `pos = row * 8 + col`. Only dark squares where `(row + col) % 2 == 1` are
+playable. Red pieces always start at rows 5–7; Black pieces always start at rows 0–2 (Red always
+moves first in standard checkers, so when `player_starts=false` the AI's Red pieces start at rows 5–7).
+Piece codes: `R` = Red regular, `r` = Red king, `B` = Black regular, `b` = Black king, `_` = empty.
+The client maps `player_symbol`/`ai_symbol` to determine which pieces belong to the player.
+
+### CheckersAIStrategy (`src/backend/game_engine/checkers_engine.py`)
+
+Implements `AIStrategy`. Wraps `_get_ai_move_chain` from `checkers.py` but returns only the **first move**
+in the chain as `(move, None)` — the heuristic has no eval score. The SSE handler drives the multi-jump
+loop, emitting chain moves directly (bypassing `StatusBroadcaster`) with a 400ms sleep between steps:
+
+```
+while current_turn == "ai":
+    move, _ = strategy.generate_move(state)   # one step
+    state = engine.apply_move(state, move)
+    yield move_event_sse_directly             # NOT via broadcaster; 400ms pacing
+    await asyncio.sleep(0.4)
+    if state["must_capture"] is None:
+        break                                 # AI chain complete
+```
+
+This gives the player visible step-by-step AI captures rather than one large board jump.
+
+### SSE Event Schema
+
+```json
+{"type": "status", "message": "Thinking..."}
+
+{"type": "move", "data": {
+  "from": 40,
+  "to": 33,
+  "captured": [36],
+  "player": "player",
+  "is_king_promotion": false,
+  "board": ["_", "B", "..."],
+  "player_starts": true,
+  "current_turn": "ai",
+  "must_capture": null,
+  "legal_pieces": [],
+  "status": "in_progress",
+  "winner": null
+}}
+
+{"type": "move", "data": {
+  "from": 5,
+  "to": 12,
+  "captured": [8],
+  "player": "ai",
+  "is_king_promotion": false,
+  "board": ["_", "B", "..."],
+  "player_starts": true,
+  "current_turn": "player",
+  "must_capture": null,
+  "legal_pieces": [40, 42, 33],
+  "status": "in_progress",
+  "winner": null
+}}
+
+{"type": "move", "data": {
+  "status": "complete",
+  "winner": "player",
+  "board": ["..."],
+  "player_starts": true,
+  "current_turn": null,
+  "must_capture": null,
+  "legal_pieces": []
+}}
+
+{"type": "heartbeat"}
+
+{"type": "error", "code": "invalid_move", "message": "..."}
+```
+
+`winner` values: `"player"` | `"ai"` | `null`.
+
+### Status Copy
+
+Player move validation produces no status event. AI multi-jump intermediate steps emit no additional
+status events (the move event itself conveys progress).
+
+| Condition | Message |
+|---|---|
+| AI begins processing | `"Thinking..."` |
+| 2.5s pass, AI still running | random: `["Hmm...", "Considering the board...", "Plotting a move...", "Analyzing..."]` |
+| 5s+ elapsed | random: `["Taking a moment...", "Almost there..."]` |
+| AI move ready | `move` event (closes the turn) |
+
+## API Endpoints
+
+All endpoints require authentication. 401 is returned for any unauthenticated request.
+
+### `GET /api/game/checkers/resume`
+
+Always called on page load. Returns the active session for the authenticated user if one exists.
+
+**Response 200 — active session:**
+```json
+{"session_id": "uuid", "state": { "...game state..." }}
+```
+
+**Response 200 — no active session:**
+```json
+{"session_id": null, "state": null}
+```
+
+A missing session is a normal state, not an error. No 404 for this path.
+
+### `POST /api/game/checkers/newgame`
+
+Closes any existing active session for this user + game type, then creates a new one. If
+`player_starts=false`, the AI takes the first move before the response is returned (the initial state
+reflects the AI's first move and `current_turn: "player"`).
+
+**Request:**
+```json
+{"player_starts": true}
+```
+
+**Response 200:**
+```json
+{"session_id": "uuid", "state": { "...initial game state..." }}
+```
+
+### `POST /api/game/checkers/move`
+
+Submits one player move step (single jump or one step of a multi-jump chain). Active session is derived
+server-side from the authenticated user + game type. No `session_id` in the request body.
+
+**Request:**
+```json
+{"from": 40, "to": 33}
+```
+
+**Response 202:** Empty body. State update delivered via SSE.
+
+**Response 422:** Invalid move. Reasons include:
+- `from` does not contain a player piece
+- `to` is occupied or not reachable
+- Not the player's turn
+- `must_capture` constraint violated (wrong piece selected, or move is not a capture)
+- Game is already over
+
+**Response 409:** No active session.
+
+### `GET /api/game/checkers/events/{session_id}`
+
+Persistent SSE stream. The authenticated user must own the session.
+
+**Response:** `text/event-stream`
+
+Cloud Run request timeout must be set to 3600s. Heartbeat events every 30s prevent intermediate proxy
+timeouts.
+
+## Session Lifecycle and Timeout
+
+Sessions remain active indefinitely as long as the player reconnects. Abandoned sessions (browser closed,
+navigation away, crash) are cleaned up by the existing `POST /internal/cleanup-sessions` endpoint, which
+is triggered by a GCP Cloud Scheduler job.
+
+**Timeout configuration**: `session_timeout_hours` column in the `games` table. Checkers: 24 hours
+(measured from `last_move_at`).
+
+Sessions closed by the cleanup job emit the `game.sessions.completed` metric with outcome `abandoned`,
+consistent with the observability spec.
+
+## Observability
+
+Follows the conventions in `features/observability/spec.md`.
+
+**`games.py` (request layer):**
+- `POST /newgame`, `POST /move`, `GET /resume`, `GET /events/{session_id}`: set `game.id` and
+  `game.session_id` as attributes on the auto-instrumented HTTP span via `span.set_attribute`.
+- No new spans at this layer.
+
+**`games.py` — AI move processing:**
+- Child span `game.ai.move` on the SSE handler. Attributes: `game.id`, `compute_duration_ms`,
+  `ai_invalid_move_count`.
+- For AI multi-jump chains, a single `game.ai.move` span covers the entire chain (all steps).
+
+**`persistence_service.py`:**
+- Existing child spans for `record_move` and `end_session` already cover DB writes. No changes required.
+
+**SSE connection lifecycle:**
+- SSE open: `span.set_attribute("game.id", ...), span.set_attribute("game.session_id", ...)`
+- SSE close (normal): `logger.info("checkers_sse_closed", extra={"session_id": session_id})`
+- SSE close (error / unexpected): `logger.exception("checkers_sse_error", extra={"session_id": session_id})` +
+  `span.record_exception(e)` + `span.set_status(ERROR)`
+
+**Invalid move logging:**
+- `POST /move` returning 422: `logger.warning("checkers_invalid_move", extra={"session_id": session_id, "move": move})`
+
+**No instrumentation inside `game_engine/` files.** All manual instrumentation lives at the router and
+persistence layers only.
+
+## Client Behavior
+
+### Page Load and Resume
+
+The client uses five phases: `loading`, `newgame`, `resumeprompt`, `playing`, `terminal`.
+
+1. Check `localStorage` for key `checkers_game_hint`. If present and `expires` is in the future, enter
+   `loading` phase (spinner overlay on board) while `/resume` is in flight. Otherwise enter `newgame`
+   immediately.
+2. On `/resume` response:
+   - Active in-progress session → set board state from response, enter `resumeprompt` phase. SSE is
+     **not** subscribed yet.
+   - Completed session → set board state, enter `terminal` phase directly (no prompt needed).
+   - Null → enter `newgame` phase, clear any stale localStorage hint.
+
+**`checkers_game_hint` shape:**
+```json
+{"expires": 1234567890000}
+```
+TTL: 10 minutes. Refreshed on every received SSE `move` event.
+
+Cleared when:
+- Terminal game state received over SSE.
+- Player clicks "New Game" (before `/newgame` is even sent).
+- `beforeunload` fires (handles normal tab/browser close; TTL handles crashes).
+
+### Resume Prompt
+
+When in `resumeprompt` phase, the board renders (dimmed, locked) with a centred overlay:
+
+- **Continue Game** → subscribes to SSE, enters `playing` phase.
+- **New Game** → enters `newgame` phase (overlay changes to turn-order selector; previous board stays
+  visible dimmed underneath).
+
+### Turn Order Selection
+
+Shown as a board overlay in `newgame` phase. Two buttons:
+- "Play as Red — Go First"
+- "Play as Black — Go Second"
+
+`player_starts: true` (Red, go first) or `false` (Black, go second) is submitted to `POST /newgame`.
+
+The board renders immediately in `playing` phase (empty, locked) before the API responds so the layout
+does not shift. When going second, the AI computes its first move server-side before `/newgame` returns;
+the board updates from the response state.
+
+### Move Submission and Loading State
+
+1. Tap a piece → client checks it is in `legal_pieces`, selects it, and highlights valid destinations.
+2. Tap a highlighted destination → client locks the board and submits `POST /move {"from": int, "to": int}`.
+3. On 202: SSE events drive status display and board updates.
+4. SSE `status` events update the AI `PlayerCard` status text.
+5. SSE `move` event for the player's step: board updates. If `must_capture` is set and `current_turn` is
+   still `"player"`, only the piece at `must_capture` is interactive, and only its capture destinations
+   are shown. Another `POST /move` is submitted for the next step.
+6. SSE `move` event for AI step(s): board updates per step with 400ms between AI jumps.
+7. After AI turn completes, `legal_pieces` is populated for the player's next turn.
+
+### Multi-Jump
+
+- Player multi-jump: each step is a separate `POST /move`. After submitting a step, the client waits for
+  the SSE move event to determine if continuation is required (`must_capture != null`).
+- When `must_capture` is set: only the piece at `must_capture` is tappable; only its capture
+  destinations are highlighted. All other pieces are non-interactive.
+- Multi-jump ends when `must_capture` is null in the SSE move event.
+- If king promotion occurs mid-jump: `is_king_promotion: true` in the SSE event; `must_capture` is
+  cleared; the turn passes to AI.
+
+### Outcome
+
+Game result is displayed inside the `PlayerCard` components (above and below the board), not as a
+standalone banner. A "New Game" button appears below the player card; clicking it enters `newgame` phase
+(overlay on dimmed board).
+
+### SSE Reconnect and Error Path
+
+Browser `EventSource` reconnects automatically on disconnect. On reconnect:
+1. Call `/resume`.
+2. Active session → re-render board from returned state, resubscribe to SSE.
+3. Null session (game ended or timed out) → render "New Game" UI, clear localStorage hint.
+
+On any 401 from any game API: clear local game state, display `AuthModal`. No silent retry.
+
+## UI / Layout
+
+Layout (top to bottom): AI `PlayerCard` → board (with overlay) → player `PlayerCard` → "New Game" button.
+
+The `PlayerCard` component (`src/frontend/src/components/PlayerCard.tsx`) is used for both participants.
+See `features/player-card/spec.md` for the full component spec.
+
+- AI card (above board): bot icon avatar, "AI Opponent" label, piece color indicator (Black), SSE status
+  text during AI turn, result badge on terminal state.
+- Player card (below board): user avatar / initials, display name, piece color indicator (Red or Black
+  matching `player_symbol`), result badge on terminal state.
+- Board orientation: player's pieces always at bottom, from the player's perspective. When
+  `player_starts=true` (player is Red), Red pieces are at the bottom. When `player_starts=false` (player
+  is Black), the board flips so Black pieces are at the bottom.
+- Board display: 8×8 grid. Light squares are decorative only (non-interactive, muted background). Dark
+  squares are playable. Only dark squares render pieces and receive tap events.
+- Pieces: Red disc for R/r, dark disc for B/b. Kings display a crown overlay or inner ring on the disc
+  to distinguish them from regular pieces.
+- Valid move highlights: when a piece is selected, reachable destination squares are highlighted. If
+  mandatory capture applies, only capture destinations are shown for the selected piece. Pieces not in
+  `legal_pieces` are non-interactive and show no hover state.
+- Board overlays (positioned absolute, `inset-0`, `bg-base-100/80 backdrop-blur-sm`):
+  - `loading`: centred spinner.
+  - `resumeprompt`: "Game in progress" label + Continue / New Game buttons.
+  - `newgame`: "Choose your side:" label + "Play as Red — Go First" / "Play as Black — Go Second" buttons.
+- **Mobile (< 640px)**: board fills viewport width; piece tap targets at least 44px for comfortable
+  interaction; cards and controls stack above/below the board; no horizontal scroll.
+- **Desktop**: max-width `lg` container centred; same vertical stack.
+- All screen sizes and orientations supported without layout breakage.
+
+## Data Persistence
+
+Every valid move (player and AI, including each step of a multi-jump chain) is recorded via
+`persistence_service.record_move()`. The `player` argument must be `"human"` for player moves and
+`"ai"` for AI moves — consistent with TTT and the existing DB data. `engine_eval` is stored as `null`
+(the AI uses a random capture heuristic; no numeric score is computed). Terminal state triggers
+`persistence_service.end_game_session()`. No changes to the persistence service API are required.
 
 ## Test Cases
 
-_To be defined during planning session._
+### Unit
+
+| Test name | Scenario |
+|---|---|
+| `test_checkers_engine_validate_move_invalid_from_not_player_piece` | validate_move returns false when `from` does not contain a player piece |
+| `test_checkers_engine_validate_move_invalid_to_occupied` | validate_move returns false when `to` is occupied |
+| `test_checkers_engine_validate_move_wrong_turn` | validate_move returns false when it is the AI's turn |
+| `test_checkers_engine_validate_move_must_capture_constraint` | validate_move returns false when `must_capture` is set and `from != must_capture` |
+| `test_checkers_engine_validate_move_valid_regular` | validate_move returns true for a legal non-capture move |
+| `test_checkers_engine_validate_move_valid_capture` | validate_move returns true for a legal capture move |
+| `test_checkers_engine_apply_move_single_step_updates_board` | apply_move moves piece from `from` to `to`, clears `from` |
+| `test_checkers_engine_apply_move_capture_removes_captured_piece` | apply_move removes the captured piece and sets `captured` in `last_move` |
+| `test_checkers_engine_apply_move_king_promotion_sets_flag` | apply_move sets `is_king_promotion: true` and promotes piece to lowercase when reaching back rank |
+| `test_checkers_engine_apply_move_must_capture_set_on_chain_available` | apply_move sets `must_capture` to landing position when further captures are available |
+| `test_checkers_engine_apply_move_must_capture_cleared_when_no_further` | apply_move clears `must_capture` when no further captures exist from landing position |
+| `test_checkers_engine_apply_move_must_capture_cleared_on_promotion` | apply_move clears `must_capture` even if further captures exist when king promotion occurs |
+| `test_checkers_engine_is_terminal_player_wins_no_ai_pieces` | is_terminal returns (True, "player") when AI has no pieces |
+| `test_checkers_engine_is_terminal_ai_wins_no_player_pieces` | is_terminal returns (True, "ai") when player has no pieces |
+| `test_checkers_engine_is_terminal_player_wins_ai_blocked` | is_terminal returns (True, "player") when AI has pieces but no legal moves |
+| `test_checkers_engine_is_terminal_ai_wins_player_blocked` | is_terminal returns (True, "ai") when player has pieces but no legal moves |
+| `test_checkers_engine_is_terminal_in_progress` | is_terminal returns (False, None) for an active game |
+| `test_checkers_engine_get_legal_moves_mandatory_capture_only` | get_legal_moves returns only capture moves when any capture is available |
+| `test_checkers_engine_get_legal_moves_no_captures_returns_all` | get_legal_moves returns all regular moves when no captures available |
+| `test_checkers_engine_get_legal_moves_empty_when_blocked` | get_legal_moves returns empty list when the current player has no moves |
+| `test_checkers_engine_get_legal_pieces_captures_only_when_available` | get_legal_pieces returns only pieces that have captures when captures exist |
+| `test_checkers_engine_get_legal_pieces_all_movable_when_no_captures` | get_legal_pieces returns all pieces with any legal move when no captures exist |
+| `test_move_processor_ai_invalid_move_retries` | processor retries on invalid AI move, logs warning |
+| `test_move_processor_ai_fallback_after_max_retries` | processor falls back to random valid move after max retries |
+| `test_status_broadcaster_enforces_min_interval` | broadcaster holds events to min_interval |
+| `test_status_broadcaster_closes_on_terminal_event` | stream terminates after terminal event |
+| `test_status_broadcaster_emits_heartbeat` | heartbeat event emitted at configured interval |
+
+### API Integration
+
+| Test name | Scenario |
+|---|---|
+| `test_checkers_resume_no_active_session` | GET /resume returns `{session_id: null, state: null}` |
+| `test_checkers_resume_active_session_returns_state` | GET /resume returns current board state and session_id |
+| `test_checkers_resume_unauthenticated_returns_401` | GET /resume without auth cookie |
+| `test_checkers_newgame_player_first` | POST /newgame player_starts=true → state has current_turn="player", Red pieces at rows 5-7 |
+| `test_checkers_newgame_ai_first` | POST /newgame player_starts=false → state reflects AI's first move, current_turn="player" |
+| `test_checkers_newgame_closes_existing_session` | POST /newgame closes old active session, creates new session |
+| `test_checkers_move_valid_returns_202` | POST /move with a legal move returns 202 and empty body |
+| `test_checkers_move_invalid_piece_returns_422` | POST /move where `from` is not a player piece |
+| `test_checkers_move_must_capture_constraint_violated_returns_422` | POST /move where `must_capture` is set but wrong piece selected |
+| `test_checkers_move_no_session_returns_409` | POST /move with no active session |
+| `test_checkers_move_unauthenticated_returns_401` | POST /move without auth |
+| `test_checkers_sse_delivers_status_then_move` | SSE delivers status event(s) followed by move event in order |
+| `test_checkers_sse_heartbeat_within_interval` | SSE sends heartbeat within 35s of idle |
+| `test_checkers_sse_unauthorized_session_returns_403` | GET /events/{id} for another user's session returns 403 |
+| `test_checkers_sse_stream_closes_on_terminal_state` | SSE stream closes after a game-over move event |
+| `test_checkers_sse_move_triggers_record_move` | SSE move event results in a DB record_move call |
+| `test_checkers_multijump_two_posts_complete_chain` | Two sequential POSTs complete a two-step capture chain; board reflects each intermediate step |
+| `test_checkers_cleanup_marks_stale_sessions_abandoned` | Cleanup endpoint marks sessions past session_timeout_hours as abandoned |
+
+### E2E
+
+| Test name | Scenario |
+|---|---|
+| `test_checkers_full_game_player_wins` | Player plays to win by capturing all AI pieces; result badge appears in PlayerCards |
+| `test_checkers_full_game_ai_wins` | AI wins; loss result appears in PlayerCards |
+| `test_checkers_full_game_ai_blocked_player_wins` | Player wins by blocking all AI moves (no captures required) |
+| `test_checkers_multijump_player_completes_two_step_capture` | Player executes a two-step jump; board updates after each POST |
+| `test_checkers_king_promotion_shows_crown_visual` | Piece reaching back rank renders with crown overlay |
+| `test_checkers_mandatory_capture_only_capture_destinations_shown` | When a capture is available, only capture destinations are highlighted for the capturing piece |
+| `test_checkers_resume_prompt_shown_for_in_progress_session` | resumeprompt overlay renders over dimmed board when active session found on page load |
+| `test_checkers_resume_prompt_continue_starts_sse` | Clicking Continue from resumeprompt subscribes to SSE and enters playing phase |
+| `test_checkers_resume_prompt_new_game_shows_side_selector` | Clicking New Game from resumeprompt shows turn-order overlay |
+| `test_checkers_go_second_ai_makes_first_move` | With player_starts=false, AI's first move is reflected in the state returned by /newgame |
+| `test_checkers_result_shown_in_player_cards` | Win/loss badge appears in both PlayerCards, not as a standalone alert |
+| `test_checkers_new_game_abandons_in_progress_session` | "New Game" closes old session and starts a fresh board |
+| `test_checkers_unauthenticated_user_sees_login_prompt` | Auth gate shows centred sign-in card blocking game UI |
+| `test_checkers_resume_after_page_refresh` | Mid-game refresh restores board state via /resume |
+| `test_checkers_401_shows_auth_modal` | 401 from any game API triggers AuthModal |
+| `test_checkers_mobile_viewport_playable` | Board fully playable at 375px wide; tap targets meet minimum size |
+| `test_checkers_sse_reconnect_restores_state` | SSE disconnect and reconnect shows correct board state |
+| `test_checkers_sse_reconnect_after_game_ends` | Reconnect to closed stream renders New Game UI |
+
+### Manual
+
+| Scenario |
+|---|
+| Crown overlay clearly distinguishes king pieces from regular pieces on both Red and Black |
+| Only pieces in `legal_pieces` are interactive; non-legal pieces show no hover state |
+| Multi-jump continuation: only the jumping piece is interactive and highlighted mid-chain; all other pieces are locked |
+| AI capture chain animates step-by-step with visible ~400ms delay between each jump |
+| Board orientation is correct: player's pieces at bottom, opponent at top, for both Red and Black player perspectives |
+| Status text changes are readable at 2–3s intervals — not flickering, not stale |
+| Loading spinner renders before /resume resolves when localStorage hint is present |
+| Piece tap targets are comfortable on a physical mobile device |
+| Landscape orientation on mobile renders without layout breakage |
+| SSE reconnects and restores board correctly after a simulated network drop |
+| AI "Thinking..." text appears inside the AI PlayerCard during AI turn, not below the board |
+| Resume prompt shows correct board state (dimmed) when returning to an in-progress game |

--- a/features/game-chess/spec.md
+++ b/features/game-chess/spec.md
@@ -4,58 +4,688 @@
 
 ## Background
 
-Backend game logic is fully implemented in `src/backend/game_logic/chess.py`, including piece movement,
-castling, and en passant. The existing `src/frontend/public/js/basic-chess-ai.js` (~39KB minimax) and
-`chess-evaluation.js` are legacy client-side files from the pre-React implementation. REST API exists at
-`/api/game/chess/start`, `/api/game/chess/move`, `/api/game/chess/session/{id}`. The React page at
-`src/frontend/src/pages/games/ChessPage.tsx` is currently a stub. This spec supersedes the Chess section of
-the react-migration Phase 3 spec.
+Backend game logic is fully implemented in `src/backend/game_logic/chess.py`, including all standard chess
+rules: piece movement, castling, en passant, pawn promotion, check, checkmate, and stalemate. The existing
+`src/frontend/public/js/basic-chess-ai.js` (~39KB minimax with alpha-beta pruning) and
+`src/frontend/public/js/chess-evaluation.js` (piece-square table evaluation) are legacy client-side files
+from the pre-React implementation. Their logic is **ported to Python** as `ChessAIStrategy` and the
+original JS files are deleted as part of this feature.
+Legacy REST endpoints at `/api/game/chess/start`, `/api/game/chess/move`, and
+`/api/game/chess/session/{id}` are also retired. The React page at
+`src/frontend/src/pages/games/ChessPage.tsx` is currently a stub. The game-data-persistence feature is
+complete and integrated. This spec supersedes the Chess section of the react-migration Phase 3 spec and
+resolves the transport open question in `features/websocket/spec.md` for turn-based games: SSE, not
+WebSocket.
 
-Chess is the most complex game in the set and should be implemented last.
+Chess is the most complex game in the set and is implemented last.
 
-## Known Requirements
+## Resolved Design Decisions
 
-- **Mobile + desktop responsive**: 8x8 board must render at a playable size on mobile without overflow; piece
-  tap targets must be large enough; game board is the primary focus above the fold; captured pieces, move
-  history, and controls stack below or in a collapsible panel on small viewports
-- Connect to backend REST API for game start and moves
-- Move transport (REST vs. WebSocket) is an open question pending the websocket feature spec — see
-  `features/websocket/`
-- When the game-data-persistence feature is complete, session data capture must be integrated
-- **Frontend move validation**: the React client validates moves in real time to block illegal inputs before
-  they are submitted — this is a UX layer, not a security boundary
-- **Backend move validation (player)**: the backend re-validates every player move server-side as a redundancy
-  against frontend manipulation
-- **Backend move validation (AI)**: the backend validates every AI-generated move; if invalid, it rates the
-  move and retries the AI logic until a valid move is produced (up to a configurable retry limit); the client
-  always receives a guaranteed-valid AI move
-- The legacy `basic-chess-ai.js` and `chess-evaluation.js` files are to be removed as part of Phase 4 cleanup;
-  AI logic runs server-side only
+- **Auth required**: No unauthenticated gameplay. Game pages display a login prompt blocking the game UI
+  for unauthenticated users. Any API call without a valid session returns 401; the client surfaces an
+  `AuthModal`, no silent retry.
+- **Transport**: Server-Sent Events for all server→client push. Client POSTs moves (202 Accepted, no state
+  in response); state updates arrive over SSE.
+- **One session per user per game**: Enforced by existing DB partial unique index. Starting a new game
+  explicitly closes any existing active session before creating a new one.
+- **No AI difficulty**: The AI difficulty parameter is removed entirely from the user-facing API. The
+  `games` table retains its `difficulty` column as game-level metadata (indicating how hard the game is
+  for humans — Chess is "high"). This is unrelated to AI difficulty and must not be conflated.
+- **Turn order**: Player selects whether to go first (White) or second (Black) before the game starts.
+  Internally this is stored and passed as `player_starts: bool`. If `player_starts` is false, the AI
+  (White) takes the first move before `/newgame` returns.
+- **Session ID ownership**: The client never stores `session_id` across page loads. It is received from
+  `/resume` or `/newgame` and used only to subscribe to the SSE stream. Move requests carry no
+  `session_id`; the server derives the active session from the authenticated user + game type.
+- **Board orientation**: Always rendered from the player's perspective. White player = row 7 at bottom
+  (standard). Black player = row 0 at bottom (flipped).
+- **Pawn promotion**: When the player moves a pawn to the back rank, the client shows a promotion modal
+  overlay (same style as the "New Game" overlay — centred, backdrop blur) presenting the four valid
+  choices: Queen, Rook, Bishop, Knight (as piece icons in the player's color). The POST is held until the
+  player selects a piece, then sent with `promotionPiece` set to the chosen piece. AI always promotes to
+  queen automatically.
+- **Check/checkmate/stalemate**: Fully server-side. The SSE move event includes `in_check: bool` for the
+  player whose turn it now is. Stalemate is a draw.
+- **Move selection**: Two-click model. Tap a piece to select it; tap a highlighted destination to submit.
+  No drag-and-drop.
+- **Valid move highlighting**: On piece tap, client calls `GET /api/game/chess/legal-moves?from_row=r&from_col=c`
+  to get valid destinations and highlights them. Castling and en passant destinations appear as normal
+  highlighted squares; the server handles the special mechanics automatically.
+- **Captured pieces display**: Shown as a row of small piece icons adjacent to each `PlayerCard`.
+- **Move history**: Scrollable list of move pairs. Notation comes from the `notation` field in each SSE
+  move event (server-generated long algebraic notation). Client accumulates entries from received events.
+- **`engine_eval`**: Stored as the minimax evaluation score normalized to `[-1, 1]` (centipawn score / 1000, clamped). Positive = AI advantage. Available because the JS evaluation function is ported to Python.
+- **Legacy files deleted**: `src/frontend/public/js/basic-chess-ai.js` and
+  `src/frontend/public/js/chess-evaluation.js` are deleted after their logic is ported to `ChessAIStrategy`.
 
-## Open Questions
+## Architecture
 
-### Gameplay
-- Should unauthenticated users be able to play, or is login required?
-- Player color selection (white vs. black)?
-- What difficulty levels map to which search depths?
-- Check / checkmate / stalemate detection: is this fully handled by the backend, or does the frontend need to
-  detect any of these?
-- En passant and castling: are these fully handled by the backend API, or does the frontend need special logic?
-- Promotion: how is pawn promotion handled — automatic queen, or player choice?
-- Session recovery on page refresh?
+### Abstractions (shared across all turn-based games)
 
-### UI / UX
-- Move selection model: tap piece to select, tap destination to move — or drag-and-drop?
-- How are valid moves highlighted on piece selection?
-- Move history / notation panel (algebraic notation)?
-- Captured pieces display?
-- AI "thinking" indicator (chess AI can be slow at deeper depths)?
-- Win/loss/draw/stalemate outcome display?
+These live in `src/backend/game_engine/base.py`. Chess implements the same `GameEngine` and `AIStrategy`
+ABCs as Tic-Tac-Toe.
 
-### Stats & Persistence
-- Win/loss/draw stats on the game page? (Depends on game-data-persistence feature)
-- Should move history be persisted for game replay?
+**`GameEngine` (abstract base)**
+```
+validate_move(state, move) → bool
+apply_move(state, move) → GameState
+is_terminal(state) → tuple[bool, outcome | None]
+get_legal_moves(state) → list[Move]
+initial_state(player_starts: bool) → GameState
+```
+
+**`AIStrategy` (abstract base)**
+```
+generate_move(state) → tuple[Move, Optional[float]]
+    # Move may be invalid; no guarantee. float is engine_eval or None if strategy has no score.
+```
+
+**`MoveProcessor` (shared, game-agnostic)**
+```
+process_player_move(engine, state, move) → GameState | ValidationError
+process_ai_turn(engine, strategy, state, max_retries=5) → GameState
+```
+`process_ai_turn` loop:
+1. `move = strategy.generate_move(state)`
+2. If `engine.validate_move(state, move)`: break
+3. `log.warning("ai_invalid_move", attempt=n)` + OTel attribute `ai_invalid_move_count`
+4. After `max_retries` exhausted: `move = random.choice(engine.get_legal_moves(state))` (guaranteed valid)
+
+**`StatusBroadcaster` (shared)**
+```
+emit(event: StatusEvent) → None     # called by game processor at full speed; non-blocking
+stream() → AsyncGenerator[StatusEvent]  # drives the SSE endpoint; enforces min_interval
+```
+- `min_interval`: 2.5 seconds between sends to client
+- First status held for ~0.5s (prevents flash for near-instant AI responses)
+- Heartbeat event every 30s (client ignores; keeps stream alive through proxies)
+- Terminal event closes the stream
+
+### ChessEngine (`src/backend/game_engine/chess_engine.py`)
+
+Implements `GameEngine`. Wraps the existing logic in `src/backend/game_logic/chess.py`.
+
+**`initial_state(player_starts: bool) → GameState`**: Returns a fresh board. If `player_starts` is false,
+`player_color` is `"black"` and `current_player` is `"white"`.
+
+**`apply_move(state, move) → GameState`**: Executes exactly one move (player or AI). Does not process the
+opponent. Uses existing `_get_valid_moves` and `_execute_move` logic. Updates board, `castling_rights`,
+`en_passant_target`, `king_positions`, `captured_pieces`. Sets `last_move` (see GameState shape below).
+Toggles `current_player`. Does NOT call `_check_game_end`. Computes `in_check` as
+`_is_in_check(state, state["current_player"])` after the move.
+
+**`is_terminal(state) → tuple[bool, outcome | None]`**: Calls `_check_game_end`. Maps winner to
+`"player_won"` | `"ai_won"` | `"draw"`.
+
+**`get_legal_moves(state) → list[Move]`**: Returns all legal moves for the current player as
+`[{"fromRow", "fromCol", "toRow", "toCol", "promotionPiece"}, ...]`. Used by the legal-moves endpoint
+and the AI fallback path.
+
+### ChessAIStrategy (`src/backend/game_engine/chess_engine.py`)
+
+Implements `AIStrategy`. Ports the minimax with alpha-beta pruning from `basic-chess-ai.js` and the
+piece-square table evaluation from `chess-evaluation.js` to Python. Search depth: configurable constant
+(default 3). Returns a single move dict with `promotionPiece` set to `"Q"`/`"q"` for AI pawn promotion.
+
+The ported evaluation function produces a score in centipawns (positive = AI advantage). This is stored
+as `engine_eval` normalized to `[-1, 1]` by dividing by a scaling factor (e.g., 1000 centipawns = ±1.0,
+clamped). This replaces the earlier "store null" decision that assumed a random AI.
+
+### GameState Shape
+
+```json
+{
+  "board": [[...8×8...]],
+  "current_player": "white" | "black",
+  "player_color": "white" | "black",
+  "game_active": true,
+  "player_starts": true,
+  "king_positions": {"white": [7, 4], "black": [0, 4]},
+  "castling_rights": {
+    "white": {"kingside": true, "queenside": true},
+    "black": {"kingside": true, "queenside": true}
+  },
+  "en_passant_target": null,
+  "captured_pieces": {"player": [], "ai": []},
+  "last_move": null,
+  "in_check": false
+}
+```
+
+Board: 8×8 2D array, row 0 = black's back rank, row 7 = white's back rank. Uppercase = white
+(R, N, B, Q, K, P), lowercase = black (r, n, b, q, k, p), null = empty.
+
+`last_move` shape (null until the first move is made):
+```json
+{
+  "fromRow": 6, "fromCol": 4, "toRow": 4, "toCol": 4,
+  "piece": "P",
+  "captured": null,
+  "is_castling": false,
+  "is_en_passant": false,
+  "promotion": null,
+  "notation": "e2-e4"
+}
+```
+
+`in_check` is computed after each `apply_move` call: `_is_in_check(state, state["current_player"])`.
+
+### SSE Event Schema
+
+```json
+{"type": "status", "message": "Thinking..."}
+
+{"type": "move", "data": {
+  "fromRow": 6, "fromCol": 4, "toRow": 4, "toCol": 4,
+  "piece": "P",
+  "captured": null,
+  "is_castling": false,
+  "is_en_passant": false,
+  "promotion": null,
+  "notation": "e2-e4",
+  "player": "player",
+  "board": [[...8×8...]],
+  "player_color": "white",
+  "current_player": "black",
+  "in_check": false,
+  "captured_pieces": {"player": [], "ai": []},
+  "en_passant_target": [5, 4],
+  "castling_rights": {
+    "white": {"kingside": true, "queenside": true},
+    "black": {"kingside": true, "queenside": true}
+  },
+  "status": "in_progress",
+  "winner": null
+}}
+
+{"type": "move", "data": {
+  "fromRow": 3, "fromCol": 4, "toRow": 1, "toCol": 4,
+  "piece": "q",
+  "captured": null,
+  "is_castling": false,
+  "is_en_passant": false,
+  "promotion": null,
+  "notation": "e5-e7#",
+  "player": "ai",
+  "board": [[...8×8...]],
+  "player_color": "white",
+  "current_player": null,
+  "in_check": true,
+  "captured_pieces": {"player": [], "ai": []},
+  "en_passant_target": null,
+  "castling_rights": {
+    "white": {"kingside": true, "queenside": true},
+    "black": {"kingside": true, "queenside": true}
+  },
+  "status": "complete",
+  "winner": "ai"
+}}
+
+{"type": "heartbeat"}
+
+{"type": "error", "code": "invalid_move", "message": "..."}
+```
+
+`status` is `"in_progress"` or `"complete"`. `winner` is `"player"` | `"ai"` | `"draw"` | null.
+`current_player` is null when the game is complete.
+
+### Status Copy
+
+Player move validation produces no status event — the client already reflects the move visually and
+validation is near-instant.
+
+| Condition | Message |
+|---|---|
+| AI begins processing | `"Thinking..."` |
+| 2.5s pass, AI still running | random: `["Analyzing...", "Considering...", "Plotting a move...", "Hmm..."]` |
+| 5s+ elapsed | random: `["Taking a moment...", "Almost there..."]` |
+| AI move ready | `move` event (closes the turn) |
+
+## API Endpoints
+
+All endpoints require authentication. 401 is returned for any unauthenticated request.
+
+### `GET /api/game/chess/resume`
+
+Always called on page load, regardless of how the user arrived. Returns the active session for the
+authenticated user if one exists.
+
+**Response 200 — active session:**
+```json
+{"session_id": "uuid", "state": { ...game state... }}
+```
+
+**Response 200 — no active session:**
+```json
+{"session_id": null, "state": null}
+```
+The client handles the null case by rendering the "New Game" UI. There is no 404 for this path — a
+missing session is a normal state, not an error.
+
+### `POST /api/game/chess/newgame`
+
+Called only when the player explicitly chooses to start a new game. Closes any existing active session
+for this user + game type, then creates a new one. If `player_starts` is false, the AI (White) takes
+the first move server-side before the response is returned; the initial state in the response reflects
+that move.
+
+**Request:**
+```json
+{"player_starts": true}
+```
+
+**Response 200:**
+```json
+{"session_id": "uuid", "state": { ...initial game state... }}
+```
+
+### `POST /api/game/chess/move`
+
+Submits the player's move. Active session is derived server-side from the authenticated user + game
+type. No `session_id` in request.
+
+**Request:**
+```json
+{"fromRow": 6, "fromCol": 4, "toRow": 4, "toCol": 4, "promotionPiece": null}
+```
+
+`promotionPiece` is required when the move is a pawn-reaches-back-rank move; the client holds the POST
+until the player selects a piece from the promotion modal. `null` for all other moves.
+
+**Response 202:** Empty body. State update delivered via SSE.
+
+**Response 422:** Invalid move (wrong color piece, illegal destination, moves into check, not player's
+turn, game already over, pawn-reaches-back-rank move submitted with `promotionPiece: null`).
+
+**Response 409:** No active session.
+
+### `GET /api/game/chess/events/{session_id}`
+
+Persistent SSE stream. Authenticated user must own the session.
+
+**Response:** `text/event-stream`
+
+Cloud Run request timeout must be raised to 3600s. Heartbeat events every 30s prevent intermediate
+proxy timeouts.
+
+### `GET /api/game/chess/legal-moves`
+
+Returns all legal destinations for the piece at the given square for the current player. Read-only;
+uses the existing `_get_valid_moves` logic via `ChessEngine.get_legal_moves` filtered to the specified
+source square.
+
+**Query params:** `from_row` (int), `from_col` (int)
+
+**Response 200:**
+```json
+{"moves": [[4, 4], [5, 4]]}
+```
+Each element is `[toRow, toCol]`.
+
+**Response 422:** `from_row` or `from_col` out of range, or no piece at square, or piece belongs to
+opponent.
+
+**Response 409:** No active session.
+
+## Session Lifecycle and Timeout
+
+A session remains active indefinitely as long as the player reconnects and resumes. Sessions abandoned
+without explicit closure must eventually be cleaned up.
+
+**Timeout configuration**: The `games` DB table `session_timeout_hours` column (integer, not null).
+Chess: 24 hours. This is the maximum idle time (measured from `last_move_at`) before a session is
+marked abandoned.
+
+**Cleanup mechanism**: A GCP Cloud Scheduler job fires periodically (e.g., every hour) and calls an
+internal, non-public endpoint (`POST /internal/cleanup-sessions`). This endpoint queries all
+`in_progress` sessions where `last_move_at < now() - session_timeout_hours` and marks them abandoned
+via `end_game_session()`. The endpoint requires an internal-only auth header (not the user session
+cookie).
+
+Sessions closed this way emit the `game.sessions.completed` metric with outcome `abandoned`, consistent
+with the observability spec.
+
+## Observability
+
+Follows the conventions in `features/observability/spec.md`.
+
+**`games.py` (request layer):**
+- `POST /newgame`, `POST /move`, `GET /resume`, `GET /events/{session_id}`, `GET /legal-moves`: set
+  `game.id` and `game.session_id` as attributes on the auto-instrumented HTTP span via
+  `span.set_attribute`.
+- No new spans at this layer.
+
+**`games.py` — AI move processing:**
+- Child span `game.ai.move` on the SSE handler. Attributes: `game.id`, `compute_duration_ms`,
+  `ai_invalid_move_count`.
+
+**`persistence_service.py`:**
+- Existing child spans for `record_move` and `end_session` already cover DB writes. No changes required.
+
+**SSE connection lifecycle:**
+- SSE open: `span.set_attribute("game.id", ...)`, `span.set_attribute("game.session_id", ...)`
+- SSE close (normal): `logger.info("chess_sse_closed", extra={"session_id": session_id})`
+- SSE close (error / unexpected): `logger.exception("chess_sse_error", extra={"session_id": session_id})` +
+  `span.record_exception(e)` + `span.set_status(ERROR)`
+- Per-message spans: not required (too noisy). The `game.ai.move` child span covers the significant event.
+
+**Invalid move logging:**
+- `POST /move` returning 422: `logger.warning("chess_invalid_move", extra={"session_id": session_id, "move": move})`
+
+**`GET /legal-moves` logging:**
+- This endpoint is called on every piece tap and is high-frequency. It must NOT emit INFO-level log
+  records per call. Span attributes (`game.id`, `game.session_id`) are sufficient for trace-level
+  visibility. Only log at WARNING or higher if the endpoint returns 422.
+
+**No instrumentation inside `game_engine/` files.** All manual instrumentation lives at the router and
+persistence layers only.
+
+## Client Behavior
+
+### Page Load and Resume
+
+The client uses five phases: `loading`, `newgame`, `resumeprompt`, `playing`, `terminal`.
+
+1. Check `localStorage` for key `chess_game_hint`. If present and `expires` is in the future, enter
+   `loading` phase (spinner overlay on board) while `/resume` is in flight. Otherwise enter `newgame`
+   immediately.
+2. On `/resume` response:
+   - Active in-progress session → set board state from response, enter `resumeprompt` phase. SSE is
+     **not** subscribed yet.
+   - Completed session → set board state, enter `terminal` phase directly (no prompt needed).
+   - Null → enter `newgame` phase, clear any stale localStorage hint.
+
+**`chess_game_hint` shape:**
+```json
+{"expires": 1234567890000}
+```
+TTL: 10 minutes. Refreshed on every received SSE `move` event.
+
+Cleared when:
+- Terminal game state received over SSE.
+- Player clicks "New Game" (before `/newgame` is even sent).
+- `beforeunload` fires (handles normal tab/browser close; TTL handles crashes).
+
+### Resume Prompt
+
+When in `resumeprompt` phase, the board renders (dimmed, locked) with a centred overlay:
+
+- **Continue Game** → subscribes to SSE, enters `playing` phase.
+- **New Game** → enters `newgame` phase (overlay changes to turn-order selector; previous board stays
+  visible dimmed underneath).
+
+### Turn Order Selection
+
+Shown as a board overlay in `newgame` phase. Two buttons: "Play as White — Go First" / "Play as Black
+— Go Second (AI moves first)". Submitting triggers `POST /newgame` with `player_starts: true/false`.
+
+The board renders immediately in `playing` phase (empty, locked) before the API responds so the layout
+does not shift. When going second (Black), the AI computes White's first move server-side before
+`/newgame` returns; the board updates with that move once the response arrives.
+
+### Piece Selection and Legal Moves
+
+1. Tap player's own piece → client calls `GET /api/game/chess/legal-moves?from_row=r&from_col=c`.
+2. While loading: selected piece shows loading state (opacity pulse).
+3. On response: highlight all valid destination squares; show selected piece as "active" (highlighted
+   border or background).
+4. Tap a highlighted square → `POST /move` with coords + auto-promotion piece if applicable. Board
+   locks on 202; unlocks when AI move arrives via SSE.
+5. Tap the same piece again → deselect.
+6. Tap another own piece → reselect (calls legal-moves for the new piece).
+7. Tap a non-highlighted square or opponent piece → deselect.
+
+Board is locked (no interaction) while awaiting AI move via SSE.
+
+### Pawn Promotion Modal
+
+When the player selects a pawn and taps a back-rank destination (`toRow == 0` for White, `toRow == 7`
+for Black), the client does NOT immediately POST the move. Instead, a promotion overlay appears
+(positioned and styled identically to the "New Game" overlay: centred, `bg-base-100/80 backdrop-blur-sm`
+over the dimmed board). The overlay shows four piece options as icons in the player's color:
+
+- Queen
+- Rook
+- Bishop
+- Knight
+
+Tapping a piece closes the overlay and fires `POST /move` with `promotionPiece` set to the appropriate
+letter (`"Q"` / `"R"` / `"B"` / `"N"` for White; lowercase for Black). The board remains locked while
+the overlay is visible. Tapping outside the overlay cancels the move and returns to the piece-selected
+state (valid destinations still highlighted).
+
+### Check Indicator
+
+When a `move` event arrives with `in_check: true` and `current_player == player_color`, highlight the
+player's king square with a red background. Clear the indicator when the next move event arrives.
+
+When `in_check: true` and `current_player != player_color` (opponent is in check), optionally show a
+subtle indicator on the opponent king square (e.g., muted highlight). Terminal move events with
+`in_check: true` indicate checkmate.
+
+### Captured Pieces
+
+Each player's captured pieces are rendered as a row of small piece icons:
+- Row above the AI `PlayerCard`: pieces captured by the AI (pieces the player has lost, rendered from
+  the player's perspective as pieces removed from their side).
+- Row below the Player `PlayerCard`: pieces captured by the player (pieces the player has taken).
+
+Use the `captured_pieces` field from each SSE move event. Update in real time on receipt. Use Unicode
+chess symbols or SVG sprites.
+
+### Move History
+
+A scrollable list of move pairs rendered below the captured pieces section. The client accumulates
+entries from received SSE move events. Format: `1. e2-e4  e7-e5`, `2. Ng1-f3  Nb8-c6`. Notation comes
+from the `notation` field in each move event. Always scroll to the latest move on update.
+
+On mobile, the move history panel is collapsible. On desktop, it is always visible.
+
+### Outcome
+
+Game result is displayed inside the `PlayerCard` components (above and below the board), not as a
+standalone banner. A "New Game" button appears below the player card; clicking it enters `newgame`
+phase (overlay on dimmed board).
+
+Outcome states:
+- Checkmate: winner's card shows win badge; loser's card shows loss badge.
+- Stalemate: both cards show draw badge.
+
+### SSE Reconnect and Error Path
+
+Browser `EventSource` reconnects automatically on disconnect. On reconnect:
+1. Call `/resume`.
+2. If active session: re-render board from returned state, resubscribe to SSE.
+3. If null session (stream closed because game ended, or session timed out): render "New Game" UI,
+   clear localStorage hint.
+
+On any 401 from any game API: clear local game state, display `AuthModal`. No silent retry.
+
+## UI / Layout
+
+Layout (top to bottom): AI `PlayerCard` → captured pieces (AI's captures) → board (with overlay) →
+captured pieces (player's captures) → Player `PlayerCard` → move history panel → "New Game" button.
+
+The `PlayerCard` component (`src/frontend/src/components/PlayerCard.tsx`) is used for both participants.
+See `features/player-card/spec.md` for the full component spec.
+
+- AI card (above board): bot icon avatar, "AI Opponent" label, color indicator, SSE status text during
+  AI turn, result badge on terminal state.
+- Player card (below board): user avatar / initials, display name, color indicator, result badge on
+  terminal state.
+- Board overlays (positioned absolute, `inset-0`, `bg-base-100/80 backdrop-blur-sm`):
+  - `loading`: centred spinner.
+  - `resumeprompt`: "Game in progress" label + Continue / New Game buttons.
+  - `newgame`: "Choose your color:" label + Go First (White) / Go Second (Black) buttons.
+
+### Board Orientation
+
+- `player_color == "white"`: row 7 at bottom, row 0 at top (standard). Files a–h left to right. Ranks
+  1–8 bottom to top.
+- `player_color == "black"`: row 0 at bottom, row 7 at top (flipped). Files h–a left to right (from
+  black's perspective). Ranks 8–1 bottom to top.
+
+Rank and file labels are rendered outside the board edge, oriented from the player's perspective.
+
+### Piece Rendering
+
+Use Unicode chess symbols or SVG sprites. White pieces: ♔♕♖♗♘♙. Black pieces: ♚♛♜♝♞♟. Pieces must
+be distinguishable at small sizes on mobile.
+
+Square highlighting states:
+- Selected piece: distinct background (e.g., accent color).
+- Valid destination: dot or semi-transparent overlay.
+- Last move (from and to squares): subtle tinted background.
+- King in check: red background on the king square.
+
+### Captured Pieces Display
+
+Small piece icons in a compact row. Group by piece type if desired. No strict ordering required. Updated
+in real time from SSE move events.
+
+### Move History Panel
+
+- Desktop: always visible, fixed height with internal scroll, positioned below the captured pieces.
+- Mobile: collapsible section. Collapsed by default. Header shows move count; tap to expand.
+- Autoscrolls to the latest entry on each new move event.
+- Format: `{n}. {white_notation}  {black_notation}`. White notation is added on White's move event;
+  black notation fills in on Black's move event.
+
+### Mobile Layout
+
+- Board fills viewport width (max 100vw). Each square is at least 40×40px for comfortable tap targets.
+- Captured pieces, move history, and controls stack below the board.
+- No horizontal scroll at any viewport width.
+- Landscape orientation supported without layout breakage.
+
+## Data Persistence
+
+Every valid move (player and AI) is recorded via `persistence_service.record_move()`. The `player`
+argument must be `"human"` for player moves and `"ai"` for AI moves — consistent with TTT and the
+existing DB data. `engine_eval` is stored as the minimax score normalized to `[-1, 1]` (centipawn score
+/ 1000, clamped; positive = AI advantage). Terminal state triggers
+`persistence_service.end_game_session()`. No changes to the persistence service API are required.
+
+## Legacy Cleanup
+
+As part of implementation:
+1. Port minimax + alpha-beta pruning from `basic-chess-ai.js` to `ChessAIStrategy` in Python.
+2. Port evaluation function + piece-square tables from `chess-evaluation.js` to Python.
+3. Delete both JS files: `src/frontend/public/js/basic-chess-ai.js` and `src/frontend/public/js/chess-evaluation.js`.
+
+All AI logic runs server-side. The legacy REST endpoints `/api/game/chess/start`,
+`/api/game/chess/move` (non-SSE), and `/api/game/chess/session/{id}` are removed from
+`src/backend/games.py`. The generic `POST /game/{game_id}/start` and `POST /game/{game_id}/move`
+endpoints also use the old bundled architecture and must return `501` for `chess`.
 
 ## Test Cases
 
-_To be defined during planning session._
+### Unit
+
+| Test name | Scenario |
+|---|---|
+| `test_chess_engine_validate_move_wrong_color` | validate_move returns false when moving opponent's piece |
+| `test_chess_engine_validate_move_occupied_by_own_piece` | validate_move returns false when destination occupied by own piece |
+| `test_chess_engine_validate_move_moves_into_check` | validate_move returns false when move leaves own king in check |
+| `test_chess_engine_validate_move_valid` | validate_move returns true for a legal pawn advance |
+| `test_chess_engine_apply_move_regular_updates_board` | apply_move places piece at destination, clears source |
+| `test_chess_engine_apply_move_capture_added_to_captured_pieces` | apply_move adds captured piece to captured_pieces |
+| `test_chess_engine_apply_move_castling_moves_rook` | apply_move kingside castling repositions rook correctly |
+| `test_chess_engine_apply_move_en_passant_removes_pawn` | apply_move en passant removes captured pawn from board |
+| `test_chess_engine_apply_move_pawn_promotion_replaces_piece` | apply_move replaces promoted pawn with queen |
+| `test_chess_engine_apply_move_toggles_current_player` | apply_move alternates current_player after each move |
+| `test_chess_engine_apply_move_last_move_set` | apply_move populates last_move with correct fields including notation |
+| `test_chess_engine_is_terminal_checkmate_player_won` | is_terminal returns (True, "player_won") for checkmate against AI |
+| `test_chess_engine_is_terminal_checkmate_ai_won` | is_terminal returns (True, "ai_won") for checkmate against player |
+| `test_chess_engine_is_terminal_stalemate_draw` | is_terminal returns (True, "draw") for stalemate |
+| `test_chess_engine_is_terminal_in_progress` | is_terminal returns (False, None) mid-game |
+| `test_chess_engine_get_legal_moves_pawn_starting` | pawn on starting rank returns two forward moves |
+| `test_chess_engine_get_legal_moves_castling_included` | castling moves present when rights intact and path clear |
+| `test_chess_engine_get_legal_moves_empty_when_checkmated` | returns empty list when player is checkmated |
+| `test_chess_engine_get_legal_moves_excludes_moves_into_check` | moves that expose king are excluded |
+| `test_chess_engine_notation_regular_move` | last_move.notation is "e2-e4" for pawn advance |
+| `test_chess_engine_notation_castling_kingside` | last_move.notation is "O-O" for kingside castling |
+| `test_chess_engine_notation_castling_queenside` | last_move.notation is "O-O-O" for queenside castling |
+| `test_chess_engine_notation_promotion` | last_move.notation is "e7-e8=Q" for pawn promotion |
+| `test_chess_engine_in_check_set_after_move` | in_check field is true when current_player's king is in check after apply_move |
+| `test_move_processor_ai_invalid_move_retries` | processor retries on invalid AI move, logs warning |
+| `test_move_processor_ai_fallback_after_max_retries` | processor falls back to random valid move after exhausting retries |
+| `test_status_broadcaster_enforces_min_interval` | broadcaster holds events to min_interval |
+| `test_status_broadcaster_closes_on_terminal_event` | stream terminates after terminal event |
+| `test_status_broadcaster_emits_heartbeat` | heartbeat event emitted at configured interval |
+
+### API Integration
+
+| Test name | Scenario |
+|---|---|
+| `test_chess_resume_no_active_session` | GET /resume returns {session_id: null, state: null} |
+| `test_chess_resume_active_session_returns_state` | GET /resume returns current board state and session_id |
+| `test_chess_resume_unauthenticated_returns_401` | GET /resume without auth |
+| `test_chess_newgame_player_white` | POST /newgame player_starts=true → board in initial state, current_player=white |
+| `test_chess_newgame_player_black_ai_moves_first` | POST /newgame player_starts=false → state reflects AI's first white move |
+| `test_chess_newgame_closes_existing_session` | POST /newgame closes old active session, creates new one |
+| `test_chess_move_returns_202` | POST /move valid move returns 202, no body |
+| `test_chess_move_invalid_piece_returns_422` | POST /move with coords pointing to empty square |
+| `test_chess_move_illegal_destination_returns_422` | POST /move destination would leave king in check |
+| `test_chess_move_no_active_session_returns_409` | POST /move with no session for user |
+| `test_chess_move_unauthenticated_returns_401` | POST /move without auth |
+| `test_chess_legal_moves_pawn` | GET /legal-moves for a pawn returns correct destinations |
+| `test_chess_legal_moves_knight` | GET /legal-moves for a knight returns correct L-shaped destinations |
+| `test_chess_legal_moves_king_castling` | GET /legal-moves for king includes castling destinations when eligible |
+| `test_chess_legal_moves_no_active_session_returns_409` | GET /legal-moves with no session |
+| `test_chess_sse_delivers_status_then_move` | SSE delivers status event(s) then move event in order |
+| `test_chess_sse_move_in_check_flag` | SSE move event has in_check=true when player is in check after AI move |
+| `test_chess_sse_heartbeat_within_interval` | SSE sends heartbeat within 35s of idle |
+| `test_chess_sse_unauthorized_session_returns_403` | GET /events/{id} for another user's session |
+| `test_chess_sse_stream_closes_on_terminal_state` | SSE stream closes after game-over move event |
+| `test_chess_sse_move_triggers_record_move` | SSE move event results in DB record_move call with engine_eval=null |
+| `test_chess_cleanup_marks_stale_sessions_abandoned` | Cleanup endpoint marks chess sessions past 24h timeout as abandoned |
+
+### E2E
+
+| Test name | Scenario |
+|---|---|
+| `test_chess_full_game_player_wins` | Player plays to checkmate AI; win badge appears in player card |
+| `test_chess_full_game_ai_wins` | AI checkmates player; loss badge appears in player card |
+| `test_chess_full_game_draw_stalemate` | Game ends in stalemate; draw badge appears in both cards |
+| `test_chess_valid_move_highlights_appear_after_piece_tap` | Tapping a piece shows highlighted destination squares |
+| `test_chess_tap_non_highlighted_square_does_nothing` | Tapping a non-highlighted square deselects piece, no move submitted |
+| `test_chess_castling_rook_moves_automatically` | Player clicks king 2 squares; rook repositions in UI after AI SSE event |
+| `test_chess_en_passant_captured_pawn_disappears` | Player executes en passant; captured pawn is removed from board |
+| `test_chess_pawn_promotion_modal_appears` | Pawn moves to back rank; promotion overlay appears with 4 piece options |
+| `test_chess_pawn_promotion_selects_piece` | Selecting rook from promotion modal POSTs with promotionPiece="R" and board shows rook |
+| `test_chess_pawn_promotion_cancel_keeps_selection` | Tapping outside overlay cancels and valid destinations remain highlighted |
+| `test_chess_check_indicator_king_square_red` | King square turns red when player is in check |
+| `test_chess_captured_pieces_update_in_real_time` | Captured piece icons update immediately on SSE move event |
+| `test_chess_move_history_scrolls_and_shows_notation` | Move history list accumulates notation and scrolls to latest entry |
+| `test_chess_resume_prompt_shown_for_in_progress_session` | resumeprompt overlay renders over dimmed board when active session found |
+| `test_chess_resume_prompt_continue_starts_sse` | Clicking Continue from resumeprompt subscribes to SSE and enters playing |
+| `test_chess_resume_prompt_new_game_shows_side_selector` | Clicking New Game from resumeprompt shows color selector overlay |
+| `test_chess_go_second_ai_moves_first` | Player chooses Black; board shows White's first AI move before player can interact |
+| `test_chess_board_flipped_for_black_player` | When player is Black, black pieces appear at bottom of board |
+| `test_chess_result_shown_in_player_cards` | Win/loss/draw badge appears in both PlayerCards, not as standalone alert |
+| `test_chess_new_game_abandons_in_progress_session` | "New Game" closes old session and starts a fresh one |
+| `test_chess_unauthenticated_user_sees_login_prompt` | Auth gate shows centred sign-in card |
+| `test_chess_resume_after_page_refresh` | Mid-game refresh restores board state from /resume |
+| `test_chess_401_shows_auth_modal` | 401 from any game API triggers AuthModal |
+| `test_chess_sse_reconnect_restores_state` | SSE disconnect + reconnect shows correct board state |
+| `test_chess_sse_reconnect_after_game_ends` | Reconnect to closed stream after game over renders new game UI |
+| `test_chess_mobile_viewport_playable` | Board fully playable at 375px wide; tap targets ≥ 40px |
+
+### Manual
+
+| Scenario |
+|---|
+| Board orientation is correct for both white and black players |
+| Highlighted valid move squares are visually clear and not confusing |
+| Castling move is discoverable (king's +2 square appears as a valid destination) |
+| Check indicator (red king square) is prominent and immediately noticeable |
+| Captured pieces display is clean and readable at small icon sizes |
+| Move history scrolls to the latest move automatically |
+| AI "Thinking..." text appears inside the AI card during AI turn, not below the board |
+| Promotion to queen is seamless — no dialog, no visual flash |
+| Landscape orientation on mobile renders without layout overflow |
+| Board tap targets are comfortable on a physical mobile device |
+| Status text changes are readable at 2–3s intervals — not flickering, not stale |
+| Resume prompt shows correct board state (dimmed) when returning to an in-progress game |
+| SSE reconnects and restores board correctly after simulated network drop |

--- a/features/game-connect4/spec.md
+++ b/features/game-connect4/spec.md
@@ -4,45 +4,415 @@
 
 ## Background
 
-Backend game logic is fully implemented in `src/backend/game_logic/connect4.py`. REST API exists at
+Backend game logic exists in `src/backend/game_logic/connect4.py`. Legacy REST API endpoints exist at
 `/api/game/connect4/start`, `/api/game/connect4/move`, `/api/game/connect4/ai-first`,
-`/api/game/connect4/session/{id}`. The backend also supports an AI-first-move endpoint. The React page at
-`src/frontend/src/pages/games/Connect4Page.tsx` is currently a stub. This spec supersedes the Connect 4
-section of the react-migration Phase 3 spec.
+`/api/game/connect4/session/{id}`. These legacy endpoints are retired by this spec. The React page at
+`src/frontend/src/pages/games/Connect4Page.tsx` is currently a stub. The game-data-persistence feature is
+complete and integrated. This spec supersedes the Connect 4 section of the react-migration Phase 3 spec and
+resolves all open questions from the previous version of this spec.
 
-## Known Requirements
+## Resolved Design Decisions
 
-- **Mobile + desktop responsive**: 7-column grid must render without horizontal overflow on small screens;
-  column drop targets must be large enough to tap; game board is the primary focus above the fold on mobile
-- Connect to existing backend REST API for game start, AI-first-move, and player moves
-- Move transport (REST vs. WebSocket) is an open question pending the websocket feature spec — see
-  `features/websocket/`
-- When the game-data-persistence feature is complete, session data capture must be integrated
-- **Frontend move validation**: the React client validates moves in real time (e.g., column full check) —
-  UX layer only, not a security boundary
-- **Backend move validation (player)**: backend re-validates every player move server-side as redundancy
-  against frontend manipulation
-- **Backend move validation (AI)**: backend validates every AI-generated move; if invalid, retries until a
-  valid move is produced (configurable retry limit); client always receives a guaranteed-valid AI move
+All decisions from `features/game-tic-tac-toe/spec.md` apply unless overridden here:
 
-## Open Questions
+- **Auth required**: No unauthenticated gameplay. Game pages display a login prompt blocking the game UI.
+  Any API call without a valid session returns 401; the client surfaces an `AuthModal`, no silent retry.
+- **Transport**: Server-Sent Events for all server→client push. Client POSTs moves (202 Accepted, no state
+  in response); state updates arrive over SSE.
+- **One session per user per game**: Enforced by DB partial unique index. Starting a new game explicitly
+  closes any existing active session before creating a new one.
+- **No AI difficulty selection**: The difficulty parameter is not exposed to the user. The AI internally
+  uses the existing medium-level heuristic (win/block/center/random). The `games` table `difficulty`
+  column remains game-level metadata only.
+- **Turn order**: Player selects Red (go first) or Yellow (go second) before the game starts. Internally
+  stored and passed as `player_starts: bool`. If `player_starts` is false, the AI (Red) takes the first
+  move before `/newgame` returns.
+- **Color assignment**: `player_starts=true` → player is Red, AI is Yellow. `player_starts=false` →
+  player is Yellow, AI is Red. The client derives display colors from `player_starts` in the state; the
+  board stores `"player"` and `"ai"` as piece values.
+- **Session ID ownership**: Client never stores `session_id` across page loads. Received from `/resume` or
+  `/newgame`, used only to subscribe to SSE. Move requests carry no `session_id`.
+- **Column selection**: The entire column is the clickable/tappable target. On hover or touch, the active
+  column highlights and an arrow indicator appears above it. No separate drop-zone row needed.
+- **Drop animation**: When a move event arrives (player or AI), the piece animates falling from the top of
+  the column to its landing row (~200ms CSS transition). The board is locked during the animation.
+- **Win highlight**: On terminal win, the 4 winning cells pulse with an outline or brightness increase; all
+  other pieces dim to 40% opacity. On draw, no highlight.
+- **Legacy endpoints retired**: `/api/game/connect4/start`, `/api/game/connect4/ai-first`,
+  `/api/game/connect4/session/{id}`, and the generic `/api/game/connect4/move` (non-SSE) are removed.
 
-### Gameplay
-- Should unauthenticated users be able to play, or is login required?
-- Player color selection (red vs. yellow / first vs. second)?
-- The backend supports an `ai-first` endpoint — how is this exposed in the UI? (Toggle before starting?)
-- What difficulty levels are surfaced to the user?
-- Session recovery on page refresh?
+## Architecture
 
-### UI / UX
-- Column selection method on mobile: tap the column, or tap a drop zone above the board?
-- AI "thinking" indicator between moves?
-- Win detection highlight: animate the winning four pieces?
-- Restart without navigating away?
+### New: Connect4Engine (`game_engine/connect4_engine.py`)
 
-### Stats & Persistence
-- Win/loss/draw stats on the game page? (Depends on game-data-persistence feature)
+Replaces the legacy `Connect4Game` class for all SSE-based game flow. Implements the `GameEngine` ABC
+from `game_engine/base.py`.
+
+```
+validate_move(state, move: {"col": int}) → bool
+    - col in range [0, 6]
+    - state["game_active"] is True
+    - state["current_turn"] == "player"
+    - column not full (state["board"][0][col] is None)
+
+apply_move(state, move: {"col": int}) → GameState
+    - Drops piece for state["current_turn"] into the lowest empty row of col
+    - Sets state["last_move"] = {"row": row, "col": col, "player": current_turn}
+    - Toggles state["current_turn"]
+    - Does NOT process the opponent's response (MoveProcessor handles sequencing)
+
+is_terminal(state) → tuple[bool, outcome | None]
+    - outcome: "player_won" | "ai_won" | "draw" | None
+    - Uses state["last_move"] to anchor win detection (same direction-scan as _check_winner)
+    - Draw: board full (move_count == 42) and no winner
+
+get_legal_moves(state) → list[{"col": int}]
+    - Returns all columns where state["board"][0][col] is None
+
+get_winning_cells(state) → list[tuple[int, int]] | None
+    - Called after is_terminal returns a win (not draw, not None)
+    - Returns the 4 [row, col] pairs of the winning line
+    - Anchored on state["last_move"]; returns None if no win present
+
+initial_state(player_starts: bool) → GameState
+```
+
+**GameState shape:**
+```json
+{
+  "board": [[null, ...], ...],
+  "current_turn": "player" | "ai",
+  "game_active": true,
+  "move_count": 0,
+  "player_starts": true,
+  "last_move": null
+}
+```
+Board is a 6-row × 7-col 2D array. Each cell: `null | "player" | "ai"`.
+
+### Connect4AIStrategy (`game_engine/connect4_engine.py`)
+
+Implements `AIStrategy`. Wraps the win/block/center/random heuristic from the existing
+`Connect4Game._get_ai_move`. Returns `({"col": int}, None)` — this heuristic has no eval score.
+
+### Shared Infrastructure (unchanged)
+
+`MoveProcessor`, `StatusBroadcaster`, and `GameEngine`/`AIStrategy` ABCs from `game_engine/base.py` are
+reused without modification.
+
+### Legacy Generic Endpoints
+
+`games.py` contains generic `POST /game/{game_id}/start` and `POST /game/{game_id}/move` endpoints that
+use the old bundled `apply_move` architecture (player + AI in one call). These must return `501` for
+`connect4` during implementation to prevent stale code paths from the pre-SSE architecture.
+
+### SSE Event Schema
+
+Status and heartbeat events are identical to TTT. Move events are Connect4-specific:
+
+```json
+{"type": "status", "message": "Thinking..."}
+
+{"type": "move", "data": {
+  "col": 3,
+  "row": 4,
+  "player": "player",
+  "board": [[null, ...], ...],
+  "player_starts": true,
+  "current_turn": "ai",
+  "status": "in_progress",
+  "winner": null,
+  "winning_cells": null
+}}
+
+{"type": "move", "data": {
+  "col": 3,
+  "row": 2,
+  "player": "ai",
+  "board": [[null, ...], ...],
+  "player_starts": true,
+  "current_turn": null,
+  "status": "complete",
+  "winner": "ai",
+  "winning_cells": [[2, 3], [3, 3], [4, 3], [5, 3]]
+}}
+
+{"type": "heartbeat"}
+
+{"type": "error", "code": "invalid_move", "message": "..."}
+```
+
+`winning_cells` is a list of `[row, col]` pairs (always exactly 4) for a win, `null` for draw or
+in-progress. `winner` values: `"player" | "ai" | "draw" | null`.
+
+### Status Copy
+
+Identical to TTT:
+
+| Condition | Message |
+|---|---|
+| AI begins processing | `"Thinking..."` |
+| 2.5s pass, AI still running | random: `["Hmm...", "Considering the board...", "Plotting a move...", "Analyzing..."]` |
+| 5s+ elapsed | random: `["Taking a moment...", "Almost there..."]` |
+| AI move ready | `move` event (closes the turn) |
+
+## API Endpoints
+
+All endpoints require authentication. 401 for any unauthenticated request.
+
+### `GET /api/game/connect4/resume`
+
+Called on every page load. Returns the active session if one exists.
+
+**Response 200 — active session:**
+```json
+{"session_id": "uuid", "state": { ...game state... }}
+```
+
+**Response 200 — no active session:**
+```json
+{"session_id": null, "state": null}
+```
+
+### `POST /api/game/connect4/newgame`
+
+Closes any existing active session, creates a new one. If `player_starts` is false, the AI takes the
+first move (as Red) before the response is returned.
+
+**Request:**
+```json
+{"player_starts": true}
+```
+
+**Response 200:**
+```json
+{"session_id": "uuid", "state": { ...initial game state... }}
+```
+
+### `POST /api/game/connect4/move`
+
+Submits the player's column choice. Active session derived server-side.
+
+**Request:**
+```json
+{"col": 3}
+```
+
+**Response 202:** Empty body. State update delivered via SSE.
+
+**Response 422:** Invalid move (col out of range, column full, not player's turn, game already over).
+
+**Response 409:** No active session.
+
+### `GET /api/game/connect4/events/{session_id}`
+
+Persistent SSE stream. Authenticated user must own the session.
+
+**Response:** `text/event-stream`
+
+Cloud Run request timeout already raised to 3600s (from TTT). Heartbeat every 30s.
+
+## Session Lifecycle and Timeout
+
+Identical to TTT. Session timeout: 24 hours (same `session_timeout_hours` column on the `games` table
+row for connect4). Cleanup via the existing `POST /internal/cleanup-sessions` endpoint.
+
+## Observability
+
+Follows the conventions in `features/observability/spec.md`.
+
+**`games.py` (request layer):**
+- `POST /newgame`, `POST /move`, `GET /resume`, `GET /events/{session_id}`: set `game.id` and
+  `game.session_id` as attributes on the auto-instrumented HTTP span via `span.set_attribute`.
+- No new spans at this layer.
+
+**`games.py` — AI move processing:**
+- Child span `game.ai.move` on the SSE handler. Attributes: `game.id`, `compute_duration_ms`,
+  `ai_invalid_move_count`.
+
+**`persistence_service.py`:**
+- Existing child spans for `record_move` and `end_session` already cover DB writes. No changes required.
+
+**SSE connection lifecycle:**
+- SSE open: `span.set_attribute("game.id", ...), span.set_attribute("game.session_id", ...)`
+- SSE close (normal): `logger.info("c4_sse_closed", extra={"session_id": session_id})`
+- SSE close (error / unexpected): `logger.exception("c4_sse_error", extra={"session_id": session_id})` +
+  `span.record_exception(e)` + `span.set_status(ERROR)`
+
+**Invalid move logging:**
+- `POST /move` returning 422: `logger.warning("c4_invalid_move", extra={"session_id": session_id, "move": move})`
+
+**No instrumentation inside `game_engine/` files.** All manual instrumentation lives at the router and
+persistence layers only.
+
+## Client Behavior
+
+### Page Load and Resume
+
+Identical phase model as TTT: `loading → newgame → resumeprompt → playing → terminal`.
+
+localStorage key: `c4_game_hint` (same shape and TTL as `ttt_game_hint`).
+
+### Turn Order Selection
+
+Overlay in `newgame` phase. Two buttons:
+- "Play as Red — Go First"
+- "Play as Yellow — Go Second"
+
+Submitting triggers `POST /newgame` with `player_starts: true/false`. Board renders immediately in
+`playing` phase (empty, locked). When going second, the AI (Red) computes its first move server-side
+before `/newgame` returns; the board updates with that move and the drop animation plays on arrival.
+
+### Move Submission and Loading State
+
+1. Column tap → client validates locally (column not full, game active, player's turn) — UX only.
+2. If valid: column highlight persists, board locks.
+3. `POST /move` fires. On 202: SSE events drive status display.
+4. SSE `status` events update the AI `PlayerCard` status text.
+5. SSE `move` event for player's piece: drop animation plays, board updates.
+6. SSE `move` event for AI's piece (same event or subsequent): drop animation plays, locks release if
+   game continues.
+
+Note: The player move and AI move each emit a separate `move` SSE event so the client can animate them
+sequentially. The board locks until both animations complete.
+
+### Column Interaction
+
+- **Hover (desktop)**: column brightens, arrow indicator appears above the topmost empty cell.
+- **Touch (mobile)**: tap commits immediately; no hover state.
+- **Full column**: column header area is grayed and non-interactive; cursor changes to not-allowed.
+- **Board locked**: no column interaction during AI turn or animation.
+
+### Drop Animation
+
+On receiving a `move` event, the piece renders at `row=0` and transitions to the landing `row` using a
+CSS transform (`translateY`) over ~200ms with `ease-in` timing (heavier piece feel). The board locks
+for the duration. If two sequential moves arrive (player then AI), animations play back-to-back.
+
+### Outcome
+
+Same as TTT: result displayed inside `PlayerCard` components (win/loss/draw badge). "New Game" button
+below the player card enters `newgame` phase.
+
+On win: `winning_cells` from the terminal move event drives the highlight. 4 cells get a pulsing ring or
+brightness boost; all others dim to 40% opacity.
+
+### SSE Reconnect and Error Path
+
+Identical to TTT: `EventSource` reconnects automatically, calls `/resume`, re-renders board state.
+401 from any game API → clear local game state, display `AuthModal`.
+
+## UI / Layout
+
+Layout (top to bottom): AI `PlayerCard` → board (with overlay) → player `PlayerCard` → "New Game"
+button.
+
+`PlayerCard` reused from TTT. AI card shows disc color badge (Red or Yellow) instead of X/O symbol;
+Player card shows the player's disc color.
+
+- **Board**: 6 rows × 7 cols grid. Each cell is a circle (disc slot). Empty slots are a muted ring.
+  Filled slots are solid Red (`player` or `ai` depending on `player_starts`) or Yellow.
+- **Column headers**: invisible tap targets spanning the full column height. On hover, the column
+  background lightens and an arrow appears above the topmost empty cell.
+- **Board overlays**: same `loading`, `resumeprompt`, `newgame` overlays as TTT (same positioning,
+  backdrop blur).
+- **Mobile (< 640px)**: board fills viewport width; each cell at minimum 40px for comfortable tap;
+  no horizontal scroll; cards and controls stack above/below.
+- **Desktop**: max-width `lg` container centred; same vertical stack.
+
+## Data Persistence
+
+Every valid move (player and AI) recorded via `persistence_service.record_move()`. The `player`
+argument must be `"human"` for player moves and `"ai"` for AI moves — consistent with TTT and the
+existing DB data. `engine_eval` is stored as `null` (the existing heuristic does not produce a
+normalized score). Terminal state triggers `persistence_service.end_game_session()`.
 
 ## Test Cases
 
-_To be defined during planning session._
+### Unit
+
+| Test name | Scenario |
+|---|---|
+| `test_c4_engine_validate_move_out_of_range` | validate_move returns false for col < 0 or > 6 |
+| `test_c4_engine_validate_move_full_column` | validate_move returns false when column is full |
+| `test_c4_engine_validate_move_wrong_turn` | validate_move returns false when it's AI's turn |
+| `test_c4_engine_apply_move_lands_at_bottom` | piece lands in lowest empty row of column |
+| `test_c4_engine_apply_move_stacks_pieces` | second piece in column lands above first |
+| `test_c4_engine_apply_move_sets_last_move` | apply_move sets last_move in state |
+| `test_c4_engine_apply_move_toggles_turn` | current_turn alternates after apply_move |
+| `test_c4_engine_is_terminal_horizontal_win` | detects horizontal four-in-a-row |
+| `test_c4_engine_is_terminal_vertical_win` | detects vertical four-in-a-row |
+| `test_c4_engine_is_terminal_diagonal_win` | detects both diagonal directions |
+| `test_c4_engine_is_terminal_draw` | full board with no winner returns draw |
+| `test_c4_engine_is_terminal_in_progress` | non-terminal state returns (False, None) |
+| `test_c4_engine_get_legal_moves_excludes_full_columns` | only non-full columns returned |
+| `test_c4_engine_get_legal_moves_empty_board` | all 7 columns returned on empty board |
+| `test_c4_engine_get_winning_cells_returns_four` | winning cells are exactly 4 for any win direction |
+| `test_c4_engine_get_winning_cells_none_when_no_win` | returns None for non-terminal or draw state |
+| `test_c4_ai_strategy_returns_valid_col` | AIStrategy.generate_move returns col within [0, 6] |
+| `test_c4_ai_strategy_wins_if_available` | AI takes winning column if one exists |
+| `test_c4_ai_strategy_blocks_player_win` | AI blocks player's winning column |
+| `test_move_processor_ai_invalid_move_retries` | reused from TTT (no new test needed) |
+| `test_move_processor_ai_fallback_after_max_retries` | reused from TTT (no new test needed) |
+
+### API Integration
+
+| Test name | Scenario |
+|---|---|
+| `test_c4_resume_no_active_session` | GET /resume returns {session_id: null, state: null} |
+| `test_c4_resume_active_session_returns_state` | GET /resume returns current board state |
+| `test_c4_resume_unauthenticated_returns_401` | GET /resume without auth |
+| `test_c4_newgame_player_first` | POST /newgame player_starts=true → empty board, player's turn |
+| `test_c4_newgame_ai_first` | POST /newgame player_starts=false → state reflects AI's first move (Red) |
+| `test_c4_newgame_closes_existing_session` | POST /newgame closes old active session, creates new |
+| `test_c4_move_returns_202` | POST /move returns 202, no state body |
+| `test_c4_move_col_out_of_range_returns_422` | POST /move col < 0 or > 6 |
+| `test_c4_move_full_column_returns_422` | POST /move to a column with no empty rows |
+| `test_c4_move_no_active_session_returns_409` | POST /move with no session |
+| `test_c4_move_unauthenticated_returns_401` | POST /move without auth |
+| `test_c4_sse_delivers_status_then_move` | SSE delivers status event(s) then move event in order |
+| `test_c4_sse_move_includes_winning_cells` | terminal win event includes exactly 4 winning_cells |
+| `test_c4_sse_draw_has_null_winning_cells` | terminal draw event has winning_cells: null |
+| `test_c4_sse_heartbeat_within_interval` | SSE sends heartbeat within 35s of idle |
+| `test_c4_sse_unauthorized_session_returns_403` | GET /events/{id} for another user's session |
+| `test_c4_sse_stream_closes_on_terminal_state` | SSE stream closes after game-over move event |
+| `test_c4_sse_move_triggers_record_move` | SSE move event results in DB record_move call |
+| `test_c4_cleanup_marks_stale_sessions_abandoned` | reuses shared cleanup mechanism |
+
+### E2E
+
+| Test name | Scenario |
+|---|---|
+| `test_c4_full_game_player_wins` | Player drops pieces to win; winning cells highlight, win badge appears |
+| `test_c4_full_game_ai_wins` | AI wins; losing cells dim, AI win badge appears |
+| `test_c4_full_game_draw` | Board fills with no winner; draw badge appears, no cells highlighted |
+| `test_c4_resume_prompt_shown_for_in_progress_session` | resumeprompt overlay renders over dimmed board |
+| `test_c4_resume_prompt_continue_starts_sse` | clicking Continue subscribes to SSE and enters playing |
+| `test_c4_resume_prompt_new_game_shows_side_selector` | clicking New Game shows Red/Yellow overlay |
+| `test_c4_go_second_board_renders_before_api_returns` | board renders empty+locked immediately when going second |
+| `test_c4_go_second_ai_first_move_visible` | after newgame returns, AI's Red piece is shown in column |
+| `test_c4_result_shown_in_player_cards` | win/loss/draw badge in both PlayerCards, not as standalone alert |
+| `test_c4_new_game_abandons_in_progress_session` | "New Game" closes old session, starts fresh |
+| `test_c4_unauthenticated_user_sees_login_prompt` | Auth gate shows centred sign-in card |
+| `test_c4_resume_after_page_refresh` | Mid-game refresh restores board state |
+| `test_c4_401_shows_auth_modal` | 401 from any game API triggers AuthModal |
+| `test_c4_mobile_viewport_playable` | Board fully playable at 375px wide, no horizontal scroll |
+| `test_c4_sse_reconnect_restores_state` | SSE disconnect + reconnect shows correct board |
+| `test_c4_column_full_is_non_interactive` | Full column shows not-allowed cursor, tap is ignored |
+| `test_c4_board_locked_during_ai_turn` | Columns non-interactive while AI is thinking |
+
+### Manual
+
+| Scenario |
+|---|
+| Drop animation plays smoothly at ~200ms; piece appears to fall with gravity (ease-in) |
+| Sequential player + AI animations play back-to-back without flicker |
+| Column hover highlights correctly and arrow points above topmost empty cell |
+| Column full state is visually obvious (dimmed header, no hover response) |
+| Winning cells pulse clearly; non-winning pieces dim noticeably |
+| Status text ("Thinking...") appears inside the AI PlayerCard during AI turn |
+| Board tap targets are comfortable on a physical mobile device (40px+ cells) |
+| Landscape orientation on mobile renders without layout breakage or overflow |
+| SSE reconnects and restores board correctly after simulated network drop |
+| Resume prompt shows correct board state (dimmed) when returning to an in-progress game |
+| Red and Yellow disc colors are visually distinct and accessible (sufficient contrast) |

--- a/features/game-dots-and-boxes/spec.md
+++ b/features/game-dots-and-boxes/spec.md
@@ -4,46 +4,589 @@
 
 ## Background
 
-Backend game logic is fully implemented in `src/backend/game_logic/dots_and_boxes.py`. REST API exists at
-`/api/game/dots-and-boxes/start` and `/api/game/dots-and-boxes/move`. The React page at
-`src/frontend/src/pages/games/DotsAndBoxesPage.tsx` is currently a stub. This spec supersedes the Dots and
-Boxes section of the react-migration Phase 3 spec.
+Backend game logic is fully implemented in `src/backend/game_logic/dots_and_boxes.py`. Legacy REST API
+routes exist at `/api/game/dots-and-boxes/start` and `/api/game/dots-and-boxes/move`; these are retired by
+this spec and replaced with SSE-based endpoints matching the TTT architecture. The React page at
+`src/frontend/src/pages/games/DotsAndBoxesPage.tsx` is currently a stub. The game-data-persistence feature
+is complete and integrated. This spec supersedes the Dots and Boxes section of the react-migration Phase 3
+spec and resolves the transport open question in `features/websocket/spec.md` for turn-based games: SSE,
+not WebSocket.
 
-## Known Requirements
+## Resolved Design Decisions
 
-- **Mobile + desktop responsive**: line segments between dots must have tap targets large enough for mobile use;
-  game board is the primary focus above the fold; claimed box scores and turn indicator stack below on small
-  viewports
-- Connect to existing backend REST API for game start and moves
-- Move transport (REST vs. WebSocket) is an open question pending the websocket feature spec — see
-  `features/websocket/`
-- When the game-data-persistence feature is complete, session data capture must be integrated
-- **Frontend move validation**: the React client validates moves in real time (e.g., line already drawn) —
-  UX layer only, not a security boundary
-- **Backend move validation (player)**: backend re-validates every player move server-side as redundancy
-  against frontend manipulation
-- **Backend move validation (AI)**: backend validates every AI-generated move; if invalid, retries until a
-  valid move is produced (configurable retry limit); client always receives a guaranteed-valid AI move
+- **Auth required**: No unauthenticated gameplay. Game pages display a login prompt blocking the game UI for
+  unauthenticated users. Any API call without a valid session returns 401; the client surfaces an
+  `AuthModal`, no silent retry.
+- **Transport**: Server-Sent Events for all server→client push. Client POSTs moves (202 Accepted, no state
+  in response); state updates arrive over SSE.
+- **One session per user per game**: Enforced by existing DB partial unique index. Starting a new game
+  explicitly closes any existing active session before creating a new one.
+- **No AI difficulty selection**: The difficulty parameter is removed from the user-facing API. The `games`
+  table retains its `difficulty` column as game-level metadata. This is unrelated to AI difficulty and must
+  not be conflated.
+- **Grid size**: Fixed at 4×4 (16 boxes, 40 lines). No user-selectable size.
+- **Turn order**: Player selects whether to go first or second before the game starts. Internally stored and
+  passed as `player_starts: bool`. If `player_starts` is false, the AI takes the first move before
+  `/newgame` returns.
+- **Session ID ownership**: The client never stores `session_id` across page loads. It is received from
+  `/resume` or `/newgame` and used only to subscribe to the SSE stream. Move requests carry no `session_id`;
+  the server derives the active session from the authenticated user + game type.
+- **Rendering**: SVG. Dots are SVG circles; lines are SVG line elements; box fills are SVG rect elements
+  rendered behind lines.
+- **Interaction model**: Tap a line segment to draw it. Each undrawn line segment has a transparent SVG
+  hit-target overlay (minimum 24px touch target). Desktop shows hover highlight on undrawn segments.
+- **Score display**: Running score shown throughout the game in the PlayerCard components. Not deferred to
+  end.
+- **Extra-turn mechanic**: When a player (or AI) draws the line that completes one or more boxes, they score
+  those boxes and take another turn immediately. Turn does not toggle in that case.
+- **Legacy endpoints retired**: `/api/game/dots-and-boxes/start` and the old
+  `/api/game/dots-and-boxes/move` (non-SSE) are removed. Additionally, the generic
+  `POST /game/{game_id}/start` and `POST /game/{game_id}/move` endpoints in `games.py` use the old
+  bundled architecture and must return `501` for `dots-and-boxes` to prevent stale code paths.
 
-## Open Questions
+## Architecture
 
-### Gameplay
-- Should unauthenticated users be able to play, or is login required?
-- What grid size(s) are supported? (The backend may have a fixed size — needs verification)
-- What difficulty levels are surfaced to the user?
-- Session recovery on page refresh?
+### Abstractions (shared across all turn-based games)
 
-### UI / UX
-- How are line segments rendered: SVG, canvas, or CSS grid?
-- Mobile interaction model: tap between two dots to draw a line, or tap-and-drag?
-- How are claimed boxes visually distinguished (color, initials, fill)?
-- AI turn indicator / thinking animation?
-- Score display: running total per turn, or only shown at end?
-- Win/loss outcome: modal, inline, or results screen?
+These live in `src/backend/game_engine/base.py` and are implemented per game.
 
-### Stats & Persistence
-- Win/loss/draw stats on the game page? (Depends on game-data-persistence feature)
+**`GameEngine` (abstract base)**
+```
+validate_move(state, move) → bool
+apply_move(state, move) → GameState
+is_terminal(state) → tuple[bool, outcome | None]
+get_legal_moves(state) → list[Move]
+initial_state(player_starts: bool) → GameState
+```
+
+**`AIStrategy` (abstract base)**
+```
+generate_move(state) → tuple[Move, Optional[float]]
+    # Move may be invalid; no guarantee. float is engine_eval or None if strategy has no score.
+```
+
+**`MoveProcessor` (shared, game-agnostic)**
+```
+process_player_move(engine, state, move) → GameState | ValidationError
+process_ai_turn(engine, strategy, state, max_retries=5) → GameState
+```
+`process_ai_turn` loop:
+1. `move = strategy.generate_move(state)`
+2. If `engine.validate_move(state, move)`: break
+3. `log.warning("ai_invalid_move", attempt=n)` + OTel attribute `ai_invalid_move_count`
+4. After `max_retries` exhausted: `move = random.choice(engine.get_legal_moves(state))` (guaranteed valid)
+
+**`StatusBroadcaster` (shared)**
+```
+emit(event: StatusEvent) → None     # called by game processor at full speed; non-blocking
+stream() → AsyncGenerator[StatusEvent]  # drives the SSE endpoint; enforces min_interval
+```
+- `min_interval`: 2.5 seconds between sends to client
+- First status held for ~0.5s (prevents flash for near-instant AI responses)
+- Heartbeat event every 30s (client ignores; keeps stream alive through proxies)
+- Terminal event closes the stream
+
+### DaBEngine
+
+Lives in `src/backend/game_engine/dab_engine.py`. Implements the `GameEngine` ABC.
+
+**GameState shape:**
+```json
+{
+  "grid_size": 4,
+  "horizontal_lines": {},
+  "vertical_lines": {},
+  "boxes": {},
+  "current_turn": "player" | "ai",
+  "game_active": true,
+  "player_starts": true,
+  "player_score": 0,
+  "ai_score": 0,
+  "move_count": 0,
+  "last_move": null | {
+    "type": "horizontal" | "vertical",
+    "row": 0,
+    "col": 0,
+    "boxes_completed": 0,
+    "newly_claimed_boxes": [{"row": 0, "col": 0}]
+  }
+}
+```
+
+Lines are stored as dicts keyed by `"row,col"` → owner string (`"player"` or `"ai"`). Boxes are stored
+the same way.
+
+**Grid geometry (grid_size=4):**
+- 5×5 dots (rows and cols 0–4)
+- Horizontal lines: row ∈ [0,4], col ∈ [0,3] → 20 horizontal lines
+- Vertical lines: row ∈ [0,3], col ∈ [0,4] → 20 vertical lines
+- 40 total lines, 16 boxes
+- Box `(row, col)` top-left corner: row, col ∈ [0,3]. Complete when
+  `horizontal(row,col)`, `horizontal(row+1,col)`, `vertical(row,col)`, `vertical(row,col+1)` are all drawn.
+
+**`DaBEngine.apply_move` behavior:**
+- Draws exactly one line (does NOT process the opponent or loop on extra turns).
+- Claims any newly completed boxes for the mover.
+- Sets `last_move` with `boxes_completed` and `newly_claimed_boxes`.
+- If `boxes_completed > 0`: `current_turn` stays the same player (extra turn).
+- If `boxes_completed == 0`: `current_turn` toggles to the opponent.
+- Updates `player_score` and `ai_score`.
+- Sets `game_active = False` and `move_count` accordingly.
+
+**`DaBEngine.is_terminal`:** Returns `True` when `player_score + ai_score == 16` (all boxes claimed).
+There is no win condition mid-game; outcome is only determined when all boxes are filled.
+
+**`DaBEngine.get_legal_moves`:** Returns all undrawn lines as
+`[{"type": str, "row": int, "col": int}]`.
+
+**`DaBEngine.initial_state`:** grid_size=4 fixed. `current_turn` set from `player_starts` param.
+
+**`DaBEngine.get_winner(state)`:** Returns `"player"` | `"ai"` | `"draw"` based on scores. Only valid when
+`is_terminal` is True.
+
+**`validate_move(state, move)`:**
+- `move["type"]` is `"horizontal"` or `"vertical"`.
+- For horizontal: `row ∈ [0,4]`, `col ∈ [0,3]`; key not already in `horizontal_lines`.
+- For vertical: `row ∈ [0,3]`, `col ∈ [0,4]`; key not already in `vertical_lines`.
+- `state["current_turn"] == "player"` (server only accepts player moves via POST /move).
+- `state["game_active"]` is True.
+
+### DaBStrategy
+
+Lives in `src/backend/game_engine/dab_engine.py`. Implements `AIStrategy`. Wraps the existing
+`_get_ai_move` heuristic from `DotsAndBoxes`. Returns `({"type": str, "row": int, "col": int}, None)` — this heuristic has no eval score.
+
+Heuristic priority:
+1. Take any move that completes a box.
+2. Take a "safe" move (does not give the opponent a box — no box with 2 sides becomes 3-sided).
+3. Random legal move.
+
+### SSE Event Schema
+
+```json
+{"type": "status", "message": "Thinking..."}
+
+{"type": "move", "data": {
+  "line_type": "horizontal",
+  "row": 1,
+  "col": 2,
+  "player": "player",
+  "boxes_completed": 1,
+  "newly_claimed_boxes": [{"row": 1, "col": 2}],
+  "horizontal_lines": {"1,2": "player"},
+  "vertical_lines": {},
+  "boxes": {"1,2": "player"},
+  "player_starts": true,
+  "current_turn": "player",
+  "player_score": 2,
+  "ai_score": 1,
+  "status": "in_progress",
+  "winner": null
+}}
+
+{"type": "move", "data": {
+  "status": "complete",
+  "winner": "ai",
+  "player_score": 7,
+  "ai_score": 9,
+  "current_turn": null
+}}
+
+{"type": "heartbeat"}
+
+{"type": "error", "code": "invalid_move", "message": "..."}
+```
+
+The `player` field in move events is `"player"` or `"ai"`. State uses `"player"`/`"ai"` throughout, not
+`"X"`/`"O"`. The client maps to display colors.
+
+### Status Copy
+
+Dots and Boxes does not use `StatusBroadcaster`. The AI heuristic is near-instant and the chain
+animation is the primary UX feedback. A single `"Thinking..."` status event is yielded directly before
+the first AI move in a turn sequence; consecutive chain moves emit no status.
+
+| Condition | Message |
+|---|---|
+| AI turn begins | `"Thinking..."` (direct yield, no rate-limiting) |
+| AI move ready (first and subsequent chain moves) | `move` event (direct yield, 500ms between each) |
+
+`StatusBroadcaster` is **not instantiated** for Dots and Boxes — the SSE handler yields all events
+directly.
+
+### Extra-Turn Loop in SSE Handler
+
+After any move event is emitted, the handler checks the resulting state:
+
+**Player extra turn:** If the move event has `current_turn == "player"` and `status == "in_progress"`,
+the SSE handler does nothing further — the board unlocks and waits for the next player POST.
+
+**AI extra-turn chain:** After an AI move is applied and emitted, if `current_turn == "ai"` and not
+terminal, the handler immediately applies the next AI move, waits 500ms, then emits another move event.
+This loop continues until `current_turn != "ai"` or the game is terminal. Each AI move in the chain is
+a separate SSE move event. The 500ms delay allows the player to observe each line being drawn.
+
+Pseudocode for the SSE handler's AI processing loop:
+
+**Important:** `StatusBroadcaster` enforces a 2.5s `MIN_INTERVAL` on all events, including move events.
+Routing AI chain moves through the broadcaster would space them 2.5s apart — far too slow for a
+box-completing chain. Instead, chain move events are yielded **directly** to the SSE stream (bypassing
+`StatusBroadcaster`) with a 500ms sleep between consecutive moves. `StatusBroadcaster` is not used for
+Dots and Boxes at all; the SSE handler yields events directly.
+
+```
+# start of player-triggered AI turn
+yield status_sse("Thinking...")       # simple direct yield, no broadcaster
+await asyncio.sleep(0.5)              # brief pause before first AI move
+
+while current_turn == "ai" and not terminal:
+    move, _ = strategy.generate_move(state)
+    state = engine.apply_move(state, move)
+    persist move
+    terminal, outcome = engine.is_terminal(state)
+    yield move_event_sse_directly
+    if current_turn == "ai" and not terminal:
+        await asyncio.sleep(0.5)      # 500ms between chain moves
+
+if terminal:
+    persist end_session
+    return  # stream generator ends naturally
+```
+
+## API Endpoints
+
+All endpoints require authentication. 401 is returned for any unauthenticated request.
+
+### `GET /api/game/dots-and-boxes/resume`
+
+Always called on page load, regardless of how the user arrived. Returns the active session for the
+authenticated user if one exists.
+
+**Response 200 — active session:**
+```json
+{"session_id": "uuid", "state": { ...game state... }}
+```
+
+**Response 200 — no active session:**
+```json
+{"session_id": null, "state": null}
+```
+The client handles the null case by rendering the "New Game" UI. There is no 404 for this path — a missing
+session is a normal state, not an error.
+
+### `POST /api/game/dots-and-boxes/newgame`
+
+Called only when the player explicitly chooses to start a new game. Closes any existing active session for
+this user + game type, then creates a new one. If `player_starts` is false, the AI takes the first move
+before the response is returned (the initial state reflects this first move).
+
+**Request:**
+```json
+{"player_starts": true}
+```
+
+**Response 200:**
+```json
+{"session_id": "uuid", "state": { ...initial game state... }}
+```
+
+### `POST /api/game/dots-and-boxes/move`
+
+Submits the player's move. Active session is derived server-side from the authenticated user + game type.
+No `session_id` in request.
+
+**Request:**
+```json
+{"type": "horizontal", "row": 1, "col": 2}
+```
+
+**Response 202:** Empty body. State update delivered via SSE.
+
+**Response 422:** Invalid move (line already drawn, out of bounds, not player's turn, game already over).
+
+**Response 409:** No active session.
+
+### `GET /api/game/dots-and-boxes/events/{session_id}`
+
+Persistent SSE stream. Authenticated user must own the session.
+
+**Response:** `text/event-stream`
+
+Cloud Run request timeout must be raised to 3600s. Heartbeat events every 30s prevent intermediate proxy
+timeouts.
+
+## Session Lifecycle and Timeout
+
+A session remains active indefinitely as long as the player reconnects and resumes — there is no hard expiry
+on active sessions from the player's perspective. Sessions abandoned without explicit closure must eventually
+be cleaned up.
+
+**Timeout configuration**: The `games` DB table has a `session_timeout_hours` column (integer, not null).
+Dots and Boxes timeout: 24 hours. This value is the maximum idle time (measured from `last_move_at`) before
+a session is marked abandoned.
+
+**Cleanup mechanism**: A GCP Cloud Scheduler job fires periodically (e.g., every hour) and calls an
+internal, non-public endpoint (`POST /internal/cleanup-sessions`). This endpoint queries all `in_progress`
+sessions where `last_move_at < now() - session_timeout_hours` and marks them abandoned via
+`end_game_session()`. The endpoint requires an internal-only auth header (not the user session cookie).
+
+Sessions closed this way emit the `game.sessions.completed` metric with outcome `abandoned`, consistent
+with the observability spec.
+
+## Observability
+
+Follows the conventions in `features/observability/spec.md`.
+
+**`games.py` (request layer):**
+- `POST /newgame`, `POST /move`, `GET /resume`, `GET /events/{session_id}`: set `game.id` and
+  `game.session_id` as attributes on the auto-instrumented HTTP span via `span.set_attribute`.
+- No new spans at this layer.
+
+**`games.py` — AI move processing:**
+- Child span `game.ai.move` on the SSE handler. Attributes: `game.id`, `compute_duration_ms`,
+  `ai_invalid_move_count`.
+- For AI extra-turn chains, each AI move within the chain records its own `game.ai.move` span.
+
+**`persistence_service.py`:**
+- Existing child spans for `record_move` and `end_session` already cover DB writes. No changes required.
+
+**SSE connection lifecycle:**
+- SSE open: `span.set_attribute("game.id", ...), span.set_attribute("game.session_id", ...)`
+- SSE close (normal): `logger.info("dab_sse_closed", extra={"session_id": session_id})`
+- SSE close (error / unexpected): `logger.exception("dab_sse_error", extra={"session_id": session_id})` +
+  `span.record_exception(e)` + `span.set_status(ERROR)`
+- Per-message spans: not required (too noisy).
+
+**Invalid move logging:**
+- `POST /move` returning 422: `logger.warning("dab_invalid_move", extra={"session_id": session_id, "move": move})`
+
+**No instrumentation inside `game_engine/` files.** All manual instrumentation lives at the router and
+persistence layers only.
+
+## Client Behavior
+
+### Page Load and Resume
+
+The client uses five phases: `loading`, `newgame`, `resumeprompt`, `playing`, `terminal`.
+
+1. Check `localStorage` for key `dab_game_hint`. If present and `expires` is in the future, enter `loading`
+   phase (spinner overlay on board) while `/resume` is in flight. Otherwise enter `newgame` immediately.
+2. On `/resume` response:
+   - Active in-progress session → set board state from response, enter `resumeprompt` phase. SSE is **not**
+     subscribed yet.
+   - Completed session → set board state, enter `terminal` phase directly (no prompt needed).
+   - Null → enter `newgame` phase, clear any stale localStorage hint.
+
+**`dab_game_hint` shape:**
+```json
+{"expires": 1234567890000}
+```
+TTL: 10 minutes. Refreshed on every received SSE `move` event.
+
+Cleared when:
+- Terminal game state received over SSE.
+- Player clicks "New Game" (before `/newgame` is even sent).
+- `beforeunload` fires (handles normal tab/browser close; TTL handles crashes).
+
+### Resume Prompt
+
+When in `resumeprompt` phase, the board renders (dimmed, locked) with a centred overlay:
+
+- **Continue Game** → subscribes to SSE, enters `playing` phase.
+- **New Game** → enters `newgame` phase (overlay changes to turn-order selector; previous board stays
+  visible dimmed underneath).
+
+### Turn Order Selection
+
+Shown as a board overlay in `newgame` phase. Two buttons: **"Go First"** / **"Go Second"**. Submitting
+triggers `POST /newgame` with `player_starts: true/false`.
+
+The board renders immediately in `playing` phase (empty, locked) before the API responds so the layout
+does not shift. When going second (`player_starts=false`), the AI computes its first move server-side
+before `/newgame` returns; the board updates with that move once the response arrives and SSE is
+subscribed.
+
+### Move Submission and Loading State
+
+1. Line segment tap → client validates locally (line not already drawn, game active, player's turn) — UX
+   layer only.
+2. If valid: line visually commits (drawn in player color), board locks.
+3. `POST /move` fires with `{"type": ..., "row": ..., "col": ...}`. On 202: SSE events drive status display.
+4. SSE `status` events update the AI `PlayerCard` status text ("Thinking...", etc.).
+5. SSE `move` event: board updates with AI move(s), locks release if game continues with player's turn.
+
+### Extra-Turn Handling
+
+**Player extra turn:** When the client receives a `move` event with `current_turn == "player"` and
+`status == "in_progress"`, the board unlocks immediately. No prompt is shown; the player simply goes again.
+The score in the player's `PlayerCard` updates to reflect the newly claimed box(es).
+
+**AI extra-turn chain:** When the client receives a `move` event with `player == "ai"` and
+`current_turn == "ai"`, another AI move event is expected imminently (after the server's 500ms delay).
+The board remains locked. Each AI move event draws the new line and updates the score. The sequence ends
+when a move event arrives with `current_turn == "player"` or `status == "complete"`.
+
+### Outcome
+
+Game result is displayed inside the `PlayerCard` components (above and below the board), not as a
+standalone banner. Final scores are shown in each card. A "New Game" button appears below the player card;
+clicking it enters `newgame` phase (overlay on dimmed board).
+
+### SSE Reconnect and Error Path
+
+Browser `EventSource` reconnects automatically on disconnect. On reconnect:
+1. Call `/resume`.
+2. If active session: re-render board from returned state, resubscribe to SSE.
+3. If null session (stream was closed because game ended, or session timed out): render "New Game" UI,
+   clear localStorage hint.
+
+On any 401 from any game API: clear local game state, display `AuthModal`. No silent retry.
+
+## UI / Layout
+
+Layout (top to bottom): AI `PlayerCard` → board (with overlay) → player `PlayerCard` → "New Game" button.
+
+The `PlayerCard` component (`src/frontend/src/components/PlayerCard.tsx`) is used for both participants.
+See `features/player-card/spec.md` for the full component spec.
+
+- AI card (above board): bot icon avatar, "AI Opponent" label, SSE status text during AI turn ("Thinking..."
+  etc.), result badge on terminal state, running score in status area ("Score: 4").
+- Player card (below board): user avatar / initials, display name, result badge on terminal state, running
+  score in status area ("Score: 5").
+
+### SVG Board
+
+The board is a single React SVG component (`DotsAndBoxesBoard.tsx`). At grid_size=4 there are 5×5 dots,
+20 horizontal lines, 20 vertical lines, and 16 box fill areas.
+
+**Dots:** SVG `<circle>` elements at each intersection. Same color for all (e.g., neutral-content).
+
+**Box fills:** SVG `<rect>` elements rendered behind lines. Each box fill covers the interior of one cell.
+Opacity 40%.
+- Player-claimed box: blue fill (`#3B82F6`, 40% opacity).
+- AI-claimed box: red fill (`#EF4444`, 40% opacity).
+- Unclaimed box: no fill.
+
+**Lines (drawn):**
+- Player lines: solid blue (`#3B82F6`).
+- AI lines: solid red (`#EF4444`).
+
+**Lines (undrawn):**
+- Rendered as faint dashed gray to indicate possible moves.
+
+**Hit targets:** Each undrawn line segment has a transparent SVG `<rect>` or `<line>` overlay with a
+minimum 24px touch target dimension so it is easily tappable on mobile. Only undrawn lines are interactive;
+drawn lines have no hit target.
+
+**Hover state (desktop only):** On `mouseenter`, an undrawn line highlights to a more prominent color (e.g.,
+blue-300 for player's turn) to indicate it is interactive. Removed on `mouseleave` or after click.
+
+**Board overlays** (positioned absolute, `inset-0`, `bg-base-100/80 backdrop-blur-sm`):
+- `loading`: centred spinner.
+- `resumeprompt`: "Game in progress" label + Continue / New Game buttons.
+- `newgame`: "Choose your turn:" label + Go First / Go Second buttons.
+
+**Mobile (< 640px):** Board fills viewport width; dots and lines scale to fill the space; hit targets remain
+≥ 24px; cards and controls stack above/below the board; no horizontal scroll.
+
+**Desktop:** max-width `lg` container centred; same vertical stack.
+
+All screen sizes and orientations supported without layout breakage.
+
+## Data Persistence
+
+Every valid move (player and AI) is recorded via `persistence_service.record_move()`. The `player`
+argument must be `"human"` for player moves and `"ai"` for AI moves — consistent with TTT and the
+existing DB data. `engine_eval` is stored as `null` (the heuristic strategy does not produce a numeric
+score). Terminal state triggers `persistence_service.end_game_session()`. No changes to the persistence
+service API are required.
 
 ## Test Cases
 
-_To be defined during planning session._
+### Unit
+
+| Test name | Scenario |
+|---|---|
+| `test_dab_engine_validate_move_line_already_drawn` | validate_move returns False when line key already in lines dict |
+| `test_dab_engine_validate_move_out_of_bounds_horizontal` | validate_move returns False for horizontal row > 4 or col > 3 |
+| `test_dab_engine_validate_move_out_of_bounds_vertical` | validate_move returns False for vertical row > 3 or col > 4 |
+| `test_dab_engine_validate_move_valid_horizontal` | validate_move returns True for valid undrawn horizontal line |
+| `test_dab_engine_validate_move_valid_vertical` | validate_move returns True for valid undrawn vertical line |
+| `test_dab_engine_apply_move_no_box_turn_toggles` | drawing a line that completes no box switches current_turn to opponent |
+| `test_dab_engine_apply_move_one_box_turn_stays` | drawing the completing line of one box keeps current_turn the same |
+| `test_dab_engine_apply_move_two_boxes_one_line` | single line completing two boxes: both claimed, current_turn stays same |
+| `test_dab_engine_apply_move_score_increments` | player_score and ai_score update correctly after box claims |
+| `test_dab_engine_apply_move_last_move_set` | last_move reflects type, row, col, boxes_completed, newly_claimed_boxes |
+| `test_dab_engine_is_terminal_all_boxes_claimed` | is_terminal returns True when player_score + ai_score == 16 |
+| `test_dab_engine_is_terminal_fifteen_boxes` | is_terminal returns False when 15 boxes claimed |
+| `test_dab_engine_get_legal_moves_count_at_start` | get_legal_moves returns 40 moves on empty board |
+| `test_dab_engine_get_legal_moves_decreases_as_lines_drawn` | count decreases by 1 for each line drawn |
+| `test_dab_engine_get_winner_player_more_boxes` | get_winner returns "player" when player_score > ai_score |
+| `test_dab_engine_get_winner_ai_more_boxes` | get_winner returns "ai" when ai_score > player_score |
+| `test_dab_engine_get_winner_equal_boxes_draw` | get_winner returns "draw" when scores are equal |
+| `test_move_processor_ai_invalid_move_retries` | processor retries on invalid AI move, logs warning |
+| `test_move_processor_ai_fallback_after_max_retries` | processor falls back to random valid move |
+| `test_move_processor_player_invalid_move_returns_error` | player validation rejects bad input |
+| `test_status_broadcaster_enforces_min_interval` | broadcaster holds events to min_interval |
+| `test_status_broadcaster_closes_on_terminal_event` | stream terminates after terminal event |
+| `test_status_broadcaster_emits_heartbeat` | heartbeat event emitted at configured interval |
+
+### API Integration
+
+| Test name | Scenario |
+|---|---|
+| `test_dab_resume_no_active_session` | GET /resume returns {session_id: null, state: null} |
+| `test_dab_resume_active_session_returns_state` | GET /resume returns current board state |
+| `test_dab_resume_unauthenticated_returns_401` | GET /resume without auth |
+| `test_dab_newgame_player_first` | POST /newgame player_starts=true → empty board, current_turn="player" |
+| `test_dab_newgame_ai_first` | POST /newgame player_starts=false → state reflects AI's first move before response |
+| `test_dab_newgame_closes_existing_session` | POST /newgame closes old active session, creates new one |
+| `test_dab_move_returns_202` | POST /move returns 202, no state body |
+| `test_dab_move_line_already_drawn_returns_422` | POST /move for a line that is already drawn |
+| `test_dab_move_invalid_type_returns_422` | POST /move with type not "horizontal" or "vertical" |
+| `test_dab_move_out_of_bounds_returns_422` | POST /move with row/col outside valid range |
+| `test_dab_move_no_active_session_returns_409` | POST /move with no active session |
+| `test_dab_move_unauthenticated_returns_401` | POST /move without auth |
+| `test_dab_sse_move_event_has_boxes_completed` | SSE move event includes correct boxes_completed count |
+| `test_dab_sse_move_event_has_newly_claimed_boxes` | SSE move event includes newly_claimed_boxes list |
+| `test_dab_sse_player_completes_box_extra_turn` | After player completes a box, next SSE move event has current_turn="player" |
+| `test_dab_sse_ai_extra_turn_chain` | AI completing boxes produces multiple consecutive AI move events with 500ms spacing |
+| `test_dab_sse_heartbeat_within_interval` | SSE sends heartbeat within 35s of idle |
+| `test_dab_sse_unauthorized_session_returns_403` | GET /events/{id} for another user's session |
+| `test_dab_sse_stream_closes_on_terminal_state` | SSE stream closes after game-over move event |
+
+### E2E
+
+| Test name | Scenario |
+|---|---|
+| `test_dab_full_game_player_wins` | Player claims more boxes; player win result shown in PlayerCards |
+| `test_dab_full_game_ai_wins` | AI claims more boxes; AI win result shown in PlayerCards |
+| `test_dab_full_game_draw` | Both players claim 8 boxes; draw result shown in PlayerCards |
+| `test_dab_player_extra_turn` | Player completes a box; player goes again without an AI move in between |
+| `test_dab_ai_box_completing_chain` | AI completes 3+ boxes consecutively; each move visible with ~500ms delay |
+| `test_dab_resume_prompt_shown_for_in_progress_session` | resumeprompt overlay renders over dimmed board when active session found |
+| `test_dab_resume_prompt_continue_starts_sse` | clicking Continue from resumeprompt subscribes to SSE and enters playing |
+| `test_dab_resume_prompt_new_game_shows_turn_selector` | clicking New Game from resumeprompt shows Go First / Go Second overlay |
+| `test_dab_go_second_ai_moves_before_response` | when going second, AI first move is reflected in initial state |
+| `test_dab_result_shown_in_player_cards` | win/loss/draw badge and final score appear in both PlayerCards |
+| `test_dab_running_score_visible_during_game` | score in PlayerCards updates after each box is claimed |
+| `test_dab_new_game_abandons_in_progress_session` | "New Game" closes old session, starts fresh |
+| `test_dab_unauthenticated_user_sees_login_prompt` | Auth gate shows centred sign-in card |
+| `test_dab_resume_after_page_refresh` | Mid-game refresh restores board state and all drawn lines |
+| `test_dab_401_shows_auth_modal` | 401 from any game API triggers AuthModal |
+| `test_dab_mobile_viewport_playable` | Board fully playable at 375px wide; line tap targets ≥ 24px |
+
+### Manual
+
+| Scenario |
+|---|
+| Line segments are clearly tappable on mobile without mis-tapping adjacent lines |
+| Hover state on desktop highlights the hovered line segment before clicking |
+| Box fill appears immediately on claim (no animation required, but must be instant) |
+| AI box-completing chain has ~500ms delay between each move — pace is readable, not too fast |
+| Score in PlayerCards updates in real time on each box claim |
+| Drawn lines for player vs AI are visually distinct (blue vs red) |
+| Landscape orientation renders without overflow on mobile |
+| Status text ("Thinking...") appears in the AI card, not below the board |
+| Resume prompt shows correct board state (dimmed) when returning to an in-progress game |
+| SSE reconnects and restores board correctly after simulated network drop |

--- a/features/observability/spec.md
+++ b/features/observability/spec.md
@@ -1,6 +1,6 @@
 # Observability Spec (OpenTelemetry)
 
-**Status: done**
+**Status: in-progress**
 
 ## Goal
 
@@ -18,6 +18,7 @@ are separate concerns with separate specs. OTel is not the right tool for either
 | Core SDK | `opentelemetry-sdk` |
 | FastAPI auto-instrumentation | `opentelemetry-instrumentation-fastapi` |
 | SQLAlchemy auto-instrumentation | `opentelemetry-instrumentation-sqlalchemy` |
+| Log trace injection | `opentelemetry-instrumentation-logging` |
 | GCP trace exporter | `opentelemetry-exporter-gcp-trace` |
 | GCP metrics exporter | `opentelemetry-exporter-gcp-monitoring` |
 | Propagation | `opentelemetry-propagator-gcp` |
@@ -61,8 +62,35 @@ has direct knowledge of session lifecycle events.
 ## Implementation
 
 ### `src/backend/telemetry.py`
-Already implemented. Configures TracerProvider + MeterProvider with BatchSpanProcessor and
-environment-based exporters (GCP in production, console locally). No changes required.
+Configures TracerProvider + MeterProvider with BatchSpanProcessor and environment-based exporters
+(GCP in production, console locally).
+
+**Requires one change:** the current `logging.basicConfig` format (`%(asctime)s %(name)s %(levelname)s
+%(message)s`) does not inject OTel trace context. In GCP Cloud Logging, log-to-trace correlation
+requires the `logging.googleapis.com/trace` field in the structured log entry. Without it, log records
+and Cloud Trace spans are siloed — you cannot click a log line and jump to its trace.
+
+Fix: call `LoggingInstrumentor().instrument(set_logging_format=True)` from
+`opentelemetry-instrumentation-logging` in `setup_telemetry()`. This adds `otelTraceID`, `otelSpanID`,
+and `otelServiceName` to every `LogRecord`. In production (Cloud Run → Cloud Logging), switch from
+`logging.basicConfig` to a JSON formatter that maps `otelTraceID` →
+`logging.googleapis.com/trace: projects/{PROJECT_ID}/traces/{trace_id}`. In development, the
+plain-text format can retain the trace ID as a readable field. The `PROJECT_ID` is read from the GCP
+metadata server or an env var.
+
+### Structured log message naming convention
+All `logger.info` / `logger.warning` / `logger.exception` calls in `games.py` for SSE lifecycle and
+move rejection events must use a consistent message string that includes the game prefix, so Cloud
+Logging filters like `jsonPayload.message="c4_sse_error"` work reliably:
+
+| Event | Level | Message |
+|-------|-------|---------|
+| SSE stream closed (normal) | INFO | `{game}_sse_closed` |
+| SSE stream closed (error / exception) | ERROR | `{game}_sse_error` |
+| Player move rejected (422) | WARNING | `{game}_invalid_move` |
+
+`extra={"session_id": session_id}` is included on all three so each log record carries the session
+context needed to correlate with the `game.session_id` span attribute.
 
 ### `src/backend/app.py`
 Already implemented. FastAPIInstrumentor and Psycopg2Instrumentor applied at startup. No changes required.
@@ -104,3 +132,4 @@ credentials required.
 | API integration | `api/telemetry.spec.ts` | Auth endpoint span includes `auth.method` attribute |
 | API integration | `api/telemetry.spec.ts` | `record_move` call produces a child DB span with correct duration and session context |
 | Manual | Cloud Trace dashboard | After first production deploy, verify traces appear and are filterable by game_id |
+| Manual | Cloud Logging → Cloud Trace | Click a log line from a game endpoint; verify the "View in Cloud Trace" link resolves to the correct span |


### PR DESCRIPTION
## Summary

- Adds fully-specified SSE-architecture specs for all four remaining turn-based games (Connect 4, Checkers, Dots and Boxes, Chess), aligned with the TTT gold standard covering engine ABCs, AI strategy, SSE event schemas, API endpoints, session lifecycle, client phases, and test cases
- Fixes four observability gaps identified during review: trace-log correlation missing (logs siloed from Cloud Trace), no structured log message names, unlogged 422 invalid moves, Chess legal-moves endpoint log noise
- Updates observability spec status to `in-progress` and adds `opentelemetry-instrumentation-logging` to the stack

## Test plan

- [ ] Spec-only change — no runtime behavior modified; no automated tests required
- [ ] Verify specs render correctly on GitHub (tables, code blocks, backslash escapes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)