### PR TITLE
spec: test audit and /bug regression tool

### DIFF
--- a/features/test-audit-and-regression/spec.md
+++ b/features/test-audit-and-regression/spec.md
@@ -1,0 +1,142 @@
+# Test Audit and Regression System
+
+## Goal
+
+1. Audit current test coverage and document gaps
+2. Fix structural inconsistencies across test files
+3. Introduce a `/bug` slash command that creates a regression test case from a bug description
+
+---
+
+## Part 1: Audit Findings
+
+### Coverage Gaps
+
+| Area | Current coverage | Gap |
+|---|---|---|
+| E2E game flows | TTT only (`tests/e2e/ttt.spec.ts`) | Checkers, Chess, Connect4, DotsAndBoxes have no E2E |
+| Playwright API | TTT only (`tests/api/ttt.spec.ts`) | Other games have thin API tests in `tests/api_tests/` but no Playwright API tests |
+| Leaderboard | `test_stats.py` — minimal | No test for "no entries when stats_public=False", no pagination test |
+| Auth password contract | E2E ttt uses `password123`; api-endpoints helper uses `demo123` | These differ — only one can be correct |
+| Game-over flows | Not tested in any E2E | Win/loss/draw state never exercised by Playwright |
+| Optimistic UI | Not tested | No test that player move appears before SSE response |
+| Checkers AI timing | Not tested | No test that bot delay >= 2000ms |
+| Chess FEN storage | Not tested at API level | No assertion on board_state format |
+
+### Structural Issues
+
+1. **Two parallel API test suites**: `tests/api_tests/` (pytest + TestClient) and `tests/api/` (Playwright .spec.ts/.js). These serve different purposes but overlap on game endpoints. The pytest TestClient tests are the right tool for data-correctness assertions; Playwright API tests are better for auth flows and SSE.
+
+2. **api-endpoints.spec.js is plain JS in a TypeScript project**: All other Playwright tests are `.ts`. This file should be converted or replaced.
+
+3. **Seed password mismatch**: `ttt.spec.ts` E2E uses `password123`; `auth-helper.js` uses `demo123`. The correct password is `password123` (matching the hash). Fix tracked in `features/nightly-e2e-fix/spec.md`.
+
+---
+
+## Part 2: Coverage Improvements
+
+### New E2E game tests
+
+Add `tests/e2e/{checkers,chess,connect4,dots-and-boxes}.spec.ts` — one per game, covering:
+- Unauthenticated user sees login prompt
+- Game start overlay shows on page load
+- Clicking "Go first" starts the game
+- Player move is reflected immediately (optimistic display)
+- Game-over overlay appears on terminal state
+- "New Game" buttons are available after game ends
+
+Use the deterministic AI header (`X-AI-Moves`) for reproducible game flows in CI.
+
+### Leaderboard coverage
+
+Add to `tests/integration/test_stats_queries.py`:
+- `test_leaderboard_excluded_when_stats_private`: user with `stats_public=False` does not appear
+- `test_leaderboard_included_when_stats_public`: user with `stats_public=True` and completed games appears
+- `test_leaderboard_pagination`: returns correct slice when page > 1
+
+### Chess FEN coverage
+
+Add to `tests/api_tests/test_chess.py`:
+- `test_chess_move_stores_fen`: `board_state` field after a move is a valid FEN string
+
+---
+
+## Part 3: Bug Regression Tool — `/bug` Slash Command
+
+### Problem
+
+When a bug is found (by the user or in testing), the current workflow is:
+1. File a GitHub issue
+2. Fix the bug
+3. Maybe add a test
+
+Step 3 is optional and often skipped. Bugs recur because there's no test enforcing the fixed behavior.
+
+### Solution
+
+A `/bug` slash command that creates a failing regression test before the fix is written. This enforces the test-driven approach for bug fixes: **Prove It pattern** — write a test that reproduces the bug, confirm it fails, fix the code, confirm the test passes.
+
+### Command spec
+
+```
+/bug <description>
+```
+
+Workflow:
+1. User describes the bug (natural language)
+2. Agent determines the appropriate test tier (unit / API / E2E) based on the bug type
+3. Agent writes a failing test that reproduces the bug
+4. Agent verifies the test currently fails (confirming bug is reproducible)
+5. Test file is saved; agent reports the test name and location
+6. Implementation conversation can reference this test as the acceptance criterion
+
+### Rules
+
+- Always write the test before the fix
+- The test must fail before the fix (do not write a passing test)
+- Test tier selection:
+  - Backend logic bug → unit (pytest)
+  - API behavior bug → API (pytest TestClient)
+  - UI behavior bug → E2E (Playwright) using deterministic AI where needed
+  - Cross-layer bug → both API + E2E
+- Test names follow the pattern: `test_bug_<short_description>` (Python) or `bug: <description>` (Playwright)
+
+### Skill file location
+
+Create `C:\Users\seiwe\.claude\skills\bug\SKILL.md` — invocable as `/bug`.
+
+---
+
+## Scope
+
+### Files to create
+- `tests/e2e/checkers.spec.ts`
+- `tests/e2e/chess.spec.ts`
+- `tests/e2e/connect4.spec.ts`
+- `tests/e2e/dots-and-boxes.spec.ts`
+- `C:\Users\seiwe\.claude\skills\bug\SKILL.md` — the /bug slash command
+
+### Files to modify
+- `tests/integration/test_stats_queries.py` — leaderboard coverage
+- `tests/api_tests/test_chess.py` — FEN assertion
+- `tests/api/api-endpoints.spec.js` → convert to `.ts` (or replace)
+
+### Files NOT to modify
+- Any backend or frontend source file (this spec is test-only)
+
+## Acceptance Criteria
+
+- All 5 games have E2E tests in `tests/e2e/`
+- Leaderboard behavior (public/private) has integration test coverage
+- `/bug <description>` produces a failing test that documents the reproduction case
+- No test files are deleted as part of this work
+
+## Test Cases
+
+*This spec adds tests rather than requiring them. The acceptance criteria above serve as the verification.*
+
+| Manual check | Criteria |
+|---|---|
+| `/bug "checkers: bot responds instantly"` | Produces a failing `test_bug_checkers_bot_responds_instantly` pytest test |
+| `/bug "leaderboard shows no data"` | Produces a failing Playwright or pytest test demonstrating empty leaderboard with stats_public=False default |
+| All 4 new E2E files pass in `nightly-e2e.yml` | CI green after this feature ships |

--- a/features/test-audit-and-regression/spec.md
+++ b/features/test-audit-and-regression/spec.md
@@ -1,142 +1,204 @@
-# Test Audit and Regression System
+# Test audit, live-game coverage, and regression discipline
 
 ## Goal
 
-1. Audit current test coverage and document gaps
-2. Fix structural inconsistencies across test files
-3. Introduce a `/bug` slash command that creates a regression test case from a bug description
+1. Audit current test coverage and document gaps.
+2. Fix structural inconsistencies across test files.
+3. Keep **documentation** the source of truth for how we add features, fix bugs, and maintain tests for the life of the
+   project.
+
+This spec is **test and process documentation only** (no application source changes in its own PR). Bug reports live in
+**GitHub Issues**, not in the repository as standalone “bug files.”
 
 ---
 
-## Part 1: Audit Findings
+## Definitions
 
-### Coverage Gaps
+### Live game
 
-| Area | Current coverage | Gap |
-|---|---|---|
-| E2E game flows | TTT only (`tests/e2e/ttt.spec.ts`) | Checkers, Chess, Connect4, DotsAndBoxes have no E2E |
-| Playwright API | TTT only (`tests/api/ttt.spec.ts`) | Other games have thin API tests in `tests/api_tests/` but no Playwright API tests |
-| Leaderboard | `test_stats.py` — minimal | No test for "no entries when stats_public=False", no pagination test |
-| Auth password contract | E2E ttt uses `password123`; api-endpoints helper uses `demo123` | These differ — only one can be correct |
-| Game-over flows | Not tested in any E2E | Win/loss/draw state never exercised by Playwright |
-| Optimistic UI | Not tested | No test that player move appears before SSE response |
-| Checkers AI timing | Not tested | No test that bot delay >= 2000ms |
-| Chess FEN storage | Not tested at API level | No assertion on board_state format |
+A **live game** is any game exposed in production routing that a user can open from the hub and play through the normal
+UI, **including** games that are playable without an AI (human-vs-human or incomplete AI is still live if the route and
+core loop ship).
 
-### Structural Issues
+**Current live games (must have automated coverage as below):** Tic-tac-toe, Checkers, Chess, Connect4, Dots and Boxes.
 
-1. **Two parallel API test suites**: `tests/api_tests/` (pytest + TestClient) and `tests/api/` (Playwright .spec.ts/.js). These serve different purposes but overlap on game endpoints. The pytest TestClient tests are the right tool for data-correctness assertions; Playwright API tests are better for auth flows and SSE.
+**Not live until explicitly promoted:** Pong remains in design/development; it is excluded from the “five live games”
+checklist until `features/game-pong/spec.md` (or product docs) mark it shipped and routes are enabled for users.
 
-2. **api-endpoints.spec.js is plain JS in a TypeScript project**: All other Playwright tests are `.ts`. This file should be converted or replaced.
+When Pong (or any new game) goes live, contributors **must** extend smoke routes, E2E game-flow specs, and any API
+contracts in the same delivery as the feature (see **CONTRIBUTING.md** — Live games and coverage).
 
-3. **Seed password mismatch**: `ttt.spec.ts` E2E uses `password123`; `auth-helper.js` uses `demo123`. The correct password is `password123` (matching the hash). Fix tracked in `features/nightly-e2e-fix/spec.md`.
+### Bug
 
----
-
-## Part 2: Coverage Improvements
-
-### New E2E game tests
-
-Add `tests/e2e/{checkers,chess,connect4,dots-and-boxes}.spec.ts` — one per game, covering:
-- Unauthenticated user sees login prompt
-- Game start overlay shows on page load
-- Clicking "Go first" starts the game
-- Player move is reflected immediately (optimistic display)
-- Game-over overlay appears on terminal state
-- "New Game" buttons are available after game ends
-
-Use the deterministic AI header (`X-AI-Moves`) for reproducible game flows in CI.
-
-### Leaderboard coverage
-
-Add to `tests/integration/test_stats_queries.py`:
-- `test_leaderboard_excluded_when_stats_private`: user with `stats_public=False` does not appear
-- `test_leaderboard_included_when_stats_public`: user with `stats_public=True` and completed games appears
-- `test_leaderboard_pagination`: returns correct slice when page > 1
-
-### Chess FEN coverage
-
-Add to `tests/api_tests/test_chess.py`:
-- `test_chess_move_stores_fen`: `board_state` field after a move is a valid FEN string
+A **bug** is a **direct violation of documented behavior** (spec, ADR, or **CONTRIBUTING.md** / user-facing docs that we
+treat as contract), **without** requiring a new infrastructure or architectural decision. If fixing it needs new infra,
+env vars, or a product decision, treat it as a **feature or ADR-level** change: update the spec first, then implement.
 
 ---
 
-## Part 3: Bug Regression Tool — `/bug` Slash Command
+## Relationship to full-site coverage
 
-### Problem
+**North star:** automated tests should cover the product so that regressions are caught as early as the right tier
+allows (unit → API → integration → E2E).
 
-When a bug is found (by the user or in testing), the current workflow is:
-1. File a GitHub issue
-2. Fix the bug
-3. Maybe add a test
+**Where this is specified elsewhere:** `features/test-coverage-overhaul/spec.md` is the umbrella for pyramid balance, CI
+tiers, deterministic AI, TestClient vs Playwright, and long-term coverage goals across the stack.
 
-Step 3 is optional and often skipped. Bugs recur because there's no test enforcing the fixed behavior.
-
-### Solution
-
-A `/bug` slash command that creates a failing regression test before the fix is written. This enforces the test-driven approach for bug fixes: **Prove It pattern** — write a test that reproduces the bug, confirm it fails, fix the code, confirm the test passes.
-
-### Command spec
-
-```
-/bug <description>
-```
-
-Workflow:
-1. User describes the bug (natural language)
-2. Agent determines the appropriate test tier (unit / API / E2E) based on the bug type
-3. Agent writes a failing test that reproduces the bug
-4. Agent verifies the test currently fails (confirming bug is reproducible)
-5. Test file is saved; agent reports the test name and location
-6. Implementation conversation can reference this test as the acceptance criterion
-
-### Rules
-
-- Always write the test before the fix
-- The test must fail before the fix (do not write a passing test)
-- Test tier selection:
-  - Backend logic bug → unit (pytest)
-  - API behavior bug → API (pytest TestClient)
-  - UI behavior bug → E2E (Playwright) using deterministic AI where needed
-  - Cross-layer bug → both API + E2E
-- Test names follow the pattern: `test_bug_<short_description>` (Python) or `bug: <description>` (Playwright)
-
-### Skill file location
-
-Create `C:\Users\seiwe\.claude\skills\bug\SKILL.md` — invocable as `/bug`.
+**Scope of _this_ spec:** close known gaps called out in Part 1–2 below (live game E2E parity, leaderboard integration
+cases, chess FEN API assertion, test file consistency). It does **not** replace the overhaul spec for “entire website
+E2E in one milestone”; remaining site flows should gain coverage through their **feature specs’ Test Cases** and through
+the overhaul plan until the north star is met.
 
 ---
 
-## Scope
+## Part 1: Audit findings
 
-### Files to create
+### Coverage gaps
+
+| Area                   | Current coverage                   | Gap                                                                                              |
+| ---------------------- | ---------------------------------- | ------------------------------------------------------------------------------------------------ |
+| E2E game flows         | TTT only (`tests/e2e/ttt.spec.ts`) | Checkers, Chess, Connect4, Dots and Boxes need the same style of flow tests                      |
+| Playwright API         | TTT only (`tests/api/ttt.spec.ts`) | Other games have pytest API tests but thin or no Playwright API specs where browser/auth matters |
+| Leaderboard            | `test_stats.py` — minimal          | No test for excluded private stats, weak pagination assertions                                   |
+| Auth password contract | E2E vs helpers can disagree        | Align on seeded passwords (`password123`); see `features/nightly-e2e-fix/spec.md` where relevant |
+| Game-over flows        | Not consistently in E2E            | Win/loss/draw overlays should be exercised per live game                                         |
+| Optimistic UI          | Not consistently tested            | Player move visible before SSE settles where applicable                                          |
+| Chess FEN storage      | Not asserted at API level          | `board_state` / FEN shape after moves                                                            |
+
+### Structural issues
+
+1. **Two parallel API suites:** `tests/api_tests/` (pytest + TestClient) and `tests/api/` (Playwright). Pytest is
+   preferred for payload and data correctness; Playwright API tests fit auth, cookies, and real HTTP edge cases. Avoid
+   duplicating the same assertion in both without reason; document which suite owns which contract.
+
+2. **`api-endpoints.spec.js` is plain JS** in a TypeScript-heavy tree: convert to `.ts` or replace with pytest coverage
+   if redundant.
+
+3. **Seed password mismatch** (historical): E2E and helpers must match **CONTRIBUTING.md** seeded accounts.
+
+---
+
+## Part 2: Coverage improvements
+
+### E2E per live game
+
+Add `tests/e2e/{checkers,chess,connect4,dots-and-boxes}.spec.ts` (TTT already exists), each covering at minimum:
+
+- Unauthenticated user sees login prompt when a move or protected action requires auth (if applicable to that game).
+- Game start overlay on first load.
+- Starting a game (e.g. “Go first” or equivalent control for that game).
+- At least one player action reflected in the UI (use **`X-AI-Moves`** in CI for any AI-dependent steps so flows stay
+  deterministic).
+- Terminal state reaches a **game-over** overlay (win, loss, or draw — whichever is easiest to force with deterministic
+  moves for that game).
+- **New game** (or equivalent) available after end of game.
+
+Games without AI still need E2E for human-side flows; omit AI-only steps only where the product truly has no AI path.
+
+### Leaderboard integration
+
+In `tests/integration/test_stats_queries.py` (or the module that owns leaderboard queries):
+
+- User with `stats_public=False` does not appear on the public leaderboard.
+- User with `stats_public=True` and qualifying completed games appears.
+- Pagination returns the correct slice when `page` > 1.
+
+### Chess FEN
+
+In `tests/api_tests/test_chess.py`:
+
+- After a move, persisted `board_state` (or equivalent field documented in the chess feature spec) is a **valid FEN**
+  string for the contract we document.
+
+---
+
+## Part 3: Bugs, issues, and regression tests
+
+### Workflow
+
+1. **Confirm documented behavior** — spec, ADR, or **CONTRIBUTING.md** / locked docs.
+2. **Open a GitHub Issue** describing the violation, with links to the doc section and minimal reproduction. Issues do
+   **not** depend on a prior PR merge; they track work independently.
+3. **Implement the fix** in a PR that **references the issue** (e.g. `Fixes #123`).
+4. **Add or extend an automated regression test** in the same PR as the fix (pytest, TestClient, Vitest, or Playwright
+   as appropriate). The test encodes the corrected contract. Prefer **red → green** locally when feasible; CI must be
+   green before merge.
+5. **Never** commit standalone “bug description” files in lieu of an Issue.
+
+### Tier selection for regression tests
+
+| Bug in                     | Primary test tier                                                                                    |
+| -------------------------- | ---------------------------------------------------------------------------------------------------- |
+| Backend logic              | pytest unit (`tests/unit/`)                                                                          |
+| API behavior / persistence | pytest + TestClient (`tests/api_tests/` or `tests/integration/`)                                     |
+| UI or cross-stack flow     | Playwright (`tests/e2e/`, `tests/smoke/`, etc.) with deterministic AI when the bug involves AI turns |
+
+Cross-layer bugs may need more than one test; the feature spec or issue should say so.
+
+### Naming
+
+Use clear names such as `test_regression_issue_123_board_state_persists` or Playwright titles that mention the issue
+slug; consistency matters more than a rigid prefix.
+
+---
+
+## Scope (files)
+
+### Create
+
 - `tests/e2e/checkers.spec.ts`
 - `tests/e2e/chess.spec.ts`
 - `tests/e2e/connect4.spec.ts`
 - `tests/e2e/dots-and-boxes.spec.ts`
-- `C:\Users\seiwe\.claude\skills\bug\SKILL.md` — the /bug slash command
 
-### Files to modify
-- `tests/integration/test_stats_queries.py` — leaderboard coverage
+### Modify
+
+- `tests/smoke/routes.spec.js` — include every **live** game slug in the route smoke list
+- `tests/integration/test_stats_queries.py` (or equivalent) — leaderboard cases
 - `tests/api_tests/test_chess.py` — FEN assertion
-- `tests/api/api-endpoints.spec.js` → convert to `.ts` (or replace)
+- `tests/api/api-endpoints.spec.js` → TypeScript or replacement per Part 1
 
-### Files NOT to modify
-- Any backend or frontend source file (this spec is test-only)
+### Do not modify (for this spec’s own delivery)
 
-## Acceptance Criteria
+- Application source under `src/backend/` and `src/frontend/src/` except when a **separate** bugfix PR is required to
+  satisfy a failing regression test.
 
-- All 5 games have E2E tests in `tests/e2e/`
-- Leaderboard behavior (public/private) has integration test coverage
-- `/bug <description>` produces a failing test that documents the reproduction case
-- No test files are deleted as part of this work
+---
+
+## Acceptance criteria
+
+- All **current live games** have E2E flow coverage in `tests/e2e/` in the style of TTT.
+- Leaderboard public/private and pagination behaviors have integration (or equivalent) tests.
+- Chess persistence asserts FEN (or documented equivalent) at API level.
+- **CONTRIBUTING.md** describes live games, bug-vs-feature, GitHub Issues, and regression tests alongside existing
+  workflow (see PR #159 if not yet on `main`).
+- No test files deleted without replacement coverage and rationale in commit message.
+
+---
 
 ## Test Cases
 
-*This spec adds tests rather than requiring them. The acceptance criteria above serve as the verification.*
+| Tier        | Test name / file                    | Scenario                                                    |
+| ----------- | ----------------------------------- | ----------------------------------------------------------- |
+| E2E         | `tests/e2e/checkers.spec.ts`        | Live game flow: auth gate, start, move, game over, new game |
+| E2E         | `tests/e2e/chess.spec.ts`           | Same for chess                                              |
+| E2E         | `tests/e2e/connect4.spec.ts`        | Same for Connect4                                           |
+| E2E         | `tests/e2e/dots-and-boxes.spec.ts`  | Same for Dots and Boxes                                     |
+| Integration | `test_stats_queries.py` (names TBD) | Private stats excluded; public included; pagination slice   |
+| API         | `test_chess.py` (name TBD)          | After move, `board_state` matches FEN contract              |
 
-| Manual check | Criteria |
-|---|---|
-| `/bug "checkers: bot responds instantly"` | Produces a failing `test_bug_checkers_bot_responds_instantly` pytest test |
-| `/bug "leaderboard shows no data"` | Produces a failing Playwright or pytest test demonstrating empty leaderboard with stats_public=False default |
-| All 4 new E2E files pass in `nightly-e2e.yml` | CI green after this feature ships |
+---
+
+## Not doing (here)
+
+- **Pong** E2E until it is a live game.
+- **Replacing** `features/test-coverage-overhaul/spec.md` — complementary, not duplicate.
+- **Slash commands or repo-local “/bug” skills** as the bug intake path — GitHub Issues are authoritative.
+- **Broad rewrite** of all Playwright JS specs beyond what is listed in Part 2.
+
+---
+
+## Open questions
+
+- Whether `tests/games/*.spec.js` should merge into `tests/e2e/` or stay parallel — decide when touching those files;
+  document in **CONTRIBUTING.md** once chosen.


### PR DESCRIPTION
## Summary
Three-part spec:

**Part 1 — Audit findings**
- 4 games (Checkers, Chess, Connect4, Dots & Boxes) have no E2E tests; only TTT has game-flow E2E
- Leaderboard public/private behavior untested
- Chess FEN storage untested at API level
- Two parallel API test suites (`tests/api_tests/` pytest + `tests/api/` Playwright) with inconsistent coverage
- `api-endpoints.spec.js` is plain JS in a TypeScript project
- Seed password mismatch: `ttt.spec.ts` uses `password123`, `auth-helper.js` uses `demo123`

**Part 2 — New coverage**
- E2E tests for all 5 games (game start, optimistic move, game-over overlay)
- Leaderboard integration tests (public/private filtering, pagination)
- Chess FEN assertion in API tests

**Part 3 — `/bug` slash command**
- New skill: `/bug <description>` creates a failing regression test before the fix is written
- Enforces the Prove-It pattern: test must fail first, then fix, then verify passing
- Tier selection logic: backend logic → pytest, API behavior → TestClient, UI → Playwright

## Review focus
- `/bug` command: should it open a GitHub issue automatically as well, or just create the test file?
- E2E game tests: should these use the deterministic AI header exclusively, or also test real AI path (which could be flaky)?
- Should `api-endpoints.spec.js` be converted to TypeScript, or replaced with tests in the existing `.spec.ts` files?

## Test plan
*This spec defines tests, not features requiring them.*
- [ ] `/bug "checkers: bot responds instantly"` → failing pytest test created
- [ ] All 4 new E2E files pass in nightly CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)