### PR TITLE
docs: comprehensive documentation review and uplift

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,25 @@ _ttt_strategy = TicTacToeAIStrategy()
 
 Replace with your new class and it will be used for all new moves immediately.
 
+**Chess model integration:**
+
+Chess has a dedicated scaffold for plugging in an external ML model. See section 10 for the short
+version, or [`src/backend/game_engine/INSTRUCTIONS.txt`](src/backend/game_engine/INSTRUCTIONS.txt)
+for the full walkthrough.
+
+**How AI move generation works (all games):**
+
+The `MoveProcessor` in `game_engine/base.py` manages the AI turn loop:
+
+1. Calls `strategy.generate_move(state)` to get a move candidate.
+2. Validates the move with `engine.validate_move(state, move)`.
+3. If invalid, retries up to 5 times with fresh `generate_move` calls.
+4. After 5 failed attempts, falls back to a random move from `engine.get_legal_moves(state)`.
+
+This means your `generate_move` does not have to guarantee a legal move — the framework handles
+retries and fallback automatically. All retry attempts are logged as warnings so you can observe
+them in `docker compose logs -f app`.
+
 ---
 
 ## 5. Reading game state and move history
@@ -216,7 +235,105 @@ export async function getActiveGame(gameType: string): Promise<GameSession | nul
 
 ---
 
-## 9. Checking your work
+## 9. Environment configuration
+
+The app reads these environment variables. In local development they are set in `docker-compose.yml`
+under the `app` service's `environment:` block.
+
+| Variable | Default | Description |
+| -------- | ------- | ----------- |
+| `ENVIRONMENT` | `development` | Set to `test` in the test Docker Compose file. Affects SSE timing (fast mode for tests) and enables the `X-AI-Moves` test header. Never set to `test` in production. |
+| `CHESS_AI_STRATEGY` | `minimax` | Set to `model` to activate `ChessModelStrategy` instead of the built-in minimax AI. |
+| `CHESS_MODEL_PATH` | `/app/model_weights/chess.pt` | Path inside the container where `ChessModelStrategy` looks for model weights. Override if your file is named differently. |
+
+To change a variable locally:
+
+1. Edit the `environment:` section in `docker-compose.yml`.
+2. Restart: `docker compose up -d`.
+
+No rebuild is needed for environment variable changes.
+
+---
+
+## 10. Chess model integration (short version)
+
+The scaffold for plugging in an external chess model lives in two files:
+
+| File | What to edit |
+| ---- | ------------ |
+| `src/backend/game_engine/chess_model_strategy.py` | Implement `_load_model(path)` and `_predict(pgn)` |
+| `docker-compose.yml` | Set `CHESS_AI_STRATEGY: model` and mount your weights volume |
+
+`_load_model` is called once at startup. `_predict` is called once per AI turn and receives the full
+PGN of the game so far; it must return a UCI move string (e.g. `"e2e4"`).
+
+Everything else — PGN construction, UCI→engine move conversion, move validation retry, logging — is
+handled by the framework. You do not need to touch any other file.
+
+See [`src/backend/game_engine/INSTRUCTIONS.txt`](src/backend/game_engine/INSTRUCTIONS.txt) for the
+full walkthrough including database access, dependency management, and how to mount model weights.
+
+---
+
+## 11. Running tests
+
+There are four test tiers. You usually only need to run the first two.
+
+**Fast tests (no Docker DB required):**
+
+```bash
+npm run test:fast
+```
+
+This runs Python unit tests (`tests/unit/`) and frontend Vitest tests in one command. No database
+needed. Run this after any backend or frontend change.
+
+**Integration and API tests (requires the test database):**
+
+```bash
+docker compose -f docker-compose.test.yml up -d
+python -m pytest tests/integration/ tests/api_tests/ -x --tb=short
+docker compose -f docker-compose.test.yml down
+```
+
+These tests hit a real PostgreSQL instance. Run them after changing API routes, database queries, or
+game engine logic.
+
+**To run only chess-related tests:**
+
+```bash
+python -m pytest tests/unit/ -k chess -x --tb=short
+python -m pytest tests/api_tests/ -k chess -x --tb=short
+```
+
+**How tests handle AI moves (deterministic testing):**
+
+When `ENVIRONMENT=test`, every game API endpoint accepts an optional `X-AI-Moves` header — a
+comma-separated list of moves. The server uses these predetermined moves instead of calling the real
+AI strategy. This makes tests reproducible without a trained model.
+
+Example (using `pytest` with the `TestClient`):
+
+```python
+response = client.post(
+    "/api/game/tic-tac-toe/move",
+    json={"position": 4},
+    headers={"X-AI-Moves": "0,8"},
+)
+```
+
+The `X-AI-Moves` header is ignored in `development` and `production` environments — it only works
+when `ENVIRONMENT=test`.
+
+**What this means for your model:**
+
+When tests run, the server uses `DeterministicAIStrategy` (if `X-AI-Moves` is set) regardless of
+the `CHESS_AI_STRATEGY` env var. Your model is never called during test runs, so it does not need to
+be available in the test environment.
+
+---
+
+## 12. Checking your work
 
 Run all checks manually before committing:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,9 +97,8 @@ Replace with your new class and it will be used for all new moves immediately.
 
 **Chess model integration:**
 
-Chess has a dedicated scaffold for plugging in an external ML model. See section 10 for the short
-version, or [`src/backend/game_engine/INSTRUCTIONS.txt`](src/backend/game_engine/INSTRUCTIONS.txt)
-for the full walkthrough.
+Chess has a dedicated scaffold for plugging in an external ML model. See section 10 for the short version, or
+[`src/backend/game_engine/INSTRUCTIONS.txt`](src/backend/game_engine/INSTRUCTIONS.txt) for the full walkthrough.
 
 **How AI move generation works (all games):**
 
@@ -110,9 +109,8 @@ The `MoveProcessor` in `game_engine/base.py` manages the AI turn loop:
 3. If invalid, retries up to 5 times with fresh `generate_move` calls.
 4. After 5 failed attempts, falls back to a random move from `engine.get_legal_moves(state)`.
 
-This means your `generate_move` does not have to guarantee a legal move — the framework handles
-retries and fallback automatically. All retry attempts are logged as warnings so you can observe
-them in `docker compose logs -f app`.
+This means your `generate_move` does not have to guarantee a legal move — the framework handles retries and fallback
+automatically. All retry attempts are logged as warnings so you can observe them in `docker compose logs -f app`.
 
 ---
 
@@ -237,14 +235,14 @@ export async function getActiveGame(gameType: string): Promise<GameSession | nul
 
 ## 9. Environment configuration
 
-The app reads these environment variables. In local development they are set in `docker-compose.yml`
-under the `app` service's `environment:` block.
+The app reads these environment variables. In local development they are set in `docker-compose.yml` under the `app`
+service's `environment:` block.
 
-| Variable | Default | Description |
-| -------- | ------- | ----------- |
-| `ENVIRONMENT` | `development` | Set to `test` in the test Docker Compose file. Affects SSE timing (fast mode for tests) and enables the `X-AI-Moves` test header. Never set to `test` in production. |
-| `CHESS_AI_STRATEGY` | `minimax` | Set to `model` to activate `ChessModelStrategy` instead of the built-in minimax AI. |
-| `CHESS_MODEL_PATH` | `/app/model_weights/chess.pt` | Path inside the container where `ChessModelStrategy` looks for model weights. Override if your file is named differently. |
+| Variable            | Default                       | Description                                                                                                                                                          |
+| ------------------- | ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ENVIRONMENT`       | `development`                 | Set to `test` in the test Docker Compose file. Affects SSE timing (fast mode for tests) and enables the `X-AI-Moves` test header. Never set to `test` in production. |
+| `CHESS_AI_STRATEGY` | `minimax`                     | Set to `model` to activate `ChessModelStrategy` instead of the built-in minimax AI.                                                                                  |
+| `CHESS_MODEL_PATH`  | `/app/model_weights/chess.pt` | Path inside the container where `ChessModelStrategy` looks for model weights. Override if your file is named differently.                                            |
 
 To change a variable locally:
 
@@ -259,19 +257,19 @@ No rebuild is needed for environment variable changes.
 
 The scaffold for plugging in an external chess model lives in two files:
 
-| File | What to edit |
-| ---- | ------------ |
-| `src/backend/game_engine/chess_model_strategy.py` | Implement `_load_model(path)` and `_predict(pgn)` |
-| `docker-compose.yml` | Set `CHESS_AI_STRATEGY: model` and mount your weights volume |
+| File                                              | What to edit                                                 |
+| ------------------------------------------------- | ------------------------------------------------------------ |
+| `src/backend/game_engine/chess_model_strategy.py` | Implement `_load_model(path)` and `_predict(pgn)`            |
+| `docker-compose.yml`                              | Set `CHESS_AI_STRATEGY: model` and mount your weights volume |
 
-`_load_model` is called once at startup. `_predict` is called once per AI turn and receives the full
-PGN of the game so far; it must return a UCI move string (e.g. `"e2e4"`).
+`_load_model` is called once at startup. `_predict` is called once per AI turn and receives the full PGN of the game so
+far; it must return a UCI move string (e.g. `"e2e4"`).
 
-Everything else — PGN construction, UCI→engine move conversion, move validation retry, logging — is
-handled by the framework. You do not need to touch any other file.
+Everything else — PGN construction, UCI→engine move conversion, move validation retry, logging — is handled by the
+framework. You do not need to touch any other file.
 
-See [`src/backend/game_engine/INSTRUCTIONS.txt`](src/backend/game_engine/INSTRUCTIONS.txt) for the
-full walkthrough including database access, dependency management, and how to mount model weights.
+See [`src/backend/game_engine/INSTRUCTIONS.txt`](src/backend/game_engine/INSTRUCTIONS.txt) for the full walkthrough
+including database access, dependency management, and how to mount model weights.
 
 ---
 
@@ -285,8 +283,8 @@ There are four test tiers. You usually only need to run the first two.
 npm run test:fast
 ```
 
-This runs Python unit tests (`tests/unit/`) and frontend Vitest tests in one command. No database
-needed. Run this after any backend or frontend change.
+This runs Python unit tests (`tests/unit/`) and frontend Vitest tests in one command. No database needed. Run this after
+any backend or frontend change.
 
 **Integration and API tests (requires the test database):**
 
@@ -296,8 +294,7 @@ python -m pytest tests/integration/ tests/api_tests/ -x --tb=short
 docker compose -f docker-compose.test.yml down
 ```
 
-These tests hit a real PostgreSQL instance. Run them after changing API routes, database queries, or
-game engine logic.
+These tests hit a real PostgreSQL instance. Run them after changing API routes, database queries, or game engine logic.
 
 **To run only chess-related tests:**
 
@@ -308,9 +305,9 @@ python -m pytest tests/api_tests/ -k chess -x --tb=short
 
 **How tests handle AI moves (deterministic testing):**
 
-When `ENVIRONMENT=test`, every game API endpoint accepts an optional `X-AI-Moves` header — a
-comma-separated list of moves. The server uses these predetermined moves instead of calling the real
-AI strategy. This makes tests reproducible without a trained model.
+When `ENVIRONMENT=test`, every game API endpoint accepts an optional `X-AI-Moves` header — a comma-separated list of
+moves. The server uses these predetermined moves instead of calling the real AI strategy. This makes tests reproducible
+without a trained model.
 
 Example (using `pytest` with the `TestClient`):
 
@@ -322,14 +319,13 @@ response = client.post(
 )
 ```
 
-The `X-AI-Moves` header is ignored in `development` and `production` environments — it only works
-when `ENVIRONMENT=test`.
+The `X-AI-Moves` header is ignored in `development` and `production` environments — it only works when
+`ENVIRONMENT=test`.
 
 **What this means for your model:**
 
-When tests run, the server uses `DeterministicAIStrategy` (if `X-AI-Moves` is set) regardless of
-the `CHESS_AI_STRATEGY` env var. Your model is never called during test runs, so it does not need to
-be available in the test environment.
+When tests run, the server uses `DeterministicAIStrategy` (if `X-AI-Moves` is set) regardless of the `CHESS_AI_STRATEGY`
+env var. Your model is never called during test runs, so it does not need to be available in the test environment.
 
 ---
 

--- a/features/PHASES.md
+++ b/features/PHASES.md
@@ -1,6 +1,6 @@
 # Development Phases & Dependency Order
 
-**Last updated: 2026-03-30** (documentation done 2026-03-30)
+**Last updated: 2026-04-10**
 
 This file defines the order in which features should be implemented, based on hard dependencies between
 specs. Update it whenever specs are added, completed, or their dependencies change.
@@ -24,7 +24,7 @@ These are done or in-progress and unblock everything else.
 |------|--------|-------|
 | google-oauth | ready/done | Auth layer; required by all authenticated features |
 | react-migration | done | React/Vite frontend in place |
-| observability | in-progress | OTel base; update for new persistence model before Phase 2 games |
+| observability | ready | OTel base; update for new persistence model before Phase 2 games |
 
 ---
 
@@ -48,7 +48,7 @@ These can run in parallel with each other.
 | Spec | Status | Blocked by |
 |------|--------|------------|
 | error-handling | done (needs minor update) | game-data-persistence |
-| observability | in-progress | game-data-persistence |
+| observability | ready | game-data-persistence |
 | about | needs implementation | — (no dependencies) |
 
 ---
@@ -60,8 +60,8 @@ UI component needed by all game pages.
 
 | Spec | Status | Blocked by |
 |------|--------|------------|
-| game-tic-tac-toe | in-progress | game-data-persistence |
-| player-card | in-progress | google-oauth |
+| game-tic-tac-toe | ready | game-data-persistence |
+| player-card | ready | google-oauth |
 
 ---
 
@@ -73,7 +73,7 @@ the reference pattern is validated.
 | Spec | Status | Blocked by |
 |------|--------|------------|
 | game-connect4 | ready | game-tic-tac-toe |
-| game-checkers | in-progress | game-tic-tac-toe |
+| game-checkers | ready | game-tic-tac-toe |
 | game-dots-and-boxes | ready | game-tic-tac-toe |
 
 ---
@@ -86,11 +86,7 @@ requires at least one game implemented to be testable end-to-end.
 | Spec | Status | Blocked by |
 |------|--------|------------|
 | game-chess | ready | game-data-persistence, player-card (for UI) |
-| game-statistics | **draft** — needs planning session before implementation | game-data-persistence (at least one game in Phase 3–4 done) |
-
-> `game-statistics` is in draft status. Before implementation begins, schedule a dedicated planning
-> conversation to answer the open questions in its spec (streak definition, public vs. private
-> profiles, leaderboard scope, completed vs. abandoned game definition).
+| game-statistics | ready | game-data-persistence (at least one game in Phase 3–4 done) |
 
 ---
 
@@ -148,12 +144,12 @@ These can be worked at any time alongside any phase. They do not block or get bl
 
 ## Discussion Points (Unresolved)
 
-These are open questions flagged during the 2026-03-30 planning session that affect phasing:
+These are open questions that affect phasing:
 
 1. **`session_id` vs `id` column naming**: The `{game_type}_games` tables use `id` as the PK (the
    session identifier). All game specs and API response shapes have been updated to use `id`. The
    existing frontend code still uses `session_id` throughout and will need migration during each
-   game's implementation pass. See the discussion in the 2026-03-30 planning session notes.
+   game's implementation pass.
 
 2. **Pong + persistence** (deferred with Phase 6): Does pong create a `pong_games` record (for stats,
    with empty `board_state`/`move_list`)? Or use a separate lightweight record? Decide at Phase 6
@@ -162,10 +158,6 @@ These are open questions flagged during the 2026-03-30 planning session that aff
 3. **Pong rally training data** (deferred with Phase 6): The `flush_rally` stub discards data.
    Training model for pong (continuous state, not discrete moves) is undefined. Decide at Phase 6
    planning time.
-
-4. **`game-statistics` open questions**: Streak definition, public vs. private profiles, leaderboard
-   scope, completed vs. abandoned definition. Must be resolved in a planning conversation before
-   Phase 5 statistics implementation begins.
 
 ---
 

--- a/features/game-checkers/spec.md
+++ b/features/game-checkers/spec.md
@@ -1,6 +1,6 @@
 # Game: Checkers
 
-**Status: in-progress**
+**Status: ready**
 
 ## Background
 
@@ -246,7 +246,7 @@ reflects the AI's first move and `current_turn: "player"`).
 
 **Response 200:**
 ```json
-{"session_id": "uuid", "state": { "...initial game state..." }}
+{"id": "uuid", "state": { "...initial game state..." }}
 ```
 
 ### `POST /api/game/checkers/move`

--- a/features/game-tic-tac-toe/spec.md
+++ b/features/game-tic-tac-toe/spec.md
@@ -1,6 +1,6 @@
 # Game: Tic-Tac-Toe
 
-**Status: in-progress**
+**Status: ready**
 
 ## Background
 

--- a/features/observability/spec.md
+++ b/features/observability/spec.md
@@ -1,6 +1,6 @@
 # Observability Spec (OpenTelemetry)
 
-**Status: in-progress**
+**Status: ready**
 
 ## Goal
 

--- a/features/player-card/spec.md
+++ b/features/player-card/spec.md
@@ -1,6 +1,6 @@
 # Feature: PlayerCard
 
-**Status: in-progress**
+**Status: ready**
 
 ## Background
 

--- a/src/backend/game_engine/INSTRUCTIONS.txt
+++ b/src/backend/game_engine/INSTRUCTIONS.txt
@@ -188,3 +188,48 @@ The PGN your model receives looks like:
 
 The result is "*" for in-progress games, "1-0" / "0-1" / "1/2-1/2" for finished.
 The moves use Standard Algebraic Notation (SAN): Nf3, O-O, exd5, e8=Q+, etc.
+
+
+10. TESTING YOUR MODEL INTEGRATION
+============================================================
+
+Run chess-specific unit and API tests with:
+
+  python -m pytest tests/unit/ -k chess -x --tb=short
+  python -m pytest tests/api_tests/ -k chess -x --tb=short
+
+Your model is NOT called during test runs. When ENVIRONMENT=test, the server
+uses DeterministicAIStrategy (predetermined moves supplied via the X-AI-Moves
+request header) instead of the real AI strategy. This means:
+
+  - Your model weights do not need to be present in the test environment.
+  - CHESS_AI_STRATEGY is ignored in tests.
+  - All existing chess tests pass regardless of whether _load_model is
+    implemented.
+
+To verify your model locally without running the full test suite:
+
+  1. Set CHESS_AI_STRATEGY=model in docker-compose.yml.
+  2. Mount your model weights (see section 7).
+  3. docker compose up -d
+  4. Log in at http://localhost:8000, start a chess game, and play a move.
+  5. Watch the logs: docker compose logs -f app
+
+You should see "chess_model_pgn_input" and "chess_model_uci_output" log lines
+for each AI turn. If _load_model raises NotImplementedError, the app will fail
+to start — check the startup logs for the error message.
+
+
+11. ENVIRONMENT VARIABLES REFERENCE
+============================================================
+
+  CHESS_AI_STRATEGY   "minimax" (default) or "model"
+                      Controls which AIStrategy is used for chess.
+
+  CHESS_MODEL_PATH    "/app/model_weights/chess.pt" (default)
+                      Path inside the container to your model file.
+                      Override if your file has a different name or location.
+
+  ENVIRONMENT         "development" (default), "test", or "production"
+                      Do not change this manually. The test Docker Compose
+                      file sets it to "test" automatically.


### PR DESCRIPTION
## Summary

- Spec status cleanup: `observability`, `game-tic-tac-toe`, `player-card`, `game-checkers` updated from `in-progress` to `ready` — specs are finalized; implementation status lives in PHASES.md
- Bug fix: checkers spec `/newgame` response key corrected from `session_id` to `id`
- PHASES.md: `game-statistics` status corrected from `draft` to `ready` (all design decisions resolved in the spec); resolved discussion point removed; all statuses synced
- `CONTRIBUTING.md`: added env var reference (§9), chess model integration short version (§10), and running tests guide (§11) including `DeterministicAIStrategy` / `X-AI-Moves` explanation and what it means for the ML model
- `INSTRUCTIONS.txt`: added testing section (§10) and env vars reference (§11) for data scientist onboarding

## Test plan

- [ ] No runtime changes — docs only, no test run required
- [ ] Verify rendered markdown looks correct on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)