### PR TITLE
spec: close accessibility open questions and add test cases

### DIFF
--- a/features/accessibility/spec.md
+++ b/features/accessibility/spec.md
@@ -33,16 +33,86 @@ goal is to eliminate the most impactful barriers:
 - DaisyUI theme colors must pass WCAG AA contrast ratio (4.5:1 for normal text, 3:1 for large text)
 - Screen reader announcements for game state changes (whose turn, move result, game outcome)
 
-## Open Questions
+## Decisions
 
-- What WCAG level is the target: A, AA, or AAA?
-- Which screen readers should be tested against? (NVDA/Windows, VoiceOver/macOS+iOS, TalkBack/Android)
-- Should game boards have an alternative text-based interface for screen reader users, or just state
-  announcements via ARIA live regions?
-- Is there a plan to add reduced-motion support for any animations (win animations, transitions)?
-- Who performs the accessibility audit — automated tools (axe, Lighthouse) only, or manual testing too?
-- Are there any legal/compliance requirements (e.g., ADA in the US) that would elevate the priority?
+### WCAG target: AA
+
+WCAG 2.1 AA is the target. Level A is the floor — missing Level A criteria are bugs. Level AAA is out
+of scope for this feature pass; specific AAA criteria can be addressed individually if needed.
+
+### Screen readers: NVDA + VoiceOver (primary)
+
+Primary test targets: NVDA on Windows, VoiceOver on macOS and iOS. These cover the two most common
+screen reader + OS combinations for web. TalkBack on Android is a secondary target — test
+manually if resources allow, but not a blocking gate.
+
+### Game board alternative interface: ARIA live regions only
+
+For non-canvas game boards, use ARIA live regions (`aria-live="polite"`) to announce state changes
+(move results, whose turn, game outcome). No separate text-based alternative interface is provided.
+
+Rationale: a full text-based game interface would be a significant parallel implementation.
+ARIA live regions are the standard web approach and are sufficient for users who want to play with
+a screen reader. If user demand for a richer accessible interface emerges, it can be specced
+separately.
+
+### Reduced motion: support `prefers-reduced-motion`
+
+Any CSS animations or transitions (win animations, drop animations, transitions) must respect
+`prefers-reduced-motion: reduce`. This means instant or near-instant state changes when the user
+has the OS reduced-motion preference set.
+
+### Audit tooling: automated + manual
+
+Automated: axe DevTools (browser extension) + Lighthouse a11y audit. These catch ~30–40% of issues.
+Manual: keyboard-only navigation walkthrough + NVDA (Windows) + VoiceOver (macOS). The manual pass
+is required before the feature is considered complete.
+
+### Legal/compliance
+
+No specific legal/compliance requirements (ADA, EN 301 549, etc.) have been identified. WCAG AA is
+adopted as a quality standard, not a compliance obligation. This may change if the site expands to
+institutional users or markets with regulatory requirements.
 
 ## Test Cases
 
-_To be defined during planning session._
+### Automated (axe + Lighthouse)
+
+| Tier | Name | What it checks |
+|------|------|----------------|
+| E2E | `test_a11y_home_page_no_violations` | axe scan of `/` returns zero violations at AA level |
+| E2E | `test_a11y_games_page_no_violations` | axe scan of `/games` returns zero violations |
+| E2E | `test_a11y_about_page_no_violations` | axe scan of `/about` returns zero violations |
+| E2E | `test_a11y_auth_modal_no_violations` | axe scan of AuthModal (open state) returns zero violations |
+| E2E | `test_a11y_game_page_no_violations` | axe scan of a game page (e.g. `/game/tic-tac-toe`) in newgame phase |
+
+### Keyboard navigation
+
+| Tier | Name | What it checks |
+|------|------|----------------|
+| E2E | `test_a11y_nav_keyboard_reachable` | All navbar links reachable via Tab; Enter activates them |
+| E2E | `test_a11y_auth_modal_focus_trap` | Tab cycles within AuthModal while open; focus returns to trigger on close |
+| E2E | `test_a11y_game_board_keyboard_operable` | All interactive board cells/columns reachable via keyboard (TTT, Connect4) |
+
+### Contrast
+
+| Tier | Name | What it checks |
+|------|------|----------------|
+| Manual | DaisyUI theme contrast | All text + interactive elements pass 4.5:1 (normal) / 3:1 (large) ratio in both light and dark themes |
+
+### Screen reader (manual)
+
+| Scenario |
+|---|
+| NVDA + Chrome: navigate home page, games list, and about page via screen reader only |
+| NVDA + Chrome: start a TTT game; verify whose-turn and move-result announcements via live regions |
+| VoiceOver + Safari: same navigation and game flow as above |
+| NVDA + Chrome: open and close AuthModal using keyboard; verify focus trap and restoration |
+| VoiceOver + iOS Safari: verify all nav links and game pages are reachable on mobile |
+| Canvas (Pong): verify `aria-label` is present on the `<canvas>` element; verify surrounding UI is keyboard-accessible |
+
+### Reduced motion
+
+| Tier | Name | What it checks |
+|------|------|----------------|
+| E2E | `test_a11y_reduced_motion_no_animation` | With `prefers-reduced-motion: reduce` set, Connect4 drop animation and win animations do not play |


### PR DESCRIPTION
## Summary

`features/accessibility/spec.md` had 6 open questions and placeholder test cases. This PR closes all of them and adds concrete test cases.

**Questions closed:**
1. WCAG target: **AA** (Level A = bug floor; AAA out of scope)
2. Screen readers: **NVDA + VoiceOver** primary; TalkBack secondary/best-effort
3. Board interface for screen readers: **ARIA live regions only** (no text-based parallel game interface)
4. Reduced motion: **yes**, respect `prefers-reduced-motion` on all animations
5. Audit tooling: **axe + Lighthouse** automated, plus manual NVDA + VoiceOver walkthrough
6. Legal/compliance: **none identified**; WCAG AA is a quality standard, not a legal obligation

**Added:** Test cases in 5 categories: automated axe scans, keyboard nav, contrast (manual), screen reader (manual), and reduced motion.

## Test plan

- [ ] Verify decisions are reasonable given the site's current tech stack (Tailwind + DaisyUI + React)
- [ ] Verify test cases are achievable with Playwright + axe-core (standard pairing)