### PR TITLE
fix(e2e): repair nightly cross-browser E2E failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,12 +44,14 @@
     1. Fetch and rebase onto `origin/main`.
     2. Scan for open PRs. If any are open, resolve them first.
     3. Push the code.
-    4. Open a PR in **draft** status (`gh pr create --draft ...`). This is the default; only omit `--draft` if explicitly told to.
+    4. Open a PR in **draft** status (`gh pr create --draft ...`). This is the default; only omit `--draft` if
+       explicitly told to.
     5. Check that the PR has no merge conflicts. If any are present, resolve them.
 - Whenever submitting a draft PR (after review is complete in Claude Code):
     1. Mark as ready: `gh pr ready <number>`
     2. Enable auto-merge: `gh pr merge <number> --auto --squash`. This is the default; only skip if explicitly told to.
-    3. Watch CI: `gh run watch`. If it fails, fix immediately and push again. The required gate is `Test Summary` — all other jobs feed into it automatically and do not need to be individually tracked in the ruleset.
+    3. Watch CI: `gh run watch`. If it fails, fix immediately and push again. The required gate is `Test Summary` — all
+       other jobs feed into it automatically and do not need to be individually tracked in the ruleset.
 - For implementation pushes (any change to runtime behavior — features, bug fixes where a test could plausibly fail): 6.
   Watch GitHub Actions inline: `gh run watch`. If CI fails, fix immediately and push again. 7. Once the PR is merged,
   GCP Cloud Build will automatically build, push to Artifact Registry, and deploy to Cloud Run. Do **not** block waiting
@@ -87,7 +89,9 @@ Transitive dependencies (e.g. `pydantic-core`) are resolved automatically by pip
 | API             | pytest + FastAPI TestClient | `tests/api_tests/`                         | Yes (PG on port 5433)                 |
 | E2E             | Playwright                  | `tests/e2e/`, `tests/smoke/`, `tests/api/` | Yes (PG on port 5432, server running) |
 
-Any `.spec.{js,ts}` file under the directories matched by `playwright.config.js` globs (`tests/api/`, `tests/auth/`, `tests/database/`, `tests/e2e/`, `tests/games/`, `tests/performance/`, `tests/smoke/`) is automatically included in the nightly cross-browser E2E job (`nightly-e2e.yml`).
+Any `.spec.{js,ts}` file under the directories matched by `playwright.config.js` globs (`tests/api/`, `tests/auth/`,
+`tests/database/`, `tests/e2e/`, `tests/games/`, `tests/performance/`, `tests/smoke/`) is automatically included in the
+nightly cross-browser E2E job (`nightly-e2e.yml`).
 
 ## Running Tests Locally
 

--- a/scripts/seed_test_data.py
+++ b/scripts/seed_test_data.py
@@ -32,13 +32,13 @@ _TEST_USERS = [
     {
         "username": "test",
         "email": "test@example.com",
-        "password_hash": "$2b$12$yRa5XdiD234Dvuavu0Cx0u5lJXaPsyufv9aG3QdIun9FIUx.t0cVS",
+        "password_hash": "$2b$12$ZzFtjWukLb1z7wJ8B8EM.uUijqU1b0LcUFqXhp2LH646KezufWtni",
         "display_name": "Test User",
     },
     {
         "username": "player1",
         "email": "player1@example.com",
-        "password_hash": "$2b$12$yRa5XdiD234Dvuavu0Cx0u5lJXaPsyufv9aG3QdIun9FIUx.t0cVS",
+        "password_hash": "$2b$12$ZzFtjWukLb1z7wJ8B8EM.uUijqU1b0LcUFqXhp2LH646KezufWtni",
         "display_name": "Player One",
     },
 ]

--- a/scripts/seed_test_data.py
+++ b/scripts/seed_test_data.py
@@ -26,19 +26,19 @@ _TEST_USERS = [
     {
         "username": "demo",
         "email": "demo@aigamehub.com",
-        "password_hash": "$2b$12$ZzFtjWukLb1z7wJ8B8EM.uUijqU1b0LcUFqXhp2LH646KezufWtni",
+        "password_hash": "$2b$12$yRa5XdiD234Dvuavu0Cx0u5lJXaPsyufv9aG3QdIun9FIUx.t0cVS",
         "display_name": "Demo Player",
     },
     {
         "username": "test",
         "email": "test@example.com",
-        "password_hash": "$2b$12$ZzFtjWukLb1z7wJ8B8EM.uUijqU1b0LcUFqXhp2LH646KezufWtni",
+        "password_hash": "$2b$12$yRa5XdiD234Dvuavu0Cx0u5lJXaPsyufv9aG3QdIun9FIUx.t0cVS",
         "display_name": "Test User",
     },
     {
         "username": "player1",
         "email": "player1@example.com",
-        "password_hash": "$2b$12$ZzFtjWukLb1z7wJ8B8EM.uUijqU1b0LcUFqXhp2LH646KezufWtni",
+        "password_hash": "$2b$12$yRa5XdiD234Dvuavu0Cx0u5lJXaPsyufv9aG3QdIun9FIUx.t0cVS",
         "display_name": "Player One",
     },
 ]

--- a/tests/api/api-endpoints.spec.js
+++ b/tests/api/api-endpoints.spec.js
@@ -300,7 +300,7 @@ test.describe('API Endpoints', () => {
     test.describe('CORS and Headers', () => {
         test('CORS headers are present', async ({ request }) => {
             const response = await request.get('/api/health', {
-                headers: { 'Origin': 'http://localhost:5173' },
+                headers: { Origin: 'http://localhost:5173' },
             });
 
             const corsHeader = response.headers()['access-control-allow-origin'];

--- a/tests/api/api-endpoints.spec.js
+++ b/tests/api/api-endpoints.spec.js
@@ -81,7 +81,7 @@ test.describe('API Endpoints', () => {
             const response = await auth.post('/api/auth/login', {
                 data: {
                     email: 'demo@aigamehub.com',
-                    password: 'password123',
+                    password: 'demo123',
                 },
             });
 
@@ -219,7 +219,7 @@ test.describe('API Endpoints', () => {
             const loginResponse = await auth.post('/api/auth/login', {
                 data: {
                     email: 'demo@aigamehub.com',
-                    password: 'password123',
+                    password: 'demo123',
                 },
             });
 
@@ -238,7 +238,7 @@ test.describe('API Endpoints', () => {
             const reLoginResponse = await auth.post('/api/auth/login', {
                 data: {
                     email: 'demo@aigamehub.com',
-                    password: 'password123',
+                    password: 'demo123',
                 },
             });
 
@@ -271,7 +271,7 @@ test.describe('API Endpoints', () => {
 
     test.describe('Error Handling', () => {
         test('non-existent endpoints return 404', async ({ request }) => {
-            const response = await request.get('/api/nonexistent');
+            const response = await request.get('/api/nonexistent-endpoint-xyz');
             expect(response.status()).toBe(404);
         });
 
@@ -283,7 +283,7 @@ test.describe('API Endpoints', () => {
                 },
             });
 
-            expect([400, 500]).toContain(response.status());
+            expect([400, 422, 500]).toContain(response.status());
         });
 
         test('missing required fields return appropriate errors', async ({ request }) => {
@@ -299,15 +299,16 @@ test.describe('API Endpoints', () => {
 
     test.describe('CORS and Headers', () => {
         test('CORS headers are present', async ({ request }) => {
-            const response = await request.get('/api/health');
+            const response = await request.get('/api/health', {
+                headers: { 'Origin': 'http://localhost:5173' },
+            });
 
             const corsHeader = response.headers()['access-control-allow-origin'];
-            // CORS should be configured (either * or specific origin)
             expect(corsHeader).toBeDefined();
         });
 
         test('Content-Type headers are correct', async ({ request }) => {
-            const response = await request.get('/api/games');
+            const response = await request.get('/api/games_list');
 
             const contentType = response.headers()['content-type'];
             expect(contentType).toContain('application/json');

--- a/tests/api/ttt.spec.ts
+++ b/tests/api/ttt.spec.ts
@@ -1,206 +1,206 @@
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-const BASE = "http://localhost:8000/api";
+const BASE = 'http://localhost:8000/api';
 
 async function loginAs(
-  request: Parameters<typeof test>[1] extends { request: infer R } ? R : never,
-  email = "test@example.com",
-  password = "password123"
+    request: Parameters<typeof test>[1] extends { request: infer R } ? R : never,
+    email = 'test@example.com',
+    password = 'password123'
 ) {
-  const res = await (request as { post: Function }).post(`${BASE}/auth/login`, {
-    data: { email, password },
-  });
-  expect(res.ok()).toBeTruthy();
-  return res.headers()["set-cookie"];
+    const res = await (request as { post: Function }).post(`${BASE}/auth/login`, {
+        data: { email, password },
+    });
+    expect(res.ok()).toBeTruthy();
+    return res.headers()['set-cookie'];
 }
 
-test.describe("ttt — resume", () => {
-  test("test_resume_no_active_session", async ({ request }) => {
-    const cookies = await loginAs(request);
-    // clear any existing session first
-    await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
+test.describe('ttt — resume', () => {
+    test('test_resume_no_active_session', async ({ request }) => {
+        const cookies = await loginAs(request);
+        // clear any existing session first
+        await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        // start a different game type to leave ttt clean on a fresh user would be ideal,
+        // but instead we just check the shape — login as player1 who has no ttt session
+        const cookies2 = await loginAs(request, 'player1@example.com', 'password123');
+        const res = await request.get(`${BASE}/game/tic-tac-toe/resume`, {
+            headers: { Cookie: cookies2 },
+        });
+        expect(res.ok()).toBeTruthy();
+        const body = await res.json();
+        expect(body).toHaveProperty('id');
+        expect(body).toHaveProperty('state');
     });
-    // start a different game type to leave ttt clean on a fresh user would be ideal,
-    // but instead we just check the shape — login as player1 who has no ttt session
-    const cookies2 = await loginAs(request, "player1@example.com", "password123");
-    const res = await request.get(`${BASE}/game/tic-tac-toe/resume`, {
-      headers: { Cookie: cookies2 },
-    });
-    expect(res.ok()).toBeTruthy();
-    const body = await res.json();
-    expect(body).toHaveProperty("id");
-    expect(body).toHaveProperty("state");
-  });
 
-  test("test_resume_active_session_returns_state", async ({ request }) => {
-    const cookies = await loginAs(request);
-    await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
+    test('test_resume_active_session_returns_state', async ({ request }) => {
+        const cookies = await loginAs(request);
+        await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        const res = await request.get(`${BASE}/game/tic-tac-toe/resume`, {
+            headers: { Cookie: cookies },
+        });
+        expect(res.ok()).toBeTruthy();
+        const { id, state } = await res.json();
+        expect(id).toBeTruthy();
+        expect(state).not.toBeNull();
+        expect(state.board).toHaveLength(9);
+        expect(state.status).toBe('in_progress');
     });
-    const res = await request.get(`${BASE}/game/tic-tac-toe/resume`, {
-      headers: { Cookie: cookies },
-    });
-    expect(res.ok()).toBeTruthy();
-    const { id, state } = await res.json();
-    expect(id).toBeTruthy();
-    expect(state).not.toBeNull();
-    expect(state.board).toHaveLength(9);
-    expect(state.status).toBe("in_progress");
-  });
 
-  test("test_resume_unauthenticated_returns_401", async ({ request }) => {
-    const res = await request.get(`${BASE}/game/tic-tac-toe/resume`);
-    expect(res.status()).toBe(401);
-  });
+    test('test_resume_unauthenticated_returns_401', async ({ request }) => {
+        const res = await request.get(`${BASE}/game/tic-tac-toe/resume`);
+        expect(res.status()).toBe(401);
+    });
 });
 
-test.describe("ttt — newgame", () => {
-  test("test_newgame_player_first", async ({ request }) => {
-    const cookies = await loginAs(request);
-    const res = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
+test.describe('ttt — newgame', () => {
+    test('test_newgame_player_first', async ({ request }) => {
+        const cookies = await loginAs(request);
+        const res = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        expect(res.ok()).toBeTruthy();
+        const { id, state } = await res.json();
+        expect(id).toBeTruthy();
+        expect(state.board.every((c: unknown) => c === null)).toBe(true);
+        expect(state.current_turn).toBe('player');
+        expect(state.player_symbol).toBe('X');
     });
-    expect(res.ok()).toBeTruthy();
-    const { id, state } = await res.json();
-    expect(id).toBeTruthy();
-    expect(state.board.every((c: unknown) => c === null)).toBe(true);
-    expect(state.current_turn).toBe("player");
-    expect(state.player_symbol).toBe("X");
-  });
 
-  test("test_newgame_ai_first", async ({ request }) => {
-    const cookies = await loginAs(request);
-    const res = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: false },
-      headers: { Cookie: cookies },
+    test('test_newgame_ai_first', async ({ request }) => {
+        const cookies = await loginAs(request);
+        const res = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: false },
+            headers: { Cookie: cookies },
+        });
+        expect(res.ok()).toBeTruthy();
+        const { state } = await res.json();
+        const filledCells = state.board.filter((c: unknown) => c !== null);
+        expect(filledCells).toHaveLength(1);
+        expect(filledCells[0]).toBe(state.ai_symbol);
+        expect(state.current_turn).toBe('player');
     });
-    expect(res.ok()).toBeTruthy();
-    const { state } = await res.json();
-    const filledCells = state.board.filter((c: unknown) => c !== null);
-    expect(filledCells).toHaveLength(1);
-    expect(filledCells[0]).toBe(state.ai_symbol);
-    expect(state.current_turn).toBe("player");
-  });
 
-  test("test_newgame_closes_existing_session", async ({ request }) => {
-    const cookies = await loginAs(request);
-    const res1 = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
-    });
-    const { id: sid1 } = await res1.json();
+    test('test_newgame_closes_existing_session', async ({ request }) => {
+        const cookies = await loginAs(request);
+        const res1 = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        const { id: sid1 } = await res1.json();
 
-    const res2 = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
+        const res2 = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        expect(res2.ok()).toBeTruthy();
+        const { id: sid2 } = await res2.json();
+        expect(sid2).not.toBe(sid1);
     });
-    expect(res2.ok()).toBeTruthy();
-    const { id: sid2 } = await res2.json();
-    expect(sid2).not.toBe(sid1);
-  });
 });
 
-test.describe("ttt — move", () => {
-  test("test_move_returns_202", async ({ request }) => {
-    const cookies = await loginAs(request);
-    await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
+test.describe('ttt — move', () => {
+    test('test_move_returns_202', async ({ request }) => {
+        const cookies = await loginAs(request);
+        await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
+            data: { position: 4 },
+            headers: { Cookie: cookies },
+        });
+        expect(res.status()).toBe(202);
     });
-    const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
-      data: { position: 4 },
-      headers: { Cookie: cookies },
-    });
-    expect(res.status()).toBe(202);
-  });
 
-  test("test_move_occupied_cell_returns_422", async ({ request }) => {
-    const cookies = await loginAs(request);
-    await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
+    test('test_move_occupied_cell_returns_422', async ({ request }) => {
+        const cookies = await loginAs(request);
+        await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        await request.post(`${BASE}/game/tic-tac-toe/move`, {
+            data: { position: 0 },
+            headers: { Cookie: cookies },
+        });
+        // wait a moment for SSE processing before second move attempt
+        await new Promise(r => setTimeout(r, 200));
+        // resume to get updated state, then try to play on cell 0 again
+        const resumeRes = await request.get(`${BASE}/game/tic-tac-toe/resume`, {
+            headers: { Cookie: cookies },
+        });
+        const { state } = await resumeRes.json();
+        // cell 0 should be occupied now
+        if (state && state.board[0] !== null) {
+            const moveRes = await request.post(`${BASE}/game/tic-tac-toe/move`, {
+                data: { position: 0 },
+                headers: { Cookie: cookies },
+            });
+            expect(moveRes.status()).toBe(422);
+        }
     });
-    await request.post(`${BASE}/game/tic-tac-toe/move`, {
-      data: { position: 0 },
-      headers: { Cookie: cookies },
-    });
-    // wait a moment for SSE processing before second move attempt
-    await new Promise((r) => setTimeout(r, 200));
-    // resume to get updated state, then try to play on cell 0 again
-    const resumeRes = await request.get(`${BASE}/game/tic-tac-toe/resume`, {
-      headers: { Cookie: cookies },
-    });
-    const { state } = await resumeRes.json();
-    // cell 0 should be occupied now
-    if (state && state.board[0] !== null) {
-      const moveRes = await request.post(`${BASE}/game/tic-tac-toe/move`, {
-        data: { position: 0 },
-        headers: { Cookie: cookies },
-      });
-      expect(moveRes.status()).toBe(422);
-    }
-  });
 
-  test("test_move_out_of_range_returns_422", async ({ request }) => {
-    const cookies = await loginAs(request);
-    await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies },
+    test('test_move_out_of_range_returns_422', async ({ request }) => {
+        const cookies = await loginAs(request);
+        await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies },
+        });
+        const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
+            data: { position: 99 },
+            headers: { Cookie: cookies },
+        });
+        expect(res.status()).toBe(422);
     });
-    const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
-      data: { position: 99 },
-      headers: { Cookie: cookies },
-    });
-    expect(res.status()).toBe(422);
-  });
 
-  test("test_move_no_active_session_returns_409", async ({ request }) => {
-    const cookies = await loginAs(request, "demo@aigamehub.com", "password123");
-    // ensure no active session by starting then immediately aborting
-    // we test against a clean demo user with no session
-    const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
-      data: { position: 0 },
-      headers: { Cookie: cookies },
+    test('test_move_no_active_session_returns_409', async ({ request }) => {
+        const cookies = await loginAs(request, 'demo@aigamehub.com', 'demo123');
+        // ensure no active session by starting then immediately aborting
+        // we test against a clean demo user with no session
+        const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
+            data: { position: 0 },
+            headers: { Cookie: cookies },
+        });
+        // Either 409 (no session) or 422 (has session but turn mismatch) — both indicate correct guard
+        expect([409, 422]).toContain(res.status());
     });
-    // Either 409 (no session) or 422 (has session but turn mismatch) — both indicate correct guard
-    expect([409, 422]).toContain(res.status());
-  });
 
-  test("test_move_unauthenticated_returns_401", async ({ request }) => {
-    const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
-      data: { position: 0 },
+    test('test_move_unauthenticated_returns_401', async ({ request }) => {
+        const res = await request.post(`${BASE}/game/tic-tac-toe/move`, {
+            data: { position: 0 },
+        });
+        expect(res.status()).toBe(401);
     });
-    expect(res.status()).toBe(401);
-  });
 });
 
-test.describe("ttt — SSE events", () => {
-  test("test_sse_unauthorized_session_returns_403", async ({ request }) => {
-    const cookies1 = await loginAs(request, "test@example.com", "password123");
-    const newRes = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
-      data: { player_starts: true },
-      headers: { Cookie: cookies1 },
-    });
-    const { id } = await newRes.json();
+test.describe('ttt — SSE events', () => {
+    test('test_sse_unauthorized_session_returns_403', async ({ request }) => {
+        const cookies1 = await loginAs(request, 'test@example.com', 'password123');
+        const newRes = await request.post(`${BASE}/game/tic-tac-toe/newgame`, {
+            data: { player_starts: true },
+            headers: { Cookie: cookies1 },
+        });
+        const { id } = await newRes.json();
 
-    const cookies2 = await loginAs(request, "player1@example.com", "password123");
-    const eventsRes = await request.get(`${BASE}/game/tic-tac-toe/events/${id}`, {
-      headers: { Cookie: cookies2 },
+        const cookies2 = await loginAs(request, 'player1@example.com', 'password123');
+        const eventsRes = await request.get(`${BASE}/game/tic-tac-toe/events/${id}`, {
+            headers: { Cookie: cookies2 },
+        });
+        expect(eventsRes.status()).toBe(403);
     });
-    expect(eventsRes.status()).toBe(403);
-  });
 });
 
-test.describe("ttt — cleanup", () => {
-  test("test_cleanup_marks_stale_sessions_abandoned", async ({ request }) => {
-    // Cleanup endpoint requires INTERNAL_API_KEY; without it returns 403
-    const res = await request.post(`${BASE}/internal/cleanup-sessions`, {
-      headers: { "X-Internal-Key": "wrong-key" },
+test.describe('ttt — cleanup', () => {
+    test('test_cleanup_marks_stale_sessions_abandoned', async ({ request }) => {
+        // Cleanup endpoint requires INTERNAL_API_KEY; without it returns 403
+        const res = await request.post(`${BASE}/internal/cleanup-sessions`, {
+            headers: { 'X-Internal-Key': 'wrong-key' },
+        });
+        expect(res.status()).toBe(403);
     });
-    expect(res.status()).toBe(403);
-  });
 });


### PR DESCRIPTION
## Summary

- Regenerated bcrypt hash in `scripts/seed_test_data.py` to match `demo123` (was `password123`), fixing all auth-dependent nightly E2E tests returning 401
- Fixed 4 stale assertions in `tests/api/api-endpoints.spec.js`:
  - CORS test: adds `Origin` header so server returns CORS response headers
  - Content-Type test: corrects endpoint `/api/games` → `/api/games_list`
  - 404 test: uses `/api/nonexistent-endpoint-xyz` to avoid SPA catch-all
  - Malformed JSON test: adds 422 to accepted status codes (FastAPI validation error)
- Fixed direct `password: 'password123'` login calls in the same file to use `demo123`

## Test plan

- [ ] Trigger `nightly-e2e.yml` manually and verify all three browser jobs (chromium, firefox, webkit) pass
- [ ] `API Endpoints > CORS and Headers > CORS headers are present` — passes with Origin header
- [ ] `API Endpoints > CORS and Headers > Content-Type headers are correct` — passes on `/api/games_list`
- [ ] `API Endpoints > Error Handling > non-existent endpoints return 404` — passes on unambiguous API route
- [ ] `API Endpoints > Error Handling > malformed JSON requests are handled gracefully` — 422 accepted
- [ ] `API Endpoints > Authentication API > POST /api/auth/login with valid credentials` — passes with `demo123`