### PR TITLE
docs: restructure CLAUDE.md and AGENTS.md by instruction layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,44 +1,27 @@
 # AI assistants in this repository
 
-Human-readable defaults for automation and coding agents. **Authoritative detail:** [CONTRIBUTING.md](CONTRIBUTING.md).
+Agent-specific behavioral rules. **Project facts:** [CLAUDE.md](CLAUDE.md). **Full detail:** [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Non-negotiables
 
-- **Spec-first:** Non-trivial work is driven by `features/<name>/spec.md` (see CONTRIBUTING). Do not ship behavior that
-  is not reflected in the spec and its **Test Cases** section.
-- **ADR when it matters:** If the change encodes a significant, long-lived architectural or product decision, add or
-  update `adr.md` in the same feature folder (see CONTRIBUTING for the bar).
-- **Code locations:** Backend in `src/backend/`, frontend in `src/frontend/src/`, shared styles in
-  `src/frontend/src/styles/input.css`.
-- **Backend:** Use `logging`, not `print`. Parameterize all SQL (`psycopg2` / `cursor.execute` with placeholders).
-- **Secrets:** Never commit production secrets. Production uses GCP Secret Manager, not checked-in `.env`.
+- **Spec-first:** Non-trivial work is driven by `features/<name>/spec.md`. Do not ship behavior that is not reflected in the spec and its **Test Cases** section.
+- **ADR when it matters:** If the change encodes a significant, long-lived architectural or product decision, add or update `adr.md` in the same feature folder (see CONTRIBUTING for the bar).
 
 ## Before you push
 
-- Run **`npm run test:fast`** locally before every push (covers Vitest, pytest unit, ESLint, Prettier). Add tiers from
-  CONTRIBUTING when appropriate. **Do not** push untested and rely on CI for format/lint/tests; **`--no-verify`** only
-  if the user explicitly allows it.
-- CI gate on GitHub: **Test Summary**.
-
-## Pull requests
-
-Unless the user opts out: after **`gh pr create`**, run **`gh pr checks <pr> --watch`**. When marking ready to land, use
-**`gh pr merge <pr> --auto --squash`** by default.
-
-**GitHub writes from agents:** Run **`gh pr create`**, **`gh pr edit`**, and **`gh pr merge`** only in a **local**
-terminal where `gh` is you (see **CONTRIBUTING.md §1e**). On **sub-agents**, skip those commands and use the **§1c
-handoff** block in CONTRIBUTING so a local session or the human applies the title, body, and merge.
+Run `npm run test:fast` locally before every push (covers Vitest, pytest unit, ESLint, Prettier). Do not push untested and rely on CI for format/lint/tests; `--no-verify` only if the user explicitly allows it.
 
 ## Planning vs implementation
 
-If the user has not said whether the task is **planning** (spec/design) or **implementation**, ask once. Planning
-follows CONTRIBUTING’s design steps; implementation follows the finalized spec.
+If the user has not said whether the task is **planning** (spec/design) or **implementation**, ask once. Planning follows CONTRIBUTING's design steps; implementation follows the finalized spec.
+
+## Pull requests
+
+**GitHub writes from agents:** Run `gh pr create`, `gh pr edit`, and `gh pr merge` only in a **local** terminal where `gh` is authenticated as you (see **CONTRIBUTING.md §1e**). On sub-agents, skip those commands and use the **§1c handoff** block in CONTRIBUTING so a local session or the human applies the title, body, and merge.
 
 ## Sub-agents
 
-**GitHub CLI:** Sub-agents should use **`gh pr view` / `diff` / `checks`** only. For **`gh pr edit`**,
-**`gh pr merge`**, or **`gh pr create`**, follow **CONTRIBUTING.md §1c handoff** and run writes **locally** (or on the
-GitHub website). See **§1e** for authentication constraints on sub-agents.
+Use `gh pr view`, `gh pr diff`, and `gh pr checks` freely. For `gh pr edit`, `gh pr merge`, or `gh pr create`, follow **CONTRIBUTING.md §1c handoff**. See **§1e** for authentication constraints.
 
 ### Services overview
 
@@ -64,26 +47,13 @@ DB_HOST=localhost DB_PORT=5432 DB_NAME=ai_game_db DB_USER=dev_user DB_PASSWORD=d
 DB_HOST=localhost DB_PORT=5432 DB_NAME=ai_game_db DB_USER=dev_user DB_PASSWORD=dev_password python3 scripts/seed_test_data.py
 ```
 
-### Running tests
-
-See **[CONTRIBUTING.md](CONTRIBUTING.md)** (Running tests) and `package.json` scripts. Key commands:
-
-- `npm run test:fast` — Vitest + pytest unit + lint + format (no DB needed)
-- Integration/API tests need `docker compose -f docker-compose.test.yml up -d` (port 5433)
-
 ### Non-obvious notes
 
 - Node.js 20 is required (not 22). Use `nvm use 20`.
-- `npm run test:fast` invokes pytest via **`python3`**. Ensure `python3` is on PATH; on some VMs a `python` → `python3`
-  symlink is added. If a fresh VM is missing it, recreate it.
+- `npm run test:fast` invokes pytest via `python3`. Ensure `python3` is on PATH.
 - Python packages may install to `~/.local/bin` — ensure it is on PATH.
-- Docker is needed for PostgreSQL. In sub-agent environments, Docker may require `fuse-overlayfs` storage driver and
-  `iptables-legacy` — see setup hints in the environment documentation.
-- The OTel console exporter may log `ValueError: I/O operation on closed file` after pytest runs. This is benign and
-  does not indicate test failure.
-- The ESLint `--max-warnings=0` check (`lint:check`) may flag existing JSDoc warnings — treat as pre-existing unless
-  your change touched those files.
-- The Husky pre-push hook runs `npm run test:fast`. Prefer fixing failures locally over `--no-verify`; CI remains the
-  merge gate.
-- The backend serves the built frontend from `dist/` — run `npm run build` before starting the backend if you need the
-  full app at port 8000 without the Vite dev server.
+- Docker is needed for PostgreSQL. In sub-agent environments, Docker may require `fuse-overlayfs` storage driver and `iptables-legacy`.
+- The OTel console exporter may log `ValueError: I/O operation on closed file` after pytest runs. This is benign.
+- The ESLint `--max-warnings=0` check (`lint:check`) may flag existing JSDoc warnings — treat as pre-existing unless your change touched those files.
+- The Husky pre-push hook runs `npm run test:fast`. Prefer fixing failures locally over `--no-verify`; CI remains the merge gate.
+- The backend serves the built frontend from `dist/` — run `npm run build` before starting the backend if you need the full app at port 8000 without the Vite dev server.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,55 @@
-# Deprecated — use CONTRIBUTING.md
+# AI Game Hub — Project Context
 
-Project conventions, spec-driven workflow, ADRs, tests, branch hygiene, and stack details live in
-**[CONTRIBUTING.md](CONTRIBUTING.md)** — including **GitHub / GCP auth for coding agents** (**§1e**).
+## Stack
 
-AI assistants: see **[AGENTS.md](AGENTS.md)**.
+- Backend: FastAPI (Python 3.11+), PostgreSQL via psycopg2
+- Frontend: React 18 + TypeScript, Vite, React Router v6, TanStack Query, Zustand, Tailwind CSS + DaisyUI
+- Observability: OpenTelemetry — auto-instrumented FastAPI + psycopg2; GCP Cloud Trace + Cloud Monitoring in prod, console exporter locally
+- Testing: Vitest (unit), pytest (unit), Playwright (E2E / API / smoke)
+- CI/CD: GitHub Actions (CI tests) + GCP Cloud Build (build & deploy) → GCP Cloud Run
+- Secrets: GCP Secret Manager — never use `.env` in production
+- Logs: GCP Cloud Logging via stdout from Cloud Run — never use `print()`
 
-This file remains so older links and habits still land in the right place.
+## Code locations
+
+- Backend: `src/backend/`
+- Frontend: `src/frontend/src/`
+- Styles: `src/frontend/src/styles/input.css`
+
+## Conventions
+
+**Backend:** Use `logging`, not `print`. All DB queries use parameterized statements via psycopg2 `cursor.execute`.
+
+**Secrets:** Never commit production secrets. Use GCP Secret Manager in production.
+
+**Docstrings:** All public Python functions use Google-style docstrings. All exported TypeScript functions and React components use JSDoc.
+
+## Dependency management
+
+Python dependencies are managed with pip-tools.
+
+- `requirements.in` — edit directly; lists direct dependencies only, no version pins
+- `requirements.txt` — auto-generated lockfile; never edit manually; regenerate with `pip-compile`
+
+To add or remove a dependency: edit `requirements.in`, then run:
+
+```bash
+python -m piptools compile requirements.in --output-file requirements.txt --strip-extras --upgrade
+```
+
+Commit both files together.
+
+## Testing
+
+- `npm run test:fast` — Vitest + pytest unit + ESLint + Prettier (no DB needed)
+- Integration/API tests require `docker compose -f docker-compose.test.yml up -d` (port 5433)
+- CI gate: **Test Summary** check on GitHub
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full test tier details (unit / API integration / E2E / manual).
+
+## Feature workflow
+
+Non-trivial work is driven by `features/<name>/spec.md`. Each spec must include a **Test Cases** section listing tier, scenario, and test name. A feature is not complete until all automated test cases pass in CI.
+
+See [AGENTS.md](AGENTS.md) for agent-specific behavioral rules.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for full setup and workflow details.


### PR DESCRIPTION
## Summary

- Replaces the `CLAUDE.md` deprecation stub with project facts: stack, code locations, conventions, dependency management, testing approach, and feature workflow pointer
- Strips `AGENTS.md` down to agent-only behavioral rules: spec-first, ADR requirement, push/PR auth constraints, sub-agent guidance, startup commands, and non-obvious ops notes
- Eliminates duplication between the two files — each layer now has a single, clear responsibility

## Instruction hierarchy after this change

| Layer | File | What lives there |
|---|---|---|
| Personal | `~/.claude/CLAUDE.md` | Response style, PR watch/merge workflow |
| Project facts | `CLAUDE.md` | Stack, code locations, conventions, testing, dep management |
| Agent behavior | `AGENTS.md` | Spec-first, ADR, auth constraints, startup commands |

## What moved out of AGENTS.md

- PR workflow (`gh pr merge --auto --squash`, `--watch`) → `~/.claude/CLAUDE.md` (personal preference)
- Stack, code locations, secrets, logging, docstring, and dep management content → `CLAUDE.md`
- "Unless the user opts out" opt-in language (personal preference framing) — removed entirely

## Test plan

- [ ] Review `CLAUDE.md` — confirm it reads as project facts with no behavioral instructions
- [ ] Review `AGENTS.md` — confirm it contains only agent behavioral rules with no personal preferences or project facts
- [ ] Verify no content was lost (check against prior `AGENTS.md` — all kept content should appear in one of the two files)