### PR TITLE
docs: GH_TOKEN for cloud agent GitHub CLI writes

### DIFF
--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -20,8 +20,10 @@ Unless the user opts out:
 1. After **`gh pr create`** (draft or not): **`gh pr checks <pr> --watch`** until required checks settle.
 2. When submitting / marking ready to merge: **`gh pr merge <pr> --auto --squash`** (same unless user says not to enable auto-merge).
 
-Cloud agents: **`gh pr edit` / merge** need **`GH_TOKEN`** (scoped PAT) in the agent environment if `gh auth status`
-shows the limited **`cursor`** / **`ghs_`** integration; see **CONTRIBUTING.md §1e**.
+**Remote Cursor cloud agent:** Do **not** run **`gh pr edit`**, **`gh pr merge`**, or **`gh pr create`**; they usually fail
+(**`cursor`** / **`ghs_`**). Output **CONTRIBUTING.md §1c handoff** (proposed title, body, local `gh` commands). **Local**
+Cursor / contributor machine: run those **`gh`** writes (and user **`~/.cursor`** rules such as PAT helpers apply only
+there). Details: **CONTRIBUTING.md §1e**.
 
 ## Stack (short)
 

--- a/.cursor/rules/00-project-always.mdc
+++ b/.cursor/rules/00-project-always.mdc
@@ -20,6 +20,9 @@ Unless the user opts out:
 1. After **`gh pr create`** (draft or not): **`gh pr checks <pr> --watch`** until required checks settle.
 2. When submitting / marking ready to merge: **`gh pr merge <pr> --auto --squash`** (same unless user says not to enable auto-merge).
 
+Cloud agents: **`gh pr edit` / merge** need **`GH_TOKEN`** (scoped PAT) in the agent environment if `gh auth status`
+shows the limited **`cursor`** / **`ghs_`** integration; see **CONTRIBUTING.md §1e**.
+
 ## Stack (short)
 
 - Backend: FastAPI, Python 3.11+, PostgreSQL via psycopg2.

--- a/.cursor/rules/branch-pr-workflow.mdc
+++ b/.cursor/rules/branch-pr-workflow.mdc
@@ -16,3 +16,7 @@ See **[CONTRIBUTING.md](../../CONTRIBUTING.md)** and **`00-project-always.mdc`**
 - Post-merge deploy (Cloud Run): optional `gcloud` verification on a later pass — CONTRIBUTING.
 
 If `gh` is unavailable, say so and use the web UI equivalents.
+
+**Cloud / remote agent:** Do not rely on **`gh pr edit`** or **`gh pr merge`**; use **CONTRIBUTING.md §1c handoff** for
+the human or a **local** terminal to run writes. Read-only **`gh pr checks` / `view` / `diff`** on the remote agent is
+fine.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,10 @@ Human-readable defaults for automation and coding agents. **Authoritative detail
 Unless the user opts out: after **`gh pr create`**, run **`gh pr checks <pr> --watch`**. When marking ready to land, use
 **`gh pr merge <pr> --auto --squash`** by default.
 
+**GitHub writes from agents:** Run **`gh pr create`**, **`gh pr edit`**, and **`gh pr merge`** only in a **local**
+terminal where `gh` is you (see **CONTRIBUTING.md §1e**). On **remote Cursor cloud agents**, skip those commands and use
+the **§1c handoff** block in CONTRIBUTING so a local session or the human applies the title, body, and merge.
+
 ## Planning vs implementation
 
 If the user has not said whether the task is **planning** (spec/design) or **implementation**, ask once. Planning
@@ -39,9 +43,9 @@ what must be fresh in every turn; long prose stays in CONTRIBUTING.
 
 ## Cursor Cloud and agent VMs
 
-**GitHub CLI in cloud agents:** `gh pr edit`, merge, and similar writes need a user-scoped token in the VM environment.
-See **[CONTRIBUTING.md](CONTRIBUTING.md) (section 1e — GitHub CLI)** for **`GH_TOKEN`** and verification with
-`gh api user`.
+**GitHub CLI:** Cloud agents should use **`gh pr view` / `diff` / `checks`** only. For **`gh pr edit`**,
+**`gh pr merge`**, or **`gh pr create`**, follow **CONTRIBUTING.md §1c handoff** and run writes **locally** (or on the
+GitHub website). See **§1e** for why **`ghs_`** / **`cursor`** cannot be relied on for mutations.
 
 ### Services overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,10 @@ what must be fresh in every turn; long prose stays in CONTRIBUTING.
 
 ## Cursor Cloud and agent VMs
 
+**GitHub CLI in cloud agents:** `gh pr edit`, merge, and similar writes need a user-scoped token in the VM environment.
+See **[CONTRIBUTING.md](CONTRIBUTING.md) (section 1e — GitHub CLI)** for **`GH_TOKEN`** and verification with
+`gh api user`.
+
 ### Services overview
 
 | Service                    | How to start              | Port |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,6 +147,12 @@ cross-game behavior), update the PR before or with the next push so reviewers an
   and dependency notes (e.g. “merge after X”) stay current. Link relevant **`features/*/adr.md`** files when the PR
   implements or supersedes an architectural decision.
 
+**Where to run `gh pr edit` (and other GitHub writes):** Only on a **machine where GitHub CLI is authenticated as you**
+(local Cursor workspace terminal, Git Bash on your PC, and so on). **Remote Cursor cloud agents** typically cannot
+mutate PRs (see **§1e**). If work runs on a cloud agent, **do not** keep retrying `gh pr edit` there; finish the branch,
+then apply the title/body using a **local** shell or hand the exact commands to the contributor (see **§1c handoff**
+below).
+
 Use the GitHub CLI from the PR branch, for example:
 
 ```bash
@@ -156,6 +162,25 @@ gh pr edit <number> --body-file path/to/pr-body.md
 
 If you only need a small fix, `gh pr edit <number> --body "..."` is fine. Do not leave stale review questions in the
 body once they are answered; replace them with the agreed outcome.
+
+### §1c handoff (cloud or read-only `gh`)
+
+When a session **cannot** run `gh pr edit` / `gh pr merge` / `gh pr create` successfully, output a block the contributor
+can paste into a **local** terminal (after writing `pr-body.md` or inlining the body):
+
+```text
+PR: <number>
+Proposed title: <one line>
+
+Proposed body (save to pr-body.md or pass with --body):
+--- begin ---
+<markdown>
+--- end ---
+
+Local commands:
+gh pr edit <number> --title "paste title here"
+gh pr edit <number> --body-file pr-body.md
+```
 
 ---
 
@@ -188,23 +213,25 @@ repo.
 
 ### GitHub CLI (`gh`)
 
-**Local Cursor / your PC:** In **Cursor’s integrated terminal** (or any terminal on the machine), run `gh auth login`
-and complete the browser or device flow. That stores the session where `gh` expects it (for example Windows Credential
-Manager and GitHub CLI config under `%AppData%`).
+**Default workflow:** Treat **GitHub mutations** (`gh pr create`, `gh pr edit`, `gh pr merge`, and write-style `gh api`
+calls) as **local-only**. Run them from **Cursor’s integrated terminal on your machine**, **Git Bash**, or any shell
+where `gh auth login` (or **`GH_TOKEN`**) identifies **your** account. User-level rules under **`~/.cursor`** (for
+example PAT handling or wrapper docs) exist **only on your PC**; they are **not** mounted into **remote Cursor cloud
+agent** VMs.
 
-**Cloud or background agents (Linux VM):** Browser login on your PC does **not** apply to that environment. The VM may
-show `gh auth status` as account **`cursor`** with a **`ghs_`** token; that integration can **read** PRs but often
-**cannot** mutate them (`gh pr edit`, `gh pr merge`, some `gh api` writes), which surfaces as **Resource not accessible
-by integration**.
+**Local auth:** Run `gh auth login` and complete the browser or device flow. That stores the session where `gh` expects
+it (for example Windows Credential Manager and GitHub CLI config). Optionally set a scoped PAT as **`GH_TOKEN`** in your
+**user** environment for that machine (`gh` prefers it over the stored OAuth token for API calls). **Never** commit a
+PAT to the repository.
 
-For **any** `gh` call that must act as **you** (or a bot user with repo write), set a **personal access token** in the
-**agent shell environment** as **`GH_TOKEN`** (GitHub CLI treats `GH_TOKEN` as higher precedence than `gh auth login`
-for API requests). Scope the PAT to the minimum needed (for PR edits: **pull requests** write on this repo; add
-**contents** if you also need merge or branch operations). Configure the value wherever Cursor exposes **secrets** or
-**environment variables** for cloud agents, or export it for the session before running `gh` — **never** commit a PAT to
-the repository.
+**Remote / cloud agents (Linux VM on Cursor infrastructure):** These environments use Cursor’s **integration** identity
+(`gh auth status` may show **`cursor`** with a **`ghs_`** token). That identity can **read** PRs and run **read-only**
+`gh` commands (`gh pr view`, `gh pr diff`, `gh pr checks`) but **often cannot mutate** PRs, which surfaces as **Resource
+not accessible by integration**. **Do not** depend on cloud agents to update PR bodies, titles, or merges. Instead:
+complete code and pushes on the remote branch, then use **§1c handoff** so a **local** session or the contributor
+applies `gh pr edit` / merge, or edit the PR on **github.com**.
 
-Verify the effective identity (after setting `GH_TOKEN`):
+Verify the effective identity before relying on writes:
 
 ```bash
 gh api user -q .login

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,21 +186,44 @@ your day-to-day terminal. If a command fails with **permission**, **401/403**, *
 integration**, or **not authenticated**, do **not** ask the user to paste tokens into chat or commit secrets to the
 repo.
 
-**Ask the user** to perform authorization **on their Windows machine** so credentials land in the OS trust store (for
-example **Windows Credential Manager** via normal GitHub CLI and Google Cloud flows):
+### GitHub CLI (`gh`)
 
-- **GitHub / `gh`:** In **Cursor’s integrated terminal** (or any terminal on the PC), run `gh auth login` and complete
-  the browser or device flow. That stores the session where `gh` expects it on Windows (Credential Manager / GitHub CLI
-  config under `%AppData%`). Retry `gh pr view`, `gh pr edit`, or `gh api` after login. If `gh pr edit` fails with a
-  **Projects (classic)** GraphQL deprecation error, use `gh api repos/<owner>/<repo>/pulls/<n> -X PATCH` with a JSON
-  body as a workaround, or remove the PR from classic Projects.
-- **GCP / `gcloud`:** Run `gcloud auth login` and, when tools need application default credentials,
-  `gcloud auth application-default login`, again from a terminal on the user’s machine so ADC and tokens are stored
-  locally.
+**Local Cursor / your PC:** In **Cursor’s integrated terminal** (or any terminal on the machine), run `gh auth login`
+and complete the browser or device flow. That stores the session where `gh` expects it (for example Windows Credential
+Manager and GitHub CLI config under `%AppData%`).
+
+**Cloud or background agents (Linux VM):** Browser login on your PC does **not** apply to that environment. The VM may
+show `gh auth status` as account **`cursor`** with a **`ghs_`** token; that integration can **read** PRs but often
+**cannot** mutate them (`gh pr edit`, `gh pr merge`, some `gh api` writes), which surfaces as **Resource not accessible
+by integration**.
+
+For **any** `gh` call that must act as **you** (or a bot user with repo write), set a **personal access token** in the
+**agent shell environment** as **`GH_TOKEN`** (GitHub CLI treats `GH_TOKEN` as higher precedence than `gh auth login`
+for API requests). Scope the PAT to the minimum needed (for PR edits: **pull requests** write on this repo; add
+**contents** if you also need merge or branch operations). Configure the value wherever Cursor exposes **secrets** or
+**environment variables** for cloud agents, or export it for the session before running `gh` — **never** commit a PAT to
+the repository.
+
+Verify the effective identity (after setting `GH_TOKEN`):
+
+```bash
+gh api user -q .login
+```
+
+If `gh pr edit` fails with a **Projects (classic)** GraphQL deprecation error, use
+`gh api repos/<owner>/<repo>/pulls/<n> -X PATCH` with a JSON body as a workaround, or remove the PR from classic
+Projects.
+
+### GCP (`gcloud`)
+
+**Ask the user** to perform authorization **on their Windows machine** so credentials land in the OS trust store:
+
+- Run `gcloud auth login` and, when tools need application default credentials, `gcloud auth application-default login`,
+  from a terminal on the user’s machine so ADC and tokens are stored locally.
 
 After the user confirms they completed login, **re-run** the failing command. If the agent environment still cannot see
-those credentials (common for **cloud-only** agents), say so clearly: the user may need to **configure Cursor’s GitHub
-integration** or **Secrets** for that environment, not only local Windows auth.
+those credentials (common for **cloud-only** agents), say so clearly: the user may need **GCP secrets or ADC**
+configured for that environment, not only local Windows auth.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Documents that Cursor cloud agents authenticate `gh` as the limited **cursor** / **ghs_** integration unless **`GH_TOKEN`** is set in the agent environment. Expands CONTRIBUTING §1e with local vs cloud behavior, minimal PAT scopes, and `gh api user` verification. Adds pointers from AGENTS.md and `.cursor/rules/00-project-always.mdc`.

## Test plan

- `npm run test:fast`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-08970338-650a-42c5-a288-bc1682e3e171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-08970338-650a-42c5-a288-bc1682e3e171"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

