### PR TITLE
spec: close profile-settings open questions, add API endpoints and test cases

### DIFF
--- a/features/profile-settings/spec.md
+++ b/features/profile-settings/spec.md
@@ -21,7 +21,8 @@ Implement the Profile and Settings pages with real content and backend support.
 - Change display name
 - Change password (local auth users only)
 - Account info (email, auth provider — read-only)
-- Account deletion or deactivation (open question)
+- Stats visibility toggle (public/private — see game-statistics spec)
+- Account deletion
 
 ## Known Requirements
 
@@ -33,16 +34,102 @@ Implement the Profile and Settings pages with real content and backend support.
 - Password changes require current password confirmation before accepting a new one
 - Google OAuth users have no password — password change UI must be hidden for them
 
-## Open Questions
+## Decisions
 
-- Should the Profile page show a per-game stats breakdown, or only aggregate totals?
-- Is there a game history / recent games list on the Profile page?
-- Avatar / profile picture support? (Upload, Gravatar, or initials-only?)
-- Should Settings include notification preferences? (If we add email notifications later)
-- Account deletion: soft delete (deactivate) or hard delete? What happens to game history?
-- Should users be able to link/unlink Google OAuth from an existing local account?
-- Display name uniqueness: is it enforced, or can two users share a display name?
+### Profile stats: per-game breakdown
+
+The profile page shows a per-game stats grid, not aggregate totals. One row (or card) per game type
+showing games played, win rate, and best streak. This matches the data shape from `GET /api/stats/me`
+which already returns per-game breakdowns. The game-statistics spec defines this section in detail.
+
+### Game history: not in v1
+
+No game history / recent games list on the Profile page in this feature. Game history is a future
+enhancement. The profile page shows stats only.
+
+### Avatar: initials only
+
+No avatar upload, Gravatar, or profile picture support. The profile page uses the same initials
+fallback as `PlayerCard` (first letter of display name on a colored circle). Avatar upload is a
+future enhancement.
+
+### Account deletion: soft delete
+
+Account deletion deactivates the user (`is_active = false`) rather than hard-deleting the row.
+Game history and stats data are retained. The user cannot sign in after deactivation. The email
+address is not freed (cannot re-register with the same email after deletion).
+
+A hard-delete option can be added later if required by GDPR right-to-erasure requests, but soft
+delete satisfies the common case and is reversible.
+
+### Display name uniqueness: not enforced
+
+Display names do not need to be unique. Two users can share the same display name. Uniqueness
+enforcement would require a migration and UX for conflict resolution — not worth the complexity
+given that user_id is the primary identity in all game data.
+
+### Notification preferences: deferred
+
+No notification preferences in this feature. There is no email notification system. This section
+is added when notifications are introduced.
+
+### Account linking: handled by google-oauth spec
+
+Linking/unlinking Google OAuth from a local account is handled in the google-oauth spec. The Settings
+page surfaces the current auth provider (read-only). A "Link Google account" button is a follow-on.
+
+## API Endpoints
+
+### `PATCH /api/auth/settings` (new)
+
+Updates user settings. Lives in `auth.py` for organizational consistency with other user/account
+routes. Fields are optional; only provided fields are updated.
+
+**Request:**
+```json
+{
+  "display_name": "NewName",
+  "current_password": "oldpass",
+  "new_password": "newpass",
+  "stats_public": true
+}
+```
+
+`current_password` and `new_password` must both be provided together or not at all. Google OAuth
+users may not submit password fields.
+
+**Response 200:** Updated user object (same shape as `/api/auth/me`).
+
+**Response 400:** Validation error (e.g. missing `current_password` when `new_password` provided).
+
+**Response 401:** `current_password` does not match.
+
+**Response 403:** Google OAuth user attempting a password change.
+
+### `DELETE /api/auth/account` (new)
+
+Soft-deletes the authenticated user's account. Sets `is_active = false`.
+
+**Response 200:** `{"message": "Account deactivated."}`
+
+**Response 401:** Unauthenticated.
 
 ## Test Cases
 
-_To be defined during planning session._
+| Tier | Name | What it checks |
+|------|------|----------------|
+| API integration | `test_settings_update_display_name` | PATCH with display_name updates users row |
+| API integration | `test_settings_change_password_success` | PATCH with correct current_password and new_password updates hash |
+| API integration | `test_settings_change_password_wrong_current` | PATCH with wrong current_password returns 401 |
+| API integration | `test_settings_oauth_user_cannot_change_password` | Google OAuth user PATCH with password fields returns 403 |
+| API integration | `test_settings_update_stats_public` | PATCH with stats_public=true updates column; GET /api/stats/user/{id} now returns data |
+| API integration | `test_account_deletion_soft_deletes` | DELETE /api/auth/account sets is_active=false; subsequent login returns 401 |
+| API integration | `test_account_deletion_retains_game_data` | After deletion, game records for the user still exist in DB |
+| E2E | `test_profile_page_shows_display_name` | Navigate to /profile; display name and email rendered |
+| E2E | `test_profile_page_shows_per_game_stats` | Per-game stats grid renders with data from /api/stats/me |
+| E2E | `test_profile_page_stats_loading_state` | Profile page renders gracefully when stats API is slow or unavailable |
+| E2E | `test_settings_display_name_update_flow` | Change display name in settings, save, verify change reflected on profile |
+| E2E | `test_settings_password_change_flow` | Enter current and new password, save, verify old password no longer works |
+| E2E | `test_settings_oauth_user_no_password_section` | Google OAuth user does not see password change UI |
+| E2E | `test_settings_stats_public_toggle` | Toggle stats_public in settings; verify leaderboard visibility changes |
+| Manual | Account deletion end-to-end | Delete account; verify cannot log in; verify stats no longer visible on leaderboard |


### PR DESCRIPTION
## Summary

\`features/profile-settings/spec.md\` had 7 open questions and placeholder test cases. This PR closes all of them, adds concrete API endpoint specs, adds test cases, and establishes the implementation ordering with game-statistics.

**Questions closed:**
1. Stats on profile: **per-game breakdown** (matching game-statistics spec shape)
2. Game history: **not in v1** — stats only; history is a future feature
3. Avatar: **initials only** — consistent with PlayerCard spec; no upload
4. Account deletion: **soft delete** (\`is_active = false\`, data retained)
5. Display name uniqueness: **not enforced**
6. Notification preferences: **deferred** (no email system)
7. Account linking: **handled by google-oauth spec**, out of scope here

**Endpoint ownership clarified:**
- \`PATCH /api/auth/settings\` is defined and owned by **profile-settings**
- game-statistics extends this endpoint by adding the \`stats_public\` field — it does not create a new endpoint
- game-statistics status updated to reflect that it **cannot begin implementation until profile-settings is fully deployed**

**Added:**
- API endpoint specs for \`PATCH /api/auth/settings\` and \`DELETE /api/auth/account\`
- 15 test cases (API integration, E2E, manual)

## Test plan

- [ ] Verify soft delete decision is consistent with how \`is_active\` is used elsewhere in auth.py
- [ ] Verify PATCH /api/auth/settings is not duplicated in game-statistics (game-statistics should only extend it)
- [ ] Verify stats_public toggle test case is consistent with game-statistics spec