### PR TITLE
docs(CLAUDE.md): draft PRs and auto-merge by default; document nightly E2E test discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,8 +44,9 @@
     1. Fetch and rebase onto `origin/main`.
     2. Scan for open PRs. If any are open, resolve them first.
     3. Push the code.
-    4. Retrieve the PR that was submitted, and check that it has no merge conflicts. If any are present, resolve them.
-    5. Enable auto-merge: `gh pr merge <number> --auto --squash`
+    4. Open a PR in **draft** status (`gh pr create --draft ...`). This is the default; only omit `--draft` if explicitly told to.
+    5. Retrieve the PR that was submitted, and check that it has no merge conflicts. If any are present, resolve them.
+    6. Enable auto-merge (`gh pr merge <number> --auto --squash`). This is the default; only skip if explicitly told to.
 - For implementation pushes (any change to runtime behavior — features, bug fixes where a test could plausibly fail): 6.
   Watch GitHub Actions inline: `gh run watch`. If CI fails, fix immediately and push again. 7. Once the PR is merged,
   GCP Cloud Build will automatically build, push to Artifact Registry, and deploy to Cloud Run. Do **not** block waiting
@@ -82,6 +83,8 @@ Transitive dependencies (e.g. `pydantic-core`) are resolved automatically by pip
 | Integration     | pytest                      | `tests/integration/`                       | Yes (PG on port 5433)                 |
 | API             | pytest + FastAPI TestClient | `tests/api_tests/`                         | Yes (PG on port 5433)                 |
 | E2E             | Playwright                  | `tests/e2e/`, `tests/smoke/`, `tests/api/` | Yes (PG on port 5432, server running) |
+
+Any `.spec.{js,ts}` file under the directories matched by `playwright.config.js` globs (`tests/api/`, `tests/auth/`, `tests/database/`, `tests/e2e/`, `tests/games/`, `tests/performance/`, `tests/smoke/`) is automatically included in the nightly cross-browser E2E job (`nightly-e2e.yml`).
 
 ## Running Tests Locally
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,8 +45,10 @@
     2. Scan for open PRs. If any are open, resolve them first.
     3. Push the code.
     4. Open a PR in **draft** status (`gh pr create --draft ...`). This is the default; only omit `--draft` if explicitly told to.
-    5. Retrieve the PR that was submitted, and check that it has no merge conflicts. If any are present, resolve them.
-    6. Enable auto-merge (`gh pr merge <number> --auto --squash`). This is the default; only skip if explicitly told to.
+    5. Check that the PR has no merge conflicts. If any are present, resolve them.
+- Whenever submitting a draft PR (after review is complete in Claude Code):
+    1. Mark as ready: `gh pr ready <number>`
+    2. Enable auto-merge: `gh pr merge <number> --auto --squash`. This is the default; only skip if explicitly told to.
 - For implementation pushes (any change to runtime behavior — features, bug fixes where a test could plausibly fail): 6.
   Watch GitHub Actions inline: `gh run watch`. If CI fails, fix immediately and push again. 7. Once the PR is merged,
   GCP Cloud Build will automatically build, push to Artifact Registry, and deploy to Cloud Run. Do **not** block waiting

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,7 @@
 - Whenever submitting a draft PR (after review is complete in Claude Code):
     1. Mark as ready: `gh pr ready <number>`
     2. Enable auto-merge: `gh pr merge <number> --auto --squash`. This is the default; only skip if explicitly told to.
+    3. Watch CI: `gh run watch`. If it fails, fix immediately and push again. The required gate is `Test Summary` — all other jobs feed into it automatically and do not need to be individually tracked in the ruleset.
 - For implementation pushes (any change to runtime behavior — features, bug fixes where a test could plausibly fail): 6.
   Watch GitHub Actions inline: `gh run watch`. If CI fails, fix immediately and push again. 7. Once the PR is merged,
   GCP Cloud Build will automatically build, push to Artifact Registry, and deploy to Cloud Run. Do **not** block waiting


### PR DESCRIPTION
## Summary
- PRs must always be opened in draft status by default (`gh pr create --draft`)
- Auto-merge is the default on every PR (`gh pr merge --auto --squash`)
- Documents that any `.spec.{js,ts}` file in Playwright-matched directories is automatically included in the nightly cross-browser E2E job

## Test plan
- [ ] No functional changes — documentation only