### PR TITLE
spec: close build-optimization decision + add ADR and test cases

### DIFF
--- a/features/build-optimization/adr.md
+++ b/features/build-optimization/adr.md
@@ -1,0 +1,41 @@
+# ADR: Build Optimization Approach
+
+## Context
+
+Every push to main triggers a full GCP Cloud Build run — Docker build (including `npm ci` and
+`pip install` from scratch), push to Artifact Registry, migration, and deploy — taking 4–6 minutes
+end-to-end. Four options were evaluated for reducing build time.
+
+## Decision
+
+**Implement Docker layer caching (option 1) now.**
+
+Pull the `latest` image before building and pass it as `--cache-from`. On a cache hit (no changes
+to `package-lock.json` or `requirements.txt`), `npm ci` and `pip install` are skipped, saving
+2–3 minutes per build. The change is 3 lines in `cloudbuild.yaml` with no architectural changes.
+
+## Rejected Alternatives
+
+### Option 2: Build on GH Actions, push image, Cloud Build deploy only
+
+Most scalable long-term. GH Actions compute is free; Cloud Build billing drops to migration +
+deploy only (~1–2 min). Rejected for now because it requires Workload Identity Federation setup
+and a coordination contract between two CI systems. Added complexity not justified at current
+build frequency. Revisit when build cost or frequency becomes a real constraint.
+
+### Option 3: Developer builds locally before pushing
+
+Discipline-dependent, not automatable, not suitable for team workflow. Rejected entirely.
+
+### Option 4: Separate base image layer
+
+Most cache-efficient approach. Rejected for now because it requires a separate Cloud Build trigger
+or GH Actions workflow to rebuild the base image on dep changes — more infrastructure to maintain.
+This becomes attractive if option 1 proves insufficient (e.g., frequent dep changes break caching
+often enough to erode the savings).
+
+## Future Direction
+
+Option 2 (GH Actions build + Cloud Build deploy) is the planned upgrade path. The
+`test-coverage-overhaul` spec's `repository_dispatch`-based post-deploy hook already establishes
+the coordination point between GH Actions and Cloud Build, which option 2 would extend.

--- a/features/build-optimization/spec.md
+++ b/features/build-optimization/spec.md
@@ -64,13 +64,15 @@ regardless of where the build runs.
 **Tradeoff:** Requires a separate Cloud Build trigger or GH Actions workflow to rebuild the base
 image on dep changes. More infrastructure to maintain.
 
-## Recommendation
+## Decision
 
-Start with **option 1** (Docker layer caching) — it's a 3-line change to `cloudbuild.yaml` with
+**Implement option 1** (Docker layer caching) now — it's a 3-line change to `cloudbuild.yaml` with
 immediate savings and no architectural changes.
 
-**Option 2** (GH Actions build + Cloud Build deploy) is the most scalable approach once the
-project grows or build frequency increases enough to matter on cost.
+**Option 2** (GH Actions build + Cloud Build deploy) is the future direction once build frequency
+or cost warrants it. The `test-coverage-overhaul` spec documents a `repository_dispatch`-based
+post-deploy hook that would form the coordination point between GH Actions and Cloud Build in
+that model. Option 2 is not implemented in this feature — track it as a follow-on.
 
 ## Known Requirements
 
@@ -81,4 +83,9 @@ project grows or build frequency increases enough to matter on cost.
 
 ## Test Cases
 
-_To be defined during planning session._
+| Tier | Name | What it checks |
+|------|------|----------------|
+| Manual | Build time before/after | Record Cloud Build duration before the change and after the first cache-hit build; verify savings are > 1 minute |
+| Manual | Cache miss on dep change | Update `requirements.txt`, trigger a build; verify `pip install` runs in full (no stale cache) |
+| Manual | Cache hit on source-only change | Change a Python source file only, trigger build; verify `pip install` and `npm ci` steps are skipped |
+| Manual | Migration and deploy sequence intact | After caching change, verify the migration job still runs before the deploy step completes |


### PR DESCRIPTION
## Summary

The `features/build-optimization/spec.md` presented four options and gave a recommendation but never recorded a firm decision. This PR:

- **Closes on option 1** (Docker layer caching) as the immediate implementation
- Notes option 2 (GH Actions build + Cloud Build deploy) as the future direction
- Adds `adr.md` documenting the decision and rationale for rejecting options 2, 3, and 4
- Adds manual test cases for verifying cache behavior and migration sequence

## Files changed

- `features/build-optimization/spec.md` — replace "Recommendation" with "Decision"; add test cases
- `features/build-optimization/adr.md` — new ADR

## Test plan

- [ ] Verify decision matches the recommendation already in the spec
- [ ] Verify rejected alternatives are accurately summarized