### PR TITLE
spec: close notation-conversion decision in all turn-based game specs

### DIFF
--- a/features/game-checkers/spec.md
+++ b/features/game-checkers/spec.md
@@ -441,10 +441,10 @@ string for the move (e.g. `"b6d4"` for a jump from b6 to d4; multi-jump steps re
 Terminal state triggers `persistence_service.end_game()`. See the game-data-persistence spec for the
 full function signatures.
 
-**Open question — notation conversion location**: The move request arrives as
-`{from_pos, to_pos}` (board position indices). This must be converted to an algebraic coordinate
-string before calling `record_move`. Decide during implementation: does this conversion live as a
-method on `CheckersEngine` (preferred — engine owns the format), or inline in the router?
+**Notation conversion**: The engine owns the notation format. `CheckersEngine` exposes a
+`to_notation(from_pos: int, to_pos: int) -> str` method that converts board position indices to an
+algebraic coordinate string (e.g. `"b6d4"` for a jump from b6 to d4). The router calls
+`engine.to_notation(move["from"], move["to"])` before passing the string to `record_move`.
 
 ## Test Cases
 

--- a/features/game-chess/spec.md
+++ b/features/game-chess/spec.md
@@ -564,10 +564,10 @@ castling, `"e7e8q"` for promotion to queen). `board_state_after` is the full gam
 `apply_move`. Terminal state triggers `persistence_service.end_game()`. See the game-data-persistence
 spec for the full function signatures.
 
-**Open question — notation conversion location**: The move request arrives as
-`{fromRow, fromCol, toRow, toCol, promotionPiece}`. This must be converted to a UCI string before
-calling `record_move`. Decide during implementation: does this conversion live as a method on
-`ChessEngine` (preferred — engine owns the format), or inline in the router?
+**Notation conversion**: The engine owns the notation format. `ChessEngine` exposes a
+`to_notation(move: dict) -> str` method that converts `{fromRow, fromCol, toRow, toCol, promotionPiece}`
+to a UCI string (e.g. `"e2e4"`, `"e1g1"` for castling, `"e7e8q"` for promotion). The router calls
+`engine.to_notation(move)` before passing the string to `record_move`.
 
 ## Legacy Cleanup
 

--- a/features/game-connect4/spec.md
+++ b/features/game-connect4/spec.md
@@ -327,9 +327,10 @@ Every valid move (player and AI) is recorded via `persistence_service.record_mov
 Terminal state triggers `persistence_service.end_game()`. See the game-data-persistence spec for the
 full function signatures.
 
-**Open question — notation conversion location**: The move request arrives as `{column: int}`. This
-must be converted to a `"c{col}"` string before calling `record_move`. Decide during implementation:
-does this conversion live as a method on `Connect4Engine` (preferred), or inline in the router?
+**Notation conversion**: The engine owns the notation format. `Connect4Engine` exposes a
+`to_notation(col: int) -> str` method that converts a column index to `"c{col}"` (e.g. `"c3"` for
+column 3). The router calls `engine.to_notation(move["col"])` before passing the string to
+`record_move`.
 
 ## Test Cases
 

--- a/features/game-dots-and-boxes/spec.md
+++ b/features/game-dots-and-boxes/spec.md
@@ -500,10 +500,10 @@ Every valid move (player and AI) is recorded via `persistence_service.record_mov
 at row 1, col 2). Terminal state triggers `persistence_service.end_game()`. See the
 game-data-persistence spec for the full function signatures.
 
-**Open question — notation conversion location**: The move request arrives as
-`{orientation, row, col}` or similar. This must be converted to an `"h{r}{c}"` / `"v{r}{c}"` string
-before calling `record_move`. Decide during implementation: does this conversion live as a method on
-`DotsAndBoxesEngine` (preferred), or inline in the router?
+**Notation conversion**: The engine owns the notation format. `DaBEngine` exposes a
+`to_notation(move: dict) -> str` method that converts `{type, row, col}` to `"h{row}{col}"` or
+`"v{row}{col}"` (e.g. `"h12"` for the horizontal edge at row 1, col 2). The router calls
+`engine.to_notation(move)` before passing the string to `record_move`.
 
 ## Test Cases
 

--- a/features/game-tic-tac-toe/spec.md
+++ b/features/game-tic-tac-toe/spec.md
@@ -305,10 +305,9 @@ Every valid move (player and AI) is recorded via `persistence_service.record_mov
 Terminal state triggers `persistence_service.end_game()`. See the game-data-persistence spec for the
 full function signatures.
 
-**Open question — notation conversion location**: The move request arrives as `{row: int, col: int}`.
-This must be converted to an `"r{row}c{col}"` string before calling `record_move`. Decide during
-implementation: does this conversion live as a method on `TicTacToeEngine` (preferred), or inline in
-the router?
+**Notation conversion**: The engine owns the notation format. `TicTacToeEngine` exposes a
+`to_notation(position: int) -> str` method that converts a board position (0–8) to `"r{row}c{col}"`.
+The router calls `engine.to_notation(move["position"])` before passing the string to `record_move`.
 
 ## Test Cases
 


### PR DESCRIPTION
## Summary

All five turn-based game specs (TTT, Chess, Checkers, Connect4, Dots & Boxes) had the same deferred open question about where notation conversion should live. Every spec already stated the preferred answer: "engine owns the format." This PR closes the question explicitly in each spec.

**Decision recorded:** Each engine exposes a `to_notation(...)` method; the router calls it before `record_move`.

## Specs changed

- `features/game-tic-tac-toe/spec.md`
- `features/game-chess/spec.md`
- `features/game-checkers/spec.md`
- `features/game-connect4/spec.md`
- `features/game-dots-and-boxes/spec.md`

## Test plan

- [ ] Read each spec and verify the notation conversion decision is unambiguous
- [ ] Verify method signatures are consistent with notation formats in `features/game-training-data/spec.md`