### PR TITLE
fix(ci): skip webServer startup when running smoke tests against production

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -34,7 +34,7 @@ module.exports = defineConfig({
     /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
     use: {
         /* Base URL to use in actions like `await page.goto('/')`. */
-        baseURL: 'http://localhost:8000',
+        baseURL: process.env.BASE_URL || 'http://localhost:8000',
 
         /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
         trace: 'on-first-retry',
@@ -76,15 +76,22 @@ module.exports = defineConfig({
        */
     ],
 
-    /* Run your local dev server before starting the tests */
-    webServer: {
-        command: 'bash -c "cd src/backend && python -m uvicorn app:app --host 0.0.0.0 --port 8000"',
-        url: 'http://localhost:8000',
-        reuseExistingServer: !process.env.CI,
-        timeout: 120 * 1000,
-        env: {
-            NODE_ENV: 'test',
-            PORT: '8000',
-        },
-    },
+    /* Run your local dev server before starting the tests.
+     * Skipped when BASE_URL points to a non-localhost host (e.g. post-deploy smoke run). */
+    webServer: (() => {
+        const base = process.env.BASE_URL || '';
+        if (base && !base.includes('localhost') && !base.includes('127.0.0.1')) {
+            return undefined;
+        }
+        return {
+            command: 'bash -c "cd src/backend && python -m uvicorn app:app --host 0.0.0.0 --port 8000"',
+            url: 'http://localhost:8000',
+            reuseExistingServer: !process.env.CI,
+            timeout: 120 * 1000,
+            env: {
+                NODE_ENV: 'test',
+                PORT: '8000',
+            },
+        };
+    })(),
 });


### PR DESCRIPTION
## Summary

- Post-deploy smoke tests were failing with `Exit code: 1` because Playwright's `webServer` block tried to start a local uvicorn server in the GitHub Actions runner, where Python is not installed
- `playwright.config.js` now skips the `webServer` block entirely when `BASE_URL` is set to a non-localhost URL
- `baseURL` is also read from `BASE_URL` env var so smoke tests correctly hit the production host

## Test plan

- [ ] Post-deploy smoke workflow: `npx playwright test tests/smoke/ --project=chromium` with `BASE_URL=https://game-ai-website-w4453qrbcq-uc.a.run.app` should no longer fail with webServer startup error
- [ ] Local E2E runs (no `BASE_URL` set): webServer still starts uvicorn as before — no regression
- [ ] CI E2E runs (`BASE_URL=http://localhost:8000`): webServer still starts — no regression