### PR TITLE
spec: clean up cicd-staging spec + add ADR

### DIFF
--- a/features/cicd-staging/adr.md
+++ b/features/cicd-staging/adr.md
@@ -1,0 +1,47 @@
+# ADR: CI/CD Staging Environment Decisions
+
+## Context
+
+The project needed a staging tier between PR merges and production deploys. Several infrastructure
+decisions were required: GCP project scope, service topology, branch strategy, promotion workflow,
+and operational settings. This ADR records the decisions that have been made; open questions are
+tracked in the spec.
+
+## Decisions
+
+### 1. Same GCP project; separate Cloud Run service
+
+Staging runs in the same GCP project as production. A separate GCP project would add IAM and billing
+complexity (cross-project permissions, separate billing accounts, duplicated service enablement) with
+no meaningful isolation benefit at current scale.
+
+The staging service is a distinct Cloud Run service (`game-ai-website-staging`) sharing the same
+Artifact Registry. This provides a clean separation of traffic and URL without requiring a second
+image build or a second project.
+
+### 2. Only merges to `main` trigger a staging deploy
+
+Feature branches do not get staging deploys. `main` is always staging-eligible code. There is no
+separate staging branch — the branch strategy in CLAUDE.md (draft PR → squash merge to main) already
+ensures that only reviewed, CI-passing code reaches main.
+
+### 3. Automatic promotion on staging test pass
+
+Staging tests pass → the same image is promoted to production automatically. No human approval gate
+between staging and production.
+
+Rationale: a manual gate adds latency to every deploy without adding safety if the tests are
+reliable. If false-positive staging failures become a problem, a manual gate can be added. Start
+simple.
+
+### 4. Staging scales to zero
+
+Staging Cloud Run instance scales to zero when idle. Staging is only alive during a post-merge deploy
+cycle (a few minutes per merge). Persistent-instance billing for a service that runs ~5% of the
+time is not justified.
+
+### 5. Image promotion, not rebuild
+
+The exact image (by SHA) deployed to staging is promoted to production. No second build step.
+Rebuilding would risk introducing variance between the tested and deployed artifact, defeating the
+purpose of staging.

--- a/features/cicd-staging/spec.md
+++ b/features/cicd-staging/spec.md
@@ -1,6 +1,6 @@
 # CI/CD Staging Environment Spec
 
-**Status: ready**
+**Status: ready** (pending resolution of open questions below before implementation)
 
 ## Background
 
@@ -31,35 +31,55 @@ Automated tests run against staging. The same image is promoted to production on
 - Image promotion from staging to production (same artifact, no second build)
 - Staging URL must be accessible for manual testing but should not be treated as public-facing
 - There must be a documented rollback mechanism if issues are discovered after production promotion
-- The CONTRIBUTING.md branch hygiene and push workflow must be updated to reflect the new pipeline steps
+- The CLAUDE.md branch hygiene and push workflow must be updated to reflect the new pipeline steps
+
+## Resolved Questions
+
+- **GCP project**: Same GCP project as production. Separate GCP project adds IAM and billing
+  complexity with no isolation benefit at this scale.
+- **Staging service**: Separate Cloud Run service (`game-ai-website-staging`). Shares the same
+  Artifact Registry; no second image build.
+- **Branch strategy**: Only merges to `main` trigger a staging deploy. No separate staging branch.
+  `main` always represents staging-eligible code.
+- **Promotion**: Automatic — staging tests pass → same image promoted to production with no human
+  gate. Manual approval is added only if false-positive staging failures become a recurring problem.
+- **Staging scale-to-zero**: Yes. Staging Cloud Run scales to zero when idle.
 
 ## Open Questions
 
-### Environment Isolation
-- **Decided:** same GCP project, separate Cloud Run service for staging (no separate GCP project)
-- Staging DB strategy: separate Cloud SQL instance, same instance with a separate database, or schema isolation?
-- How are staging secrets managed in GCP Secret Manager (separate secret names/versions vs. environment
-  variable override)?
+These must be resolved before implementation begins.
 
-### Test Strategy for Staging
-- What test suite runs against staging? All existing E2E? Only smoke tests? New staging-specific tests?
-- How are staging-specific test fixtures or seed data managed?
-- Who is responsible for keeping staging data clean between runs?
+### Database
 
-### Promotion Workflow
-- Automatic promotion on test pass, or manual approval step before production?
-- What constitutes a "blocking" failure vs. a warning?
-- How is the deploy-to-production step triggered in Cloud Build (separate trigger, same trigger with stages)?
+- Staging DB strategy: separate Cloud SQL instance, or same instance with a dedicated staging
+  database? (Separate instance provides stronger isolation; same instance is cheaper. Consider
+  whether staging migrations could affect production if misconfigured.)
+- Does the staging deploy run migrations against the staging DB before promoting to production,
+  validating that migrations are safe?
 
-### Branch Strategy
-- Does every branch merge get a staging deploy, or only `main`?
-- Is there a separate staging branch, or does `main` always represent staging-eligible code?
+### Secrets
 
-### Cost & Operations
-- What are the cost implications of a persistent staging Cloud Run service + Cloud SQL instance?
-- Should staging scale to zero when not in use?
-- Who gets notified on staging test failures?
+- Staging secrets in GCP Secret Manager: (a) separate secret names with `-staging` suffix,
+  (b) same secrets with a staging-specific version label, or (c) environment variable overrides
+  in the Cloud Run staging service definition. Choose before implementation.
+
+### Test Suite
+
+- Which tests run against staging? All existing E2E/smoke suite, or a dedicated staging-only subset?
+- How are staging-specific seed data fixtures managed and reset between test runs?
+- Who is notified on staging test failures (Slack alert, GH check, or both)?
+
+### Cost
+
+- Estimate the monthly cost of a persistent Cloud SQL staging instance vs. ephemeral
+  (created/destroyed per deploy). The pipeline architecture differs depending on this choice.
 
 ## Test Cases
 
-_To be defined during planning session._
+| Tier | Name | What it checks |
+|------|------|----------------|
+| Manual | Staging deploy on merge to main | Merge a PR; verify Cloud Build deploys to staging, not production |
+| Manual | Staging tests block production | Break a staging test; verify production deploy does not proceed |
+| Manual | Image promotion (no rebuild) | Verify the same image SHA deployed to staging is promoted to production |
+| Manual | Staging scale-to-zero | Leave staging idle; verify it scales to zero; verify next deploy spins it back up |
+| Manual | Rollback mechanism | Trigger a rollback; verify the previous image version is deployed to production |


### PR DESCRIPTION
## Summary

\`features/cicd-staging/spec.md\` mixed decided and undecided questions in the same Open Questions section. This PR:

- Separates **Resolved Questions** (GCP project scope, staging service name, branch strategy, automatic promotion, scale-to-zero) from **Open Questions** (DB strategy, secrets management, test suite scope, cost)
- Fixes an incorrect reference to \`CONTRIBUTING.md\` — the file was listed as \`CLAUDE.md\`
- Adds manual test cases
- Adds \`adr.md\` recording the 5 decided questions with rationale
- **Status: \`ready\` → \`draft\`** — the remaining open questions must be resolved before implementation can begin

## Remaining open questions (must be resolved before implementation)

1. Staging DB strategy (separate Cloud SQL instance vs. dedicated database vs. schema isolation)
2. Secrets management in GCP Secret Manager
3. Which test suite runs against staging
4. Cost estimate for persistent vs. ephemeral staging DB

## Test plan

- [ ] Verify resolved questions match what is actually implementable without further decisions
- [ ] Verify open questions are still genuinely open (not already decided elsewhere)