### PR TITLE
Home landing, Stats route, game shell/AI metadata columns

### DIFF
--- a/features/game-statistics/spec.md
+++ b/features/game-statistics/spec.md
@@ -4,22 +4,21 @@
 
 ## Background
 
-The backend exposes `/api/game/{game_id}/stats` which currently returns hardcoded zeros for all fields
-(`gamesPlayed`, `winRate`, `bestStreak`, `aiLevel`). There is no actual statistics calculation or storage.
-The game-data-persistence feature is the source of truth for raw game records; this feature defines the
-aggregation layer on top of that data.
+The backend exposes `/api/game/{game_id}/stats` which currently returns hardcoded zeros for all fields (`gamesPlayed`,
+`winRate`, `bestStreak`, `aiLevel`). There is no actual statistics calculation or storage. The game-data-persistence
+feature is the source of truth for raw game records; this feature defines the aggregation layer on top of that data.
 
 ## Scope
 
 Implement statistics calculation and exposure for:
-- **Per-game stats** (scoped to one game, one user): games played, win/loss/draw counts, win rate, best win
-  streak, current streak, average game duration
-- **Per-game leaderboards** (all users, one game type): rankings by games played, streak high score, and
-  current streak
 
-All statistics are strictly per-game. No cross-game aggregates or global leaderboards exist in this feature.
-Games are not comparable (TTT takes seconds, chess takes minutes), so we keep them siloed to avoid
-incentivizing users to spam short games.
+- **Per-game stats** (scoped to one game, one user): games played, win/loss/draw counts, win rate, best win streak,
+  current streak, average game duration
+- **Per-game leaderboards** (all users, one game type): rankings by games played, streak high score, and current streak
+
+All statistics are strictly per-game. No cross-game aggregates or global leaderboards exist in this feature. Games are
+not comparable (TTT takes seconds, chess takes minutes), so we keep them siloed to avoid incentivizing users to spam
+short games.
 
 ## Decisions
 
@@ -31,20 +30,19 @@ incentivizing users to spam short games.
 
 Three rules based on context:
 
-| Scenario | Counts as | Affects streak? |
-|----------|-----------|-----------------|
-| Quit while actively playing (close tab, forfeit button, etc.) | Loss | Yes -- breaks streak |
-| Abandon a game < 4 hours old | Loss | Yes -- breaks streak |
-| Abandon a game >= 4 hours old | Tracked separately ("abandoned") | No -- does not break streak |
+| Scenario                                                      | Counts as                        | Affects streak?             |
+| ------------------------------------------------------------- | -------------------------------- | --------------------------- |
+| Quit while actively playing (close tab, forfeit button, etc.) | Loss                             | Yes -- breaks streak        |
+| Abandon a game < 4 hours old                                  | Loss                             | Yes -- breaks streak        |
+| Abandon a game >= 4 hours old                                 | Tracked separately ("abandoned") | No -- does not break streak |
 
-Implementation: the `game_abandoned` boolean is already stored. The 4-hour threshold is determined by
-comparing `NOW() - last_move_at >= 4 hours` (time since last activity, not game duration). "Quit while
-playing" is distinguished by the frontend sending an explicit forfeit action vs. the game timing out on
-the server side.
+Implementation: the `game_abandoned` boolean is already stored. The 4-hour threshold is determined by comparing
+`NOW() - last_move_at >= 4 hours` (time since last activity, not game duration). "Quit while playing" is distinguished
+by the frontend sending an explicit forfeit action vs. the game timing out on the server side.
 
-A "completed game" for stats purposes = `game_ended = true AND NOT (game_abandoned = true AND
-NOW() - last_move_at >= 4 hours)`. Abandoned-old games are excluded from win rate and streak
-calculations but counted in a separate `games_abandoned` field.
+A "completed game" for stats purposes =
+`game_ended = true AND NOT (game_abandoned = true AND NOW() - last_move_at >= 4 hours)`. Abandoned-old games are
+excluded from win rate and streak calculations but counted in a separate `games_abandoned` field.
 
 ### Stats privacy
 
@@ -60,30 +58,30 @@ calculations but counted in a separate `games_abandoned` field.
 
 **Per-game leaderboards only.** Three leaderboard views per game type:
 
-| Leaderboard | Scope | Ranked by |
-|-------------|-------|-----------|
-| Per-Game Games Played | Single game type | Completed games for that type |
-| Per-Game Streak High Score | Single game type | Best all-time win streak for that type |
+| Leaderboard                    | Scope            | Ranked by                               |
+| ------------------------------ | ---------------- | --------------------------------------- |
+| Per-Game Games Played          | Single game type | Completed games for that type           |
+| Per-Game Streak High Score     | Single game type | Best all-time win streak for that type  |
 | Per-Game Current Streak Leader | Single game type | Longest active win streak for that type |
 
-Leaderboards are paginated (default 10 per page). Only users with `stats_public = true` appear.
-A `game_type` query parameter is required for all leaderboard requests.
+Leaderboards are paginated (default 10 per page). Only users with `stats_public = true` appear. A `game_type` query
+parameter is required for all leaderboard requests.
 
 ### Computation strategy
 
-**Compute on-read with server-side caching.** Stats are derived from raw game records via SQL queries.
-Cache results for 60 seconds (same pattern as About page stats). This avoids a separate aggregation
-table for now; if performance becomes an issue, pre-aggregated materialized views can be added later.
+**Compute on-read with server-side caching.** Stats are derived from raw game records via SQL queries. Cache results for
+60 seconds (same pattern as About page stats). This avoids a separate aggregation table for now; if performance becomes
+an issue, pre-aggregated materialized views can be added later.
 
-Streak calculation requires ordering games by `last_move_at` per user per game type, which is
-efficient with the existing `idx_{game_type}_games_user_id` index. Add a composite index on
-`(user_id, last_move_at)` per game table if query plans show sequential scans.
+Streak calculation requires ordering games by `last_move_at` per user per game type, which is efficient with the
+existing `idx_{game_type}_games_user_id` index. Add a composite index on `(user_id, last_move_at)` per game table if
+query plans show sequential scans.
 
 ## Known Requirements
 
 - Depends on game-data-persistence (complete): stats are derived from `{game_type}_games` records
-- The existing `/api/game/{game_id}/stats` stub endpoint is removed and replaced by the consolidated
-  `/api/stats/me` endpoint
+- The existing `/api/game/{game_id}/stats` stub endpoint is removed and replaced by the consolidated `/api/stats/me`
+  endpoint
 - Stats must be scoped to authenticated users; unauthenticated requests return empty/default values
 - Game types without persistence (e.g., Pong) return zeros for all stats fields
 - Stats queries use SQLAlchemy async (AsyncSession) -- consistent with the persistence layer
@@ -93,83 +91,83 @@ efficient with the existing `idx_{game_type}_games_user_id` index. Add a composi
 
 ### 1. `GET /api/stats/me` (new)
 
-Returns per-game stats for the authenticated user. The frontend uses this one endpoint for both the
-profile page (per-game grid) and individual game pages (per-game stats panel), avoiding multiple API
-calls. No auth = empty defaults (zeros).
+Returns per-game stats for the authenticated user. The frontend uses this one endpoint for both the profile page
+(per-game grid) and individual game pages (per-game stats panel), avoiding multiple API calls. No auth = empty defaults
+(zeros).
 
-The `per_game` object includes an entry for every known game type, including those without persistence
-(e.g., Pong). Missing data returns zeros for all fields.
+The `per_game` object includes an entry for every known game type, including those without persistence (e.g., Pong).
+Missing data returns zeros for all fields.
 
 ```json
 {
-  "per_game": {
-    "tic_tac_toe": {
-      "games_played": 42,
-      "wins": 25,
-      "losses": 12,
-      "draws": 3,
-      "games_abandoned": 2,
-      "win_rate": 0.625,
-      "best_streak": 7,
-      "current_streak": 3,
-      "avg_duration_seconds": 184.5
-    },
-    "chess": {
-      "games_played": 30,
-      "wins": 16,
-      "losses": 10,
-      "draws": 2,
-      "games_abandoned": 2,
-      "win_rate": 0.571,
-      "best_streak": 4,
-      "current_streak": 0,
-      "avg_duration_seconds": 420.0
-    },
-    "checkers": {
-      "games_played": 20,
-      "wins": 13,
-      "losses": 5,
-      "draws": 1,
-      "games_abandoned": 1,
-      "win_rate": 0.684,
-      "best_streak": 5,
-      "current_streak": 2,
-      "avg_duration_seconds": 310.0
-    },
-    "connect4": {
-      "games_played": 25,
-      "wins": 18,
-      "losses": 7,
-      "draws": 0,
-      "games_abandoned": 0,
-      "win_rate": 0.72,
-      "best_streak": 11,
-      "current_streak": 3,
-      "avg_duration_seconds": 95.0
-    },
-    "dots_and_boxes": {
-      "games_played": 11,
-      "wins": 5,
-      "losses": 4,
-      "draws": 2,
-      "games_abandoned": 0,
-      "win_rate": 0.455,
-      "best_streak": 3,
-      "current_streak": 0,
-      "avg_duration_seconds": 260.0
-    },
-    "pong": {
-      "games_played": 0,
-      "wins": 0,
-      "losses": 0,
-      "draws": 0,
-      "games_abandoned": 0,
-      "win_rate": 0,
-      "best_streak": 0,
-      "current_streak": 0,
-      "avg_duration_seconds": 0
+    "per_game": {
+        "tic_tac_toe": {
+            "games_played": 42,
+            "wins": 25,
+            "losses": 12,
+            "draws": 3,
+            "games_abandoned": 2,
+            "win_rate": 0.625,
+            "best_streak": 7,
+            "current_streak": 3,
+            "avg_duration_seconds": 184.5
+        },
+        "chess": {
+            "games_played": 30,
+            "wins": 16,
+            "losses": 10,
+            "draws": 2,
+            "games_abandoned": 2,
+            "win_rate": 0.571,
+            "best_streak": 4,
+            "current_streak": 0,
+            "avg_duration_seconds": 420.0
+        },
+        "checkers": {
+            "games_played": 20,
+            "wins": 13,
+            "losses": 5,
+            "draws": 1,
+            "games_abandoned": 1,
+            "win_rate": 0.684,
+            "best_streak": 5,
+            "current_streak": 2,
+            "avg_duration_seconds": 310.0
+        },
+        "connect4": {
+            "games_played": 25,
+            "wins": 18,
+            "losses": 7,
+            "draws": 0,
+            "games_abandoned": 0,
+            "win_rate": 0.72,
+            "best_streak": 11,
+            "current_streak": 3,
+            "avg_duration_seconds": 95.0
+        },
+        "dots_and_boxes": {
+            "games_played": 11,
+            "wins": 5,
+            "losses": 4,
+            "draws": 2,
+            "games_abandoned": 0,
+            "win_rate": 0.455,
+            "best_streak": 3,
+            "current_streak": 0,
+            "avg_duration_seconds": 260.0
+        },
+        "pong": {
+            "games_played": 0,
+            "wins": 0,
+            "losses": 0,
+            "draws": 0,
+            "games_abandoned": 0,
+            "win_rate": 0,
+            "best_streak": 0,
+            "current_streak": 0,
+            "avg_duration_seconds": 0
+        }
     }
-  }
 }
 ```
 
@@ -177,27 +175,26 @@ The existing stub `GET /api/game/{game_id}/stats` is removed.
 
 ### 2. `GET /api/stats/user/{user_id}` (new)
 
-Returns stats for another user. Returns 403 if the target user has `stats_public = false`.
-Same response shape as `/api/stats/me`.
+Returns stats for another user. Returns 403 if the target user has `stats_public = false`. Same response shape as
+`/api/stats/me`.
 
 ### 3. `GET /api/leaderboard/{board_type}` (new)
 
-Returns a paginated per-game leaderboard. Query params: `game_type` (required), `page`,
-`per_page` (default 10, max 50).
+Returns a paginated per-game leaderboard. Query params: `game_type` (required), `page`, `per_page` (default 10, max 50).
 
 `board_type` is one of: `games_played`, `streak_high_score`, `current_streak`.
 
 ```json
 {
-  "board_type": "streak_high_score",
-  "game_type": "chess",
-  "entries": [
-    { "rank": 1, "user_id": 12, "display_name": "Alice", "value": 15 },
-    { "rank": 2, "user_id": 7, "display_name": "Bob", "value": 12 }
-  ],
-  "page": 1,
-  "per_page": 10,
-  "total_entries": 38
+    "board_type": "streak_high_score",
+    "game_type": "chess",
+    "entries": [
+        { "rank": 1, "user_id": 12, "display_name": "Alice", "value": 15 },
+        { "rank": 2, "user_id": 7, "display_name": "Bob", "value": 12 }
+    ],
+    "page": 1,
+    "per_page": 10,
+    "total_entries": 38
 }
 ```
 
@@ -205,32 +202,32 @@ Returns a paginated per-game leaderboard. Query params: `game_type` (required), 
 
 ### Per-game stats panel
 
-Displayed on each game page below the game board (or in a sidebar on desktop). Shows the user's
-stats for that game: games played, win rate, current streak, best streak. The data comes from the
-`per_game` field of the cached `/api/stats/me` response -- no separate API call needed.
+Displayed on each game page below the game board (or in a sidebar on desktop). Shows the user's stats for that game:
+games played, win rate, current streak, best streak. The data comes from the `per_game` field of the cached
+`/api/stats/me` response -- no separate API call needed.
 
 ### Profile stats section
 
-On the profile page, show a per-game breakdown grid from `/api/stats/me`. Each game type gets a
-mini card showing games played, win rate, and best streak.
+On the profile page, show a per-game breakdown grid from `/api/stats/me`. Each game type gets a mini card showing games
+played, win rate, and best streak.
 
-### Leaderboard page
+### Stats page (public rankings)
 
-New route: `/leaderboard`. Tabbed interface for the 3 board types (games played, streak high score,
-current streak). Each tab has a dropdown to select the game type. A `game_type` is always required.
-Paginated table with rank, display name, and value.
+Primary route: `/stats` (nav label **Stats**). Legacy `/leaderboard` redirects to `/stats`. Tabbed interface for the 3
+board types (games played, streak high score, current streak). Each tab has a dropdown to select the game type. A
+`game_type` is always required. Paginated table with rank, display name, and value.
 
 ### Settings toggle
 
-Add a "Public stats" toggle to the Settings page. Create a new `PATCH /api/auth/settings` endpoint
-(no existing settings endpoint exists). The endpoint lives in `auth.py` for organizational consistency
-with other user/account routes.
+Add a "Public stats" toggle to the Settings page. Create a new `PATCH /api/auth/settings` endpoint (no existing settings
+endpoint exists). The endpoint lives in `auth.py` for organizational consistency with other user/account routes.
 
 ## Database Changes
 
 ### Users table
 
 Add column:
+
 ```sql
 ALTER TABLE users ADD COLUMN stats_public BOOLEAN NOT NULL DEFAULT false;
 ```
@@ -238,6 +235,7 @@ ALTER TABLE users ADD COLUMN stats_public BOOLEAN NOT NULL DEFAULT false;
 ### Indexes (if needed for performance)
 
 Add composite indexes per game table:
+
 ```sql
 CREATE INDEX idx_{game_type}_games_user_completed
   ON {game_type}_games (user_id, last_move_at)
@@ -246,42 +244,42 @@ CREATE INDEX idx_{game_type}_games_user_completed
 
 ## Files to Create/Modify
 
-| Action | File |
-|--------|------|
-| Create | `src/backend/auth_deps.py` -- shared auth dependencies (require_user, optional_user) |
-| Create | `src/backend/stats.py` -- stats router with stats + leaderboard endpoints |
-| Create | `scripts/migrations/versions/0005_add_stats_public_column.py` -- migration |
-| Create | `src/frontend/src/api/stats.ts` -- API fetch functions |
-| Create | `src/frontend/src/pages/LeaderboardPage.tsx` -- leaderboard page |
-| Create | `src/frontend/src/components/games/GameStatsPanel.tsx` -- per-game stats component |
-| Modify | `src/backend/app.py` -- register stats router |
-| Modify | `src/backend/auth.py` -- remove stats stub, add PATCH settings, add statsPublic to /me |
+| Action | File                                                                                      |
+| ------ | ----------------------------------------------------------------------------------------- |
+| Create | `src/backend/auth_deps.py` -- shared auth dependencies (require_user, optional_user)      |
+| Create | `src/backend/stats.py` -- stats router with stats + leaderboard endpoints                 |
+| Create | `scripts/migrations/versions/0005_add_stats_public_column.py` -- migration                |
+| Create | `src/frontend/src/api/stats.ts` -- API fetch functions                                    |
+| Create | `src/frontend/src/pages/StatsPage.tsx` -- public rankings page                            |
+| Create | `src/frontend/src/components/games/GameStatsPanel.tsx` -- per-game stats component        |
+| Modify | `src/backend/app.py` -- register stats router                                             |
+| Modify | `src/backend/auth.py` -- remove stats stub, add PATCH settings, add statsPublic to /me    |
 | Modify | `src/backend/games.py` -- remove existing `/api/game/{game_id}/stats` stub, use auth_deps |
-| Modify | `src/frontend/src/types/index.ts` -- add stats types |
-| Modify | `src/frontend/src/App.tsx` -- add `/leaderboard` route |
-| Modify | `src/frontend/src/components/Navbar.tsx` -- add Leaderboard nav link |
-| Modify | `src/frontend/src/pages/ProfilePage.tsx` -- add per-game stats grid |
-| Modify | `src/frontend/src/pages/SettingsPage.tsx` -- add stats_public toggle |
-| Modify | All game page components -- add `<GameStatsPanel>` |
+| Modify | `src/frontend/src/types/index.ts` -- add stats types                                      |
+| Modify | `src/frontend/src/App.tsx` -- add `/stats` route; redirect `/leaderboard` to `/stats`     |
+| Modify | `src/frontend/src/components/Navbar.tsx` -- add Stats nav link                            |
+| Modify | `src/frontend/src/pages/ProfilePage.tsx` -- add per-game stats grid                       |
+| Modify | `src/frontend/src/pages/SettingsPage.tsx` -- add stats_public toggle                      |
+| Modify | All game page components -- add `<GameStatsPanel>`                                        |
 
 ## Test Cases
 
-| Tier | Name | What it checks |
-|------|------|----------------|
-| API integration | `GET /api/stats/me returns per-game stats` | Authenticated user gets per_game map with correct types |
-| API integration | `GET /api/stats/me returns zeros when unauthenticated` | No auth returns zeros for all fields |
-| API integration | `GET /api/stats/me includes all game types` | Response per_game object has entries for every known game type, including those without persistence (zeros) |
-| API integration | `GET /api/stats/user/{id} respects privacy toggle` | Returns 403 when target user has stats_public=false; 200 when true |
-| API integration | `GET /api/leaderboard/{type} returns paginated results` | Entries sorted correctly; pagination params work; only public users included |
-| API integration | `GET /api/leaderboard/{type} requires game_type` | Returns 400 when game_type query param is missing |
-| API integration | `PATCH /api/auth/settings updates stats_public` | Toggle on/off, verify /me reflects change |
-| Unit | `streak calculation handles consecutive wins` | Streak of 5 wins returns 5; loss after 5 wins resets to 0 |
-| Unit | `streak ignores old abandoned games` | Game abandoned after 4+ hours does not break streak |
-| Unit | `recent abandoned game counts as loss` | Game abandoned under 4 hours breaks streak and counts as loss |
-| Unit | `win rate excludes old abandoned games` | Old abandoned games excluded from win rate denominator |
-| E2E | `Game page shows stats panel after playing` | Play a game, verify stats panel updates with new game count |
-| E2E | `Profile page shows per-game stats` | Navigate to profile, verify per-game grid displays |
-| E2E | `Leaderboard page loads with game selector` | Navigate to /leaderboard, select game, verify table renders |
-| E2E | `Stats privacy toggle works` | Toggle stats_public in settings, verify other user can/cannot see stats |
-| Manual | `Leaderboard only shows public users` | Create users with different privacy settings, verify leaderboard filtering |
-| Manual | `Stats are accurate after multiple games` | Play several games across types, verify all numbers match expected values |
+| Tier            | Name                                                    | What it checks                                                                                              |
+| --------------- | ------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| API integration | `GET /api/stats/me returns per-game stats`              | Authenticated user gets per_game map with correct types                                                     |
+| API integration | `GET /api/stats/me returns zeros when unauthenticated`  | No auth returns zeros for all fields                                                                        |
+| API integration | `GET /api/stats/me includes all game types`             | Response per_game object has entries for every known game type, including those without persistence (zeros) |
+| API integration | `GET /api/stats/user/{id} respects privacy toggle`      | Returns 403 when target user has stats_public=false; 200 when true                                          |
+| API integration | `GET /api/leaderboard/{type} returns paginated results` | Entries sorted correctly; pagination params work; only public users included                                |
+| API integration | `GET /api/leaderboard/{type} requires game_type`        | Returns 400 when game_type query param is missing                                                           |
+| API integration | `PATCH /api/auth/settings updates stats_public`         | Toggle on/off, verify /me reflects change                                                                   |
+| Unit            | `streak calculation handles consecutive wins`           | Streak of 5 wins returns 5; loss after 5 wins resets to 0                                                   |
+| Unit            | `streak ignores old abandoned games`                    | Game abandoned after 4+ hours does not break streak                                                         |
+| Unit            | `recent abandoned game counts as loss`                  | Game abandoned under 4 hours breaks streak and counts as loss                                               |
+| Unit            | `win rate excludes old abandoned games`                 | Old abandoned games excluded from win rate denominator                                                      |
+| E2E             | `Game page shows stats panel after playing`             | Play a game, verify stats panel updates with new game count                                                 |
+| E2E             | `Profile page shows per-game stats`                     | Navigate to profile, verify per-game grid displays                                                          |
+| E2E             | `Stats page loads with game selector`                   | Navigate to /stats, select game, verify table renders                                                       |
+| E2E             | `Stats privacy toggle works`                            | Toggle stats_public in settings, verify other user can/cannot see stats                                     |
+| Manual          | `Leaderboard only shows public users`                   | Create users with different privacy settings, verify leaderboard filtering                                  |
+| Manual          | `Stats are accurate after multiple games`               | Play several games across types, verify all numbers match expected values                                   |

--- a/features/home-landing-navigation/spec.md
+++ b/features/home-landing-navigation/spec.md
@@ -1,0 +1,57 @@
+# Home Landing and Navigation
+
+**Status: implemented**
+
+## Goal
+
+The home page should orient new and returning users immediately: active games, live platform statistics, and clear paths
+to the catalog (`/games`), public rankings (`/stats`), about, and account areas. DB-backed sections use skeleton
+placeholders until data arrives.
+
+## Scope
+
+- Home (`/`): hero, active games grid (from `GET /api/games_list?category=active`), platform stats (from
+  `GET /api/about/stats`), and a compact site map with links.
+- Games catalog (`/games`): detailed cards via shared `GameSummaryCard`; cross-links to home and stats.
+- Public rankings: primary route `/stats` (nav label **Stats**); legacy `/leaderboard` redirects to `/stats`.
+- Footer: include Stats alongside Home, Games, About.
+- Loading UX: shimmer-style skeletons for games grids, stats grids, stats table, profile auth loading, games list fetch,
+  and per-game `GameStatsPanel` while `/api/stats/me` loads (not spinner-only for these surfaces).
+
+## Game metadata (database)
+
+The `games` table exposes explicit columns instead of overloading `tags`:
+
+| Column                | Type    | Meaning                                                             |
+| --------------------- | ------- | ------------------------------------------------------------------- |
+| `game_shell_ready`    | BOOLEAN | Client route and game loop are wired (false e.g. for Pong stub).    |
+| `ai_model_integrated` | BOOLEAN | Adaptive / trained model is connected (true for Tic Tac Toe today). |
+
+`GET /api/games_list` and `GET /api/game/{id}/info` include these fields. Free-form `tags` remains for display labels
+(Strategy, Quick Play, etc.).
+
+### UI rules
+
+- `game_shell_ready === false`: show **Not available yet** (neutral outline). Difficulty is not shown as meaningful AI
+  difficulty.
+- `game_shell_ready && !ai_model_integrated`: show **No trained AI yet** (warning outline) and **AI Difficulty: …** with
+  tooltip that the value is a placeholder until a model ships.
+- `ai_model_integrated`: show **AI Difficulty: …** only.
+
+## Out of scope
+
+- Multiplayer or PvP.
+- Vote-based moves (possible future; not part of this spec).
+
+## Test Cases
+
+| Tier            | Name                                                         | What it checks                                             |
+| --------------- | ------------------------------------------------------------ | ---------------------------------------------------------- |
+| Unit            | `HomePage shows primary navigation links`                    | Hero links include `/games` and `/stats`.                  |
+| Unit            | `StatsPage renders rankings heading`                         | H1 reads Stats; table loads from MSW.                      |
+| Unit            | `Navbar includes Stats link`                                 | Visible link text targets `/stats`.                        |
+| Unit            | `games api returns game_shell_ready and ai_model_integrated` | MSW games include new fields.                              |
+| Unit            | `GameInfo pydantic includes shell and AI flags`              | `tests/unit/test_models.py` constructs valid `GameInfo`.   |
+| Unit            | `GameSummaryCard reflects shell and AI flags`                | Warning vs neutral badges from `GameSummaryCard.test.tsx`. |
+| API integration | (existing) `GET /api/games_list`                             | Response games include boolean flags after migration.      |
+| Manual          | `GET /leaderboard` in browser                                | Old bookmark redirects to `/stats`.                        |

--- a/features/home-landing-navigation/spec.md
+++ b/features/home-landing-navigation/spec.md
@@ -54,4 +54,5 @@ The `games` table exposes explicit columns instead of overloading `tags`:
 | Unit            | `GameInfo pydantic includes shell and AI flags`              | `tests/unit/test_models.py` constructs valid `GameInfo`.   |
 | Unit            | `GameSummaryCard reflects shell and AI flags`                | Warning vs neutral badges from `GameSummaryCard.test.tsx`. |
 | API integration | (existing) `GET /api/games_list`                             | Response games include boolean flags after migration.      |
+| E2E             | `smoke homepage shows All games and Public stats links`      | `tests/smoke/routes.spec.js` asserts hero CTAs.            |
 | Manual          | `GET /leaderboard` in browser                                | Old bookmark redirects to `/stats`.                        |

--- a/scripts/migrations/versions/0006_game_shell_ai_columns.py
+++ b/scripts/migrations/versions/0006_game_shell_ai_columns.py
@@ -1,0 +1,66 @@
+"""Add game_shell_ready and ai_model_integrated to games
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-04-11
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0006"
+down_revision: Union[str, None] = "0005"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "games",
+        sa.Column(
+            "game_shell_ready",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+    op.add_column(
+        "games",
+        sa.Column(
+            "ai_model_integrated",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    op.execute("""
+        UPDATE games SET
+            game_shell_ready = CASE id
+                WHEN 'pong' THEN false
+                ELSE true
+            END,
+            ai_model_integrated = CASE id
+                WHEN 'tic-tac-toe' THEN true
+                ELSE false
+            END
+    """)
+    op.execute("""
+        UPDATE games SET tags = CASE id
+            WHEN 'tic-tac-toe' THEN ARRAY['Strategy', 'Quick Play']::text[]
+            WHEN 'connect4' THEN ARRAY['Strategy']::text[]
+            WHEN 'dots-and-boxes' THEN ARRAY['Strategy', 'Territory']::text[]
+            WHEN 'chess' THEN ARRAY['Strategy']::text[]
+            WHEN 'checkers' THEN ARRAY['Strategy', 'Classic']::text[]
+            WHEN 'pong' THEN ARRAY['Arcade', 'Classic']::text[]
+            ELSE tags
+        END
+    """)
+    op.alter_column("games", "game_shell_ready", server_default=None)
+    op.alter_column("games", "ai_model_integrated", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("games", "ai_model_integrated")
+    op.drop_column("games", "game_shell_ready")

--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -123,7 +123,7 @@ async def health_check():
 
 
 
-INDEXABLE_PATHS = ["/", "/games", "/about", "/leaderboard"]
+INDEXABLE_PATHS = ["/", "/games", "/about", "/stats"]
 
 
 @app.get("/robots.txt")

--- a/src/backend/games.py
+++ b/src/backend/games.py
@@ -1433,7 +1433,8 @@ async def get_games(category: Optional[str] = None, status: Optional[str] = None
     """Return a list of all games, optionally filtered by category and/or status."""
     async with get_session() as session:
         query = (
-            "SELECT id, name, description, icon, difficulty, players, status, category, tags"
+            "SELECT id, name, description, icon, difficulty, players, status, category, tags,"
+            " game_shell_ready, ai_model_integrated"
             " FROM games WHERE 1=1"
         )
         params: dict = {}
@@ -1457,6 +1458,8 @@ async def get_games(category: Optional[str] = None, status: Optional[str] = None
             "status": r[6],
             "category": r[7],
             "tags": r[8],
+            "game_shell_ready": r[9],
+            "ai_model_integrated": r[10],
         }
         for r in rows
     ]
@@ -1469,7 +1472,8 @@ async def get_game_info(game_id: str):
     async with get_session() as session:
         result = await session.execute(
             text(
-                "SELECT id, name, description, icon, difficulty, players, status, category, tags"
+                "SELECT id, name, description, icon, difficulty, players, status, category, tags,"
+                " game_shell_ready, ai_model_integrated"
                 " FROM games WHERE id = :id"
             ),
             {"id": game_id},
@@ -1490,6 +1494,8 @@ async def get_game_info(game_id: str):
             "status": row[6],
             "category": row[7],
             "tags": row[8],
+            "game_shell_ready": row[9],
+            "ai_model_integrated": row[10],
         }
     }
 

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -15,6 +15,8 @@ class GameInfo(BaseModel):
     status: str
     category: str
     tags: List[str]
+    game_shell_ready: bool
+    ai_model_integrated: bool
 
 class MoveRequest(BaseModel):
     """Generic request body for the game end/forfeit endpoint."""

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { BrowserRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { BrowserRouter, Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import ErrorBoundary from './components/ErrorBoundary';
 import Layout from './components/Layout';
 import NotificationRenderer from './components/NotificationRenderer';
@@ -8,7 +8,7 @@ import { useNotificationStore } from './store/notifications';
 import AboutPage from './pages/AboutPage';
 import GamesPage from './pages/GamesPage';
 import HomePage from './pages/HomePage';
-import LeaderboardPage from './pages/LeaderboardPage';
+import StatsPage from './pages/StatsPage';
 import NotFoundPage from './pages/NotFoundPage';
 import ProfilePage from './pages/ProfilePage';
 import SettingsPage from './pages/SettingsPage';
@@ -88,13 +88,14 @@ export default function App() {
                         }
                     />
                     <Route
-                        path='/leaderboard'
+                        path='/stats'
                         element={
                             <ErrorBoundary>
-                                <LeaderboardPage />
+                                <StatsPage />
                             </ErrorBoundary>
                         }
                     />
+                    <Route path='/leaderboard' element={<Navigate to='/stats' replace />} />
                     <Route
                         path='/settings'
                         element={

--- a/src/frontend/src/components/AboutPlatformStats.tsx
+++ b/src/frontend/src/components/AboutPlatformStats.tsx
@@ -1,0 +1,47 @@
+import { useCountUp } from '../hooks/useCountUp';
+
+function StatCard({ value, label, isFloat }: { value: number; label: string; isFloat?: boolean }) {
+    const animated = useCountUp(value);
+    const display = isFloat ? `${(animated * 100).toFixed(1)}%` : animated.toLocaleString();
+
+    return (
+        <div className='card bg-base-200 shadow-sm'>
+            <div className='card-body items-center p-4 text-center'>
+                <span className='text-3xl font-bold text-primary'>{display}</span>
+                <span className='text-sm opacity-70'>{label}</span>
+            </div>
+        </div>
+    );
+}
+
+export type AboutPlatformStatsProps = {
+    gamesPlayed: number;
+    movesAnalyzed: number;
+    uniquePlayers: number;
+    aiWinRate: number;
+    trainingMoves: number;
+    daysRunning: number;
+};
+
+/**
+ * Live platform statistics grid shared by the home and about pages.
+ */
+export default function AboutPlatformStats({
+    gamesPlayed,
+    movesAnalyzed,
+    uniquePlayers,
+    aiWinRate,
+    trainingMoves,
+    daysRunning,
+}: AboutPlatformStatsProps) {
+    return (
+        <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
+            <StatCard value={gamesPlayed} label='Games Played' />
+            <StatCard value={movesAnalyzed} label='Moves Analyzed' />
+            <StatCard value={uniquePlayers} label='Players' />
+            <StatCard value={aiWinRate} label='AI Win Rate' isFloat />
+            <StatCard value={trainingMoves} label='Training Moves' />
+            <StatCard value={daysRunning} label='Days Running' />
+        </div>
+    );
+}

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -16,6 +16,9 @@ export default function Footer() {
                 <Link to='/about' className='link link-hover'>
                     About
                 </Link>
+                <Link to='/stats' className='link link-hover'>
+                    Stats
+                </Link>
             </nav>
             <p className='text-sm opacity-60'>&copy; {new Date().getFullYear()} AI Game Hub</p>
         </footer>

--- a/src/frontend/src/components/Navbar.test.tsx
+++ b/src/frontend/src/components/Navbar.test.tsx
@@ -9,7 +9,7 @@ describe('Navbar', () => {
         expect(screen.getAllByText('Home').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('Games').length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText('About').length).toBeGreaterThanOrEqual(1);
-        expect(screen.getAllByText('Leaderboard').length).toBeGreaterThanOrEqual(1);
+        expect(screen.getAllByText('Stats').length).toBeGreaterThanOrEqual(1);
     });
 
     it('renders brand link', () => {

--- a/src/frontend/src/components/Navbar.tsx
+++ b/src/frontend/src/components/Navbar.tsx
@@ -57,7 +57,7 @@ export default function Navbar() {
                                 <Link to='/about'>About</Link>
                             </li>
                             <li>
-                                <Link to='/leaderboard'>Leaderboard</Link>
+                                <Link to='/stats'>Stats</Link>
                             </li>
                         </ul>
                     </div>
@@ -78,7 +78,7 @@ export default function Navbar() {
                             <Link to='/about'>About</Link>
                         </li>
                         <li>
-                            <Link to='/leaderboard'>Leaderboard</Link>
+                            <Link to='/stats'>Stats</Link>
                         </li>
                     </ul>
                 </div>

--- a/src/frontend/src/components/Skeleton.tsx
+++ b/src/frontend/src/components/Skeleton.tsx
@@ -1,0 +1,43 @@
+/**
+ * Block placeholder for loading states. Uses DaisyUI `skeleton` styling.
+ */
+export function SkeletonBlock({ className = '' }: { className?: string }) {
+    return <div className={`skeleton ${className}`.trim()} />;
+}
+
+/**
+ * A row of shimmering blocks sized for compact stat summaries.
+ */
+export function StatGridSkeleton({ count = 4 }: { count?: number }) {
+    return (
+        <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
+            {Array.from({ length: count }).map((_, i) => (
+                <SkeletonBlock key={i} className='h-24 w-full rounded-box' />
+            ))}
+        </div>
+    );
+}
+
+/**
+ * Placeholder cards for game grids while the games list loads.
+ */
+export function GameCardGridSkeleton({ cards = 6 }: { cards?: number }) {
+    return (
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+            {Array.from({ length: cards }).map((_, i) => (
+                <div key={i} className='card bg-base-200 shadow-md'>
+                    <div className='card-body gap-3'>
+                        <SkeletonBlock className='h-10 w-10 rounded-lg' />
+                        <SkeletonBlock className='h-6 w-2/3' />
+                        <SkeletonBlock className='h-4 w-full' />
+                        <SkeletonBlock className='h-4 w-5/6' />
+                        <div className='mt-2 flex flex-wrap gap-2'>
+                            <SkeletonBlock className='h-6 w-20 rounded-full' />
+                            <SkeletonBlock className='h-6 w-24 rounded-full' />
+                        </div>
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/src/frontend/src/components/games/GameStatsPanel.tsx
+++ b/src/frontend/src/components/games/GameStatsPanel.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchMyStats } from '../../api/stats';
+import { SkeletonBlock } from '../Skeleton';
 import type { GameStats } from '../../types';
 
 const STATS_QUERY_KEY = ['myStats'] as const;
@@ -25,8 +26,15 @@ export default function GameStatsPanel({ gameType }: { gameType: string }) {
 
     if (isLoading) {
         return (
-            <div className='mt-4 flex justify-center'>
-                <span className='loading loading-dots loading-sm' />
+            <div className='card bg-base-200 mt-4'>
+                <div className='card-body gap-3 p-4'>
+                    <SkeletonBlock className='h-4 w-24' />
+                    <div className='grid grid-cols-4 gap-2'>
+                        {Array.from({ length: 4 }).map((_, i) => (
+                            <SkeletonBlock key={i} className='mx-auto h-10 w-full max-w-[4.5rem]' />
+                        ))}
+                    </div>
+                </div>
             </div>
         );
     }

--- a/src/frontend/src/components/games/GameSummaryCard.test.tsx
+++ b/src/frontend/src/components/games/GameSummaryCard.test.tsx
@@ -1,0 +1,31 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../test-utils';
+import GameSummaryCard from './GameSummaryCard';
+
+const baseGame = {
+    id: 'chess',
+    name: 'Chess',
+    description: 'A strategy game',
+    icon: '♟️',
+    difficulty: 'Hard',
+    players: 1,
+    status: 'active',
+    category: 'strategy',
+    tags: ['Strategy'],
+    game_shell_ready: true,
+    ai_model_integrated: false,
+};
+
+describe('GameSummaryCard', () => {
+    it('shows no trained AI when model is not integrated', () => {
+        renderWithProviders(<GameSummaryCard game={baseGame} />);
+        expect(screen.getByText(/no trained ai yet/i)).toBeInTheDocument();
+        expect(screen.getByText(/ai difficulty: hard/i)).toBeInTheDocument();
+    });
+
+    it('shows not available when shell is not ready', () => {
+        renderWithProviders(<GameSummaryCard game={{ ...baseGame, id: 'pong', game_shell_ready: false }} />);
+        expect(screen.getByText(/not available yet/i)).toBeInTheDocument();
+    });
+});

--- a/src/frontend/src/components/games/GameSummaryCard.tsx
+++ b/src/frontend/src/components/games/GameSummaryCard.tsx
@@ -1,0 +1,60 @@
+import { Link } from 'react-router-dom';
+import type { Game } from '../../types';
+import { GAME_ROUTES } from '../../gameRoutes';
+
+export type GameSummaryCardProps = {
+    game: Game;
+    compact?: boolean;
+};
+
+/**
+ * Clickable game summary used on the home page and anywhere a short game preview is needed.
+ */
+export default function GameSummaryCard({ game, compact = false }: GameSummaryCardProps) {
+    const href = GAME_ROUTES[game.id] ?? `/game/${game.id}`;
+    const playable = game.game_shell_ready;
+    const hasAi = game.ai_model_integrated;
+
+    return (
+        <Link to={href} className='card bg-base-200 shadow-md transition-shadow hover:shadow-xl'>
+            <div className={`card-body ${compact ? 'gap-2 p-4' : ''}`}>
+                <div className='text-3xl'>{game.icon}</div>
+                <h2 className={`card-title ${compact ? 'text-lg' : ''}`}>{game.name}</h2>
+                <p
+                    className={`text-sm opacity-70 ${compact ? 'truncate' : ''}`.trim()}
+                    title={compact ? game.description : undefined}>
+                    {game.description}
+                </p>
+                <div className='card-actions mt-1 flex flex-wrap gap-2'>
+                    {!playable && (
+                        <div
+                            className='badge badge-neutral badge-outline'
+                            title='This game is not wired up in the client yet.'>
+                            Not available yet
+                        </div>
+                    )}
+                    {playable && !hasAi && (
+                        <>
+                            <div
+                                className='badge badge-warning badge-outline'
+                                title='You can open the game, but no adaptive model is connected yet.'>
+                                No trained AI yet
+                            </div>
+                            <div
+                                className='badge badge-outline'
+                                title='Heuristic placeholder only until the adaptive model is connected.'>
+                                AI Difficulty: {game.difficulty}
+                            </div>
+                        </>
+                    )}
+                    {playable && hasAi && <div className='badge badge-outline'>AI Difficulty: {game.difficulty}</div>}
+                    {game.tags.slice(0, compact ? 2 : 4).map(tag => (
+                        <div key={tag} className='badge badge-ghost badge-sm'>
+                            {tag}
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </Link>
+    );
+}

--- a/src/frontend/src/gameRoutes.ts
+++ b/src/frontend/src/gameRoutes.ts
@@ -1,0 +1,8 @@
+export const GAME_ROUTES: Record<string, string> = {
+    'tic-tac-toe': '/game/tic-tac-toe',
+    chess: '/game/chess',
+    checkers: '/game/checkers',
+    connect4: '/game/connect4',
+    'dots-and-boxes': '/game/dots-and-boxes',
+    pong: '/game/pong',
+};

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -120,6 +120,8 @@ export const handlers = [
                     status: 'active',
                     category: 'strategy',
                     tags: ['classic'],
+                    game_shell_ready: true,
+                    ai_model_integrated: true,
                 },
                 {
                     id: 'chess',
@@ -131,6 +133,8 @@ export const handlers = [
                     status: 'active',
                     category: 'strategy',
                     tags: ['classic'],
+                    game_shell_ready: true,
+                    ai_model_integrated: false,
                 },
             ],
         });

--- a/src/frontend/src/pages/AboutPage.tsx
+++ b/src/frontend/src/pages/AboutPage.tsx
@@ -1,8 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { fetchAboutStats } from '../api/about';
-import { useCountUp } from '../hooks/useCountUp';
+import AboutPlatformStats from '../components/AboutPlatformStats';
 import PageMeta from '../components/PageMeta';
+import { StatGridSkeleton } from '../components/Skeleton';
+import { useCountUp } from '../hooks/useCountUp';
 
 const DONATE_URLS = {
     buyMeACoffee: 'https://buymeacoffee.com/',
@@ -33,14 +36,12 @@ function seededRandom(seed: number): number {
     return x - Math.floor(x);
 }
 
-function StatCard({ value, label, isFloat }: { value: number; label: string; isFloat?: boolean }) {
+function PlaceholderStatCard({ value, label }: { value: number; label: string }) {
     const animated = useCountUp(value);
-    const display = isFloat ? `${(animated * 100).toFixed(1)}%` : animated.toLocaleString();
-
     return (
         <div className='card bg-base-200 shadow-sm'>
             <div className='card-body items-center p-4 text-center'>
-                <span className='text-3xl font-bold text-primary'>{display}</span>
+                <span className='text-3xl font-bold text-primary'>{animated.toLocaleString()}</span>
                 <span className='text-sm opacity-70'>{label}</span>
             </div>
         </div>
@@ -49,7 +50,11 @@ function StatCard({ value, label, isFloat }: { value: number; label: string; isF
 
 /** Renders the About page with live platform stats, team section, and donation links. */
 export default function AboutPage() {
-    const { data: stats } = useQuery({
+    const {
+        data: stats,
+        isLoading,
+        isError,
+    } = useQuery({
         queryKey: ['about-stats'],
         queryFn: fetchAboutStats,
         staleTime: 60_000,
@@ -80,17 +85,30 @@ export default function AboutPage() {
             </p>
 
             <section className='mb-12'>
-                <h2 className='mb-4 text-2xl font-semibold'>Platform Stats</h2>
-                <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
-                    <StatCard value={stats?.games_played ?? 0} label='Games Played' />
-                    <StatCard value={stats?.moves_analyzed ?? 0} label='Moves Analyzed' />
-                    <StatCard value={stats?.unique_players ?? 0} label='Players' />
-                    <StatCard value={stats?.ai_win_rate ?? 0} label='AI Win Rate' isFloat />
-                    <StatCard value={stats?.training_moves ?? 0} label='Training Moves' />
-                    <StatCard value={stats?.days_running ?? 0} label='Days Running' />
-                    <StatCard value={placeholders.aiIterations} label='AI Iterations' />
-                    <StatCard value={placeholders.bugsSquashed} label='Bugs Squashed' />
+                <div className='mb-4 flex flex-wrap items-end justify-between gap-4'>
+                    <h2 className='text-2xl font-semibold'>Platform Stats</h2>
+                    <Link to='/stats' className='link link-primary text-sm'>
+                        Public rankings
+                    </Link>
                 </div>
+                {isLoading && <StatGridSkeleton count={8} />}
+                {isError && <p className='text-error'>Could not load platform statistics.</p>}
+                {stats && (
+                    <div className='space-y-4'>
+                        <AboutPlatformStats
+                            gamesPlayed={stats.games_played}
+                            movesAnalyzed={stats.moves_analyzed}
+                            uniquePlayers={stats.unique_players}
+                            aiWinRate={stats.ai_win_rate}
+                            trainingMoves={stats.training_moves}
+                            daysRunning={stats.days_running}
+                        />
+                        <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
+                            <PlaceholderStatCard value={placeholders.aiIterations} label='AI Iterations' />
+                            <PlaceholderStatCard value={placeholders.bugsSquashed} label='Bugs Squashed' />
+                        </div>
+                    </div>
+                )}
             </section>
 
             <section className='mb-12'>

--- a/src/frontend/src/pages/GamesPage.tsx
+++ b/src/frontend/src/pages/GamesPage.tsx
@@ -1,17 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
 import { fetchGames } from '../api/games';
-import type { Game } from '../types';
+import GameSummaryCard from '../components/games/GameSummaryCard';
 import PageMeta from '../components/PageMeta';
-
-const GAME_ROUTES: Record<string, string> = {
-    'tic-tac-toe': '/game/tic-tac-toe',
-    chess: '/game/chess',
-    checkers: '/game/checkers',
-    connect4: '/game/connect4',
-    'dots-and-boxes': '/game/dots-and-boxes',
-    pong: '/game/pong',
-};
+import { GameCardGridSkeleton } from '../components/Skeleton';
+import type { Game } from '../types';
 
 const PLACEHOLDER_GAMES: Game[] = [
     {
@@ -20,10 +13,12 @@ const PLACEHOLDER_GAMES: Game[] = [
         description: 'Classic 3x3 grid game with adaptive AI opponent that learns your strategies',
         icon: '⭕',
         difficulty: 'Very Easy',
-        players: '1',
+        players: 1,
         status: 'active',
         category: 'strategy',
-        tags: ['Strategy', '1 Player', 'Quick Play'],
+        tags: ['Strategy', 'Quick Play'],
+        game_shell_ready: true,
+        ai_model_integrated: true,
     },
     {
         id: 'connect4',
@@ -31,10 +26,12 @@ const PLACEHOLDER_GAMES: Game[] = [
         description: 'Drop pieces to connect four in a row - vertically, horizontally, or diagonally',
         icon: '🔴',
         difficulty: 'Very Easy',
-        players: '1',
+        players: 1,
         status: 'active',
         category: 'strategy',
-        tags: ['Strategy', '1 Player', 'Coming Soon'],
+        tags: ['Strategy'],
+        game_shell_ready: true,
+        ai_model_integrated: false,
     },
     {
         id: 'dots-and-boxes',
@@ -42,10 +39,12 @@ const PLACEHOLDER_GAMES: Game[] = [
         description: 'Connect dots to complete boxes and claim territory in this strategic paper game',
         icon: '⬜',
         difficulty: 'Very Easy',
-        players: '1',
+        players: 1,
         status: 'active',
         category: 'strategy',
-        tags: ['Strategy', '1 Player', 'Coming Soon'],
+        tags: ['Strategy', 'Territory'],
+        game_shell_ready: true,
+        ai_model_integrated: false,
     },
     {
         id: 'chess',
@@ -53,10 +52,12 @@ const PLACEHOLDER_GAMES: Game[] = [
         description: 'Chess with AI that learns your playing style and adapts its strategy',
         icon: '♟️',
         difficulty: 'Very Easy',
-        players: '1',
+        players: 1,
         status: 'active',
         category: 'strategy',
-        tags: ['Strategy', '1 Player', 'Coming Soon'],
+        tags: ['Strategy'],
+        game_shell_ready: true,
+        ai_model_integrated: false,
     },
     {
         id: 'checkers',
@@ -64,10 +65,12 @@ const PLACEHOLDER_GAMES: Game[] = [
         description: 'Classic checkers with an AI that adapts to your tactical preferences',
         icon: '⚫',
         difficulty: 'Very Easy',
-        players: '1',
+        players: 1,
         status: 'active',
         category: 'strategy',
-        tags: ['Strategy', '1 Player', 'Coming Soon'],
+        tags: ['Strategy', 'Classic'],
+        game_shell_ready: true,
+        ai_model_integrated: false,
     },
     {
         id: 'pong',
@@ -75,10 +78,12 @@ const PLACEHOLDER_GAMES: Game[] = [
         description: 'Classic pong game, popularized by Atari',
         icon: '🕹️',
         difficulty: 'Very Easy',
-        players: '1',
+        players: 1,
         status: 'active',
         category: 'arcade',
-        tags: ['Arcade', '1 Player', 'Coming Soon'],
+        tags: ['Arcade', 'Classic'],
+        game_shell_ready: false,
+        ai_model_integrated: false,
     },
 ];
 
@@ -87,47 +92,45 @@ const PLACEHOLDER_GAMES: Game[] = [
  * Falls back to PLACEHOLDER_GAMES if the API returns an empty list.
  */
 export default function GamesPage() {
-    const { data: apiGames, isLoading } = useQuery({
+    const {
+        data: apiGames,
+        isLoading,
+        isError,
+    } = useQuery({
         queryKey: ['games'],
         queryFn: () => fetchGames(),
     });
     const games = apiGames?.length ? apiGames : PLACEHOLDER_GAMES;
 
     return (
-        <div className='container mx-auto px-4 py-10'>
+        <div className='container mx-auto max-w-6xl px-4 py-10'>
             <PageMeta
                 title='Games'
                 description='Browse all available games -- from Tic Tac Toe to Chess, each with an adaptive AI opponent.'
                 ogImage='/images/og/og-games.png'
             />
-            <h1 className='mb-8 text-4xl font-bold'>Games</h1>
-
-            {isLoading ? (
-                <div className='flex justify-center py-20'>
-                    <span className='loading loading-spinner loading-lg' />
+            <div className='mb-8 flex flex-wrap items-end justify-between gap-4'>
+                <h1 className='text-4xl font-bold'>Games</h1>
+                <div className='flex flex-wrap gap-3 text-sm'>
+                    <Link to='/' className='link link-hover'>
+                        Home
+                    </Link>
+                    <Link to='/stats' className='link link-hover'>
+                        Stats
+                    </Link>
+                    <Link to='/about' className='link link-hover'>
+                        About
+                    </Link>
                 </div>
-            ) : (
+            </div>
+
+            {isLoading && <GameCardGridSkeleton cards={6} />}
+            {isError && <p className='text-error'>Could not load games from the server. Showing cached defaults.</p>}
+            {!isLoading && (
                 <div className='grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3'>
-                    {games.map(game => {
-                        const isComingSoon = game.tags.includes('Coming Soon');
-                        return (
-                            <Link
-                                key={game.id}
-                                to={GAME_ROUTES[game.id] ?? `/game/${game.id}`}
-                                className='card bg-base-200 shadow-md transition-shadow hover:shadow-xl'>
-                                <div className='card-body'>
-                                    <div className='text-4xl'>{game.icon}</div>
-                                    <h2 className='card-title'>{game.name}</h2>
-                                    <p className='text-sm opacity-70'>{game.description}</p>
-                                    <div className='card-actions mt-2'>
-                                        <div className='badge badge-outline'>{game.difficulty}</div>
-                                        <div className='badge badge-outline'>{game.players}</div>
-                                        {isComingSoon && <div className='badge badge-neutral'>Coming Soon</div>}
-                                    </div>
-                                </div>
-                            </Link>
-                        );
-                    })}
+                    {games.map(game => (
+                        <GameSummaryCard key={game.id} game={game} />
+                    ))}
                 </div>
             )}
         </div>

--- a/src/frontend/src/pages/HomePage.test.tsx
+++ b/src/frontend/src/pages/HomePage.test.tsx
@@ -9,9 +9,9 @@ describe('HomePage', () => {
         expect(screen.getByText('AI Game Hub')).toBeInTheDocument();
     });
 
-    it('home page game cards link to correct routes', () => {
+    it('home page links to games and stats', () => {
         renderWithProviders(<HomePage />);
-        const browseLink = screen.getByText(/browse games/i);
-        expect(browseLink.closest('a')).toHaveAttribute('href', '/games');
+        expect(screen.getByRole('link', { name: /^all games$/i })).toHaveAttribute('href', '/games');
+        expect(screen.getByRole('link', { name: /^public stats$/i })).toHaveAttribute('href', '/stats');
     });
 });

--- a/src/frontend/src/pages/HomePage.tsx
+++ b/src/frontend/src/pages/HomePage.tsx
@@ -1,36 +1,130 @@
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
+import { fetchAboutStats } from '../api/about';
 import { fetchGames } from '../api/games';
+import AboutPlatformStats from '../components/AboutPlatformStats';
+import GameSummaryCard from '../components/games/GameSummaryCard';
 import PageMeta from '../components/PageMeta';
+import { GameCardGridSkeleton, StatGridSkeleton } from '../components/Skeleton';
 
 /**
- * Home page with a hero section linking to the games listing.
+ * Landing page with quick navigation to games, platform stats, and other main sections.
  */
 export default function HomePage() {
-    const { data: games = [], isLoading } = useQuery({
-        queryKey: ['games'],
+    const gamesQuery = useQuery({
+        queryKey: ['games', 'home'],
         queryFn: () => fetchGames('active'),
     });
+    const statsQuery = useQuery({
+        queryKey: ['about-stats'],
+        queryFn: fetchAboutStats,
+        staleTime: 60_000,
+    });
+
+    const games = gamesQuery.data ?? [];
 
     return (
         <>
             <PageMeta
                 title='AI Game Hub'
-                description='Play classic games against adaptive AI opponents that learn your style.'
+                description='Play classic games against adaptive AI. Browse games, see live platform stats, and jump to rankings.'
                 ogImage='/images/og/og-home.png'
             />
-            <div className='hero min-h-[60vh] bg-base-200'>
-                <div className='hero-content text-center'>
-                    <div className='max-w-2xl'>
-                        <h1 className='text-5xl font-bold'>AI Game Hub</h1>
-                        <p className='py-6 text-lg opacity-80'>
-                            Play classic games against adaptive AI. Every opponent learns and evolves.
-                        </p>
-                        <Link to='/games' className='btn btn-primary btn-lg'>
-                            Browse Games
+            <div className='hero min-h-[40vh] bg-base-200'>
+                <div className='hero-content flex-col px-4 py-12 text-center'>
+                    <h1 className='text-5xl font-bold'>AI Game Hub</h1>
+                    <p className='max-w-2xl py-6 text-lg opacity-80'>
+                        Play classic games against adaptive AI. Pick a game below, open the full catalog for details, or
+                        explore public rankings and your account from the navigation bar.
+                    </p>
+                    <div className='flex flex-wrap justify-center gap-3'>
+                        <Link to='/games' className='btn btn-primary'>
+                            All games
+                        </Link>
+                        <Link to='/stats' className='btn btn-outline'>
+                            Public stats
+                        </Link>
+                        <Link to='/about' className='btn btn-ghost'>
+                            About
                         </Link>
                     </div>
                 </div>
+            </div>
+
+            <div className='container mx-auto max-w-6xl px-4 py-12'>
+                <section className='mb-14'>
+                    <div className='mb-4 flex flex-wrap items-end justify-between gap-4'>
+                        <h2 className='text-2xl font-semibold'>Active games</h2>
+                        <Link to='/games' className='link link-primary text-sm'>
+                            Details for every game
+                        </Link>
+                    </div>
+                    {gamesQuery.isLoading && <GameCardGridSkeleton cards={6} />}
+                    {gamesQuery.isError && (
+                        <p className='text-error'>Could not load games. Try again from the Games page.</p>
+                    )}
+                    {!gamesQuery.isLoading && !gamesQuery.isError && games.length === 0 && (
+                        <p className='opacity-70'>No active games are listed yet.</p>
+                    )}
+                    {!gamesQuery.isLoading && !gamesQuery.isError && games.length > 0 && (
+                        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
+                            {games.map(game => (
+                                <GameSummaryCard key={game.id} game={game} compact />
+                            ))}
+                        </div>
+                    )}
+                </section>
+
+                <section className='mb-14'>
+                    <div className='mb-4 flex flex-wrap items-end justify-between gap-4'>
+                        <h2 className='text-2xl font-semibold'>Platform stats</h2>
+                        <Link to='/stats' className='link link-primary text-sm'>
+                            Deep dive into rankings
+                        </Link>
+                    </div>
+                    {statsQuery.isLoading && <StatGridSkeleton count={6} />}
+                    {statsQuery.isError && <p className='text-error'>Could not load platform statistics right now.</p>}
+                    {statsQuery.data && (
+                        <AboutPlatformStats
+                            gamesPlayed={statsQuery.data.games_played}
+                            movesAnalyzed={statsQuery.data.moves_analyzed}
+                            uniquePlayers={statsQuery.data.unique_players}
+                            aiWinRate={statsQuery.data.ai_win_rate}
+                            trainingMoves={statsQuery.data.training_moves}
+                            daysRunning={statsQuery.data.days_running}
+                        />
+                    )}
+                </section>
+
+                <section className='rounded-box bg-base-200 p-6'>
+                    <h2 className='mb-3 text-xl font-semibold'>Find everything quickly</h2>
+                    <ul className='grid gap-2 text-sm opacity-90 sm:grid-cols-2'>
+                        <li>
+                            <Link to='/games' className='link'>
+                                Games
+                            </Link>{' '}
+                            — full descriptions, difficulty, and AI status for each title.
+                        </li>
+                        <li>
+                            <Link to='/stats' className='link'>
+                                Stats
+                            </Link>{' '}
+                            — per-game leaderboards and streak boards for public profiles.
+                        </li>
+                        <li>
+                            <Link to='/about' className='link'>
+                                About
+                            </Link>{' '}
+                            — team, mission, and extra platform context.
+                        </li>
+                        <li>
+                            <Link to='/profile' className='link'>
+                                Profile
+                            </Link>{' '}
+                            — your results after you sign in (also under your avatar menu).
+                        </li>
+                    </ul>
+                </section>
             </div>
         </>
     );

--- a/src/frontend/src/pages/ProfilePage.tsx
+++ b/src/frontend/src/pages/ProfilePage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchMyStats } from '../api/stats';
 import { useAuth } from '../hooks/useAuth';
 import PageMeta from '../components/PageMeta';
+import { SkeletonBlock } from '../components/Skeleton';
 import type { GameStats } from '../types';
 
 const GAME_LABELS: Record<string, string> = {
@@ -51,8 +52,18 @@ export default function ProfilePage() {
 
     if (isLoading) {
         return (
-            <div className='flex justify-center py-20'>
-                <span className='loading loading-spinner loading-lg' />
+            <div className='container mx-auto max-w-2xl px-4 py-10'>
+                <SkeletonBlock className='mb-6 h-10 w-48' />
+                <div className='card bg-base-200 shadow'>
+                    <div className='card-body flex-row gap-4'>
+                        <SkeletonBlock className='h-16 w-16 shrink-0 rounded-full' />
+                        <div className='flex flex-1 flex-col gap-3'>
+                            <SkeletonBlock className='h-6 w-40' />
+                            <SkeletonBlock className='h-4 w-28' />
+                            <SkeletonBlock className='h-4 w-full' />
+                        </div>
+                    </div>
+                </div>
             </div>
         );
     }

--- a/src/frontend/src/pages/SettingsPage.tsx
+++ b/src/frontend/src/pages/SettingsPage.tsx
@@ -72,7 +72,7 @@ export default function SettingsPage() {
                                         disabled={mutation.isPending}
                                     />
                                     <span className='text-sm'>
-                                        Show my stats on leaderboards and allow other players to view them
+                                        Show my stats on public rankings and allow other players to view them
                                     </span>
                                 </label>
                             </div>

--- a/src/frontend/src/pages/StatsPage.test.tsx
+++ b/src/frontend/src/pages/StatsPage.test.tsx
@@ -1,11 +1,11 @@
 import { screen, waitFor } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import { renderWithProviders } from '../test-utils';
-import LeaderboardPage from './LeaderboardPage';
+import StatsPage from './StatsPage';
 
-describe('LeaderboardPage', () => {
-    it('leaderboard page renders table rows', async () => {
-        renderWithProviders(<LeaderboardPage />);
+describe('StatsPage', () => {
+    it('stats page renders table rows', async () => {
+        renderWithProviders(<StatsPage />);
         await waitFor(() => {
             expect(screen.getByText('Alice')).toBeInTheDocument();
             expect(screen.getByText('Bob')).toBeInTheDocument();
@@ -13,8 +13,8 @@ describe('LeaderboardPage', () => {
         });
     });
 
-    it('renders leaderboard heading', () => {
-        renderWithProviders(<LeaderboardPage />);
-        expect(screen.getByText(/leaderboard/i)).toBeInTheDocument();
+    it('renders stats heading', () => {
+        renderWithProviders(<StatsPage />);
+        expect(screen.getByRole('heading', { name: /^stats$/i })).toBeInTheDocument();
     });
 });

--- a/src/frontend/src/pages/StatsPage.tsx
+++ b/src/frontend/src/pages/StatsPage.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchLeaderboard } from '../api/stats';
 import PageMeta from '../components/PageMeta';
+import { SkeletonBlock } from '../components/Skeleton';
 
 const BOARD_TYPES = [
     { key: 'games_played', label: 'Games Played' },
@@ -17,10 +19,41 @@ const GAME_TYPES = [
     { key: 'dots_and_boxes', label: 'Dots & Boxes' },
 ] as const;
 
+function StatsTableSkeleton() {
+    return (
+        <div className='overflow-x-auto p-4'>
+            <table className='table'>
+                <thead>
+                    <tr>
+                        <th>Rank</th>
+                        <th>Player</th>
+                        <th className='text-right'>Value</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {Array.from({ length: 8 }).map((_, i) => (
+                        <tr key={i}>
+                            <td>
+                                <SkeletonBlock className='h-4 w-8' />
+                            </td>
+                            <td>
+                                <SkeletonBlock className='h-4 w-32' />
+                            </td>
+                            <td className='text-right'>
+                                <SkeletonBlock className='ml-auto h-4 w-12' />
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
 /**
- * Per-game leaderboard page with board type tabs and game type selector.
+ * Per-game public rankings: games played and streak boards, filterable by game type.
  */
-export default function LeaderboardPage() {
+export default function StatsPage() {
     const [boardType, setBoardType] = useState('games_played');
     const [gameType, setGameType] = useState('tic_tac_toe');
     const [page, setPage] = useState(1);
@@ -35,11 +68,25 @@ export default function LeaderboardPage() {
 
     return (
         <div className='container mx-auto max-w-3xl px-4 py-10'>
-            <PageMeta
-                title='Leaderboard'
-                description='See top players ranked by games played, win streaks, and more.'
-            />
-            <h1 className='mb-6 text-4xl font-bold'>Leaderboard</h1>
+            <PageMeta title='Stats' description='See top players ranked by games played, win streaks, and more.' />
+            <div className='mb-6 flex flex-wrap items-end justify-between gap-4'>
+                <h1 className='text-4xl font-bold'>Stats</h1>
+                <div className='flex flex-wrap gap-3 text-sm'>
+                    <Link to='/' className='link link-hover'>
+                        Home
+                    </Link>
+                    <Link to='/games' className='link link-hover'>
+                        Games
+                    </Link>
+                    <Link to='/about' className='link link-hover'>
+                        About
+                    </Link>
+                </div>
+            </div>
+            <p className='mb-6 text-sm opacity-70'>
+                Rankings include players who opted in under Settings. For aggregate activity across the site, see the
+                home page.
+            </p>
 
             <div className='flex flex-wrap gap-3 mb-6'>
                 <select
@@ -75,9 +122,7 @@ export default function LeaderboardPage() {
             <div className='card bg-base-200 shadow'>
                 <div className='card-body p-0'>
                     {isLoading ? (
-                        <div className='flex justify-center py-10'>
-                            <span className='loading loading-spinner loading-lg' />
-                        </div>
+                        <StatsTableSkeleton />
                     ) : !data || data.entries.length === 0 ? (
                         <p className='py-10 text-center opacity-60'>No entries yet. Play some games!</p>
                     ) : (

--- a/src/frontend/src/types/index.ts
+++ b/src/frontend/src/types/index.ts
@@ -16,10 +16,12 @@ export interface Game {
     description: string;
     icon: string;
     difficulty: string;
-    players: string;
+    players: string | number;
     status: string;
     category: string;
     tags: string[];
+    game_shell_ready: boolean;
+    ai_model_integrated: boolean;
 }
 
 export interface ApiError {

--- a/tests/api/api-endpoints.spec.js
+++ b/tests/api/api-endpoints.spec.js
@@ -25,7 +25,7 @@ test.describe('API Endpoints', () => {
             expect(data.games.length).toBeGreaterThan(0);
 
             if (data.games.length > 0) {
-                verifyApiResponse(data.games[0], ['id', 'name']);
+                verifyApiResponse(data.games[0], ['id', 'name', 'game_shell_ready', 'ai_model_integrated']);
             }
         });
     });

--- a/tests/smoke/routes.spec.js
+++ b/tests/smoke/routes.spec.js
@@ -9,7 +9,8 @@ test.describe('Route Smoke Tests', () => {
         await expect(page.locator('h1')).toContainText('AI Game Hub', { timeout: 10000 });
         await expect(page.locator('.navbar').first()).toBeVisible({ timeout: 5000 });
         await expect(page.locator('.hero')).toBeVisible({ timeout: 5000 });
-        await expect(page.locator('a:has-text("Browse Games")')).toBeVisible({ timeout: 5000 });
+        await expect(page.getByRole('link', { name: /^All games$/i })).toBeVisible({ timeout: 5000 });
+        await expect(page.getByRole('link', { name: /^Public stats$/i })).toBeVisible({ timeout: 5000 });
     });
 
     test('games page loads correctly', async ({ page }) => {

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -93,6 +93,8 @@ def test_game_info_valid():
         status="active",
         category="strategy",
         tags=["classic", "quick"],
+        game_shell_ready=True,
+        ai_model_integrated=True,
     )
     assert info.id == "ttt"
     assert info.tags == ["classic", "quick"]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds Alembic migration `0006` with `games.game_shell_ready` and `games.ai_model_integrated`, backfills rows (Tic Tac Toe has integrated AI; Pong shell not ready; others playable without integrated model), and trims `tags` so they are display-only.
- Extends `GET /api/games_list` and `GET /api/game/{id}/info` plus `GameInfo` with the new booleans.
- Home page shows active games (`fetchGames('active')`) and live platform stats (`fetchAboutStats`), with cross-links to Games, Stats, About, and Profile.
- Renames the public rankings UI to **Stats**: route `/stats`, nav/footer, `INDEXABLE_PATHS`; `/leaderboard` redirects to `/stats` (API path unchanged: `/api/leaderboard/...`).
- Shared `GameSummaryCard` drives home and `/games` cards: neutral **Not available yet** when the shell is not ready; warning **No trained AI yet** plus placeholder **AI Difficulty** (with `title` tooltip) when playable but no model; plain difficulty when AI is integrated.
- Skeleton loading (DaisyUI `skeleton`) for home games/stats, about stats, games list, stats table, profile loading, and `GameStatsPanel`.

## Deploy notes

- Run `alembic upgrade head` (or your migration pipeline) before relying on the new JSON fields; older DBs would error on the extended SELECT until migrated.

## Test plan

- [ ] `alembic upgrade head` on a copy of prod schema; verify `games` rows and API payloads.
- [ ] `/` shows game cards and stat cards; skeletons briefly then content.
- [ ] `/games` matches card semantics; links to `/` and `/stats`.
- [ ] `/stats` loads rankings; skeleton table while loading; `/leaderboard` redirects here.
- [ ] Playwright API test still passes `GET /api/games_list` shape including new fields.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4acae2c7-927c-4021-a22d-a691fec931f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4acae2c7-927c-4021-a22d-a691fec931f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

