### PR TITLE
plan: split per-game-bugs into per-game specs

### DIFF
--- a/features/per-game-bugs-checkers/spec.md
+++ b/features/per-game-bugs-checkers/spec.md
@@ -1,0 +1,52 @@
+# Checkers Bug Fixes
+
+**Status: ready**
+
+## Background
+
+Bugs from issue #99. Implement after `ux-game-standardization` and `ai-delay-config` are merged. The server event pacing
+(Bug 3) is already resolved by `ai-delay-config`; this spec covers the frontend feedback bugs.
+
+## Bugs
+
+### Bug 1: No visual feedback for forced captures
+
+When a player must capture with only certain pieces, other pieces give no visual indication they are out of play for
+this turn.
+
+**Fix**: During the player's turn, if forced capture applies, visually dim/desaturate pieces that cannot be played.
+Squares not reachable under the constraint should also be visually subdued.
+
+### Bug 2: Turn indicator not prominent enough
+
+When the bot makes a forced capture that gives the player another consecutive turn, it is not obvious that: (a) it is
+the player's turn again, and (b) the player must capture again.
+
+**Fix**: Add a prominent animated indicator (e.g. arrow or pulsing highlight) anchored to the active player's side of
+the board. This indicator should be visible any time it is the player's turn.
+
+### Bug 3: AI / server event cadence too fast
+
+Already resolved by the `ai-delay-config` spec. No code changes needed in this PR for pacing. Confirm that the
+`GAME_SERVER_MIN_EVENT_INTERVAL_MS` env var is respected by the checkers SSE path (covered by the integration test added
+in that spec).
+
+## Scope
+
+- `src/frontend/src/pages/games/CheckersPage.tsx` — forced capture visual dimming, turn indicator
+- `src/frontend/src/components/games/CheckersBoard.tsx` — dimming effect on non-playable pieces
+
+## Acceptance Criteria
+
+- During forced capture, pieces that cannot be played this turn appear visually dimmed or desaturated
+- A prominent animated turn indicator is visible whenever it is the player's turn
+- Server event cadence respects `GAME_SERVER_MIN_EVENT_INTERVAL_MS` (verified by existing ai-delay-config integration
+  test)
+
+## Test Cases
+
+| Tier            | Test name                                  | Scenario                                                      |
+| --------------- | ------------------------------------------ | ------------------------------------------------------------- |
+| Unit (Frontend) | `CheckersBoard > dims non-playable pieces` | When forcedCapturePieces is set, other pieces have dim style  |
+| Manual          | Checkers forced capture                    | Only capturable pieces are highlighted; others visually muted |
+| Manual          | Checkers turn indicator                    | Animated indicator visible and anchored to player side        |

--- a/features/per-game-bugs-chess/spec.md
+++ b/features/per-game-bugs-chess/spec.md
@@ -1,0 +1,102 @@
+# Chess Bug Fixes
+
+**Status: ready**
+
+## Background
+
+Bugs from issue #98. Implement after `ux-game-standardization` and `ai-delay-config` are merged. Contains both frontend
+display bugs and a backend persistence migration (FEN/SAN normalization). This is the largest per-game spec and should
+be implemented in its own dedicated PR.
+
+## Global Conventions (from per-game-bugs parent spec)
+
+- **`board_state`**: valid FEN string after every applied move (instant resume and validation).
+- **`move_list`**: SAN per half-move, append-only (human-readable and ML-friendly).
+- **PGN**: regenerated from `move_list` + session metadata on demand; not stored as a growing blob.
+- **Optimistic move rejection**: if the server rejects an optimistic move, snap to the server's authoritative
+  `board_state` immediately with a user-visible error. No success animation for a rejected move.
+
+## Bugs
+
+### Bug 1: Player color at bottom
+
+The player's pieces are always rendered at the top of the board regardless of which color they chose. The player's color
+must always appear at the bottom (standard chess orientation).
+
+**Fix**: When rendering the board, flip the rank/file indices when the player is playing Black.
+
+### Bug 2: Piece images not used
+
+Piece icons are showing as letters. Chess piece SVGs/PNGs exist in `/src/frontend/public/images/`. Use them.
+
+**Fix**: Replace the letter fallback with `<img>` tags pointing to the correct image for each piece type and color.
+
+### Bug 3: Captured pieces should use piece images
+
+The captured pieces shown in the panel currently display as letters. Use the same scaled-down piece images from Bug 2.
+
+**Fix**: Render captured piece images at ~60% size of board pieces, grouped by piece type.
+
+### Bug 4: Board state and notation for resume, UI, and analysis (backend migration)
+
+**Backend**: `board_state` must be a **valid FEN** string after every persisted move (replace arbitrary JSON shapes).
+`move_list` holds **SAN** half-moves only (append-only). For consumers that need a **PGN document**, **regenerate** it
+from `move_list` plus session metadata (player names, date, result); do not store an authoritative growing PGN column.
+
+**Fix**: Normalize chess persistence to FEN + SAN. Wire PGN generation at export/API boundaries where the DS pipeline or
+downloads need the full string.
+
+### Bug 5: Move notation must be Algebraic Notation
+
+The move list currently shows raw coordinate pairs (e.g. `e2-e4`). Display Standard Algebraic Notation (e.g. `e4`,
+`Nf3`, `O-O`).
+
+### Bug 6: Layout scrolls when move list is long
+
+The page should never require vertical scrolling. When the move list grows, it should scroll internally within a
+fixed-height container. Captured pieces panels and board layout must stay on screen at all viewport sizes.
+
+**Fix**: Give the move list and captures panels `overflow-y: auto` with `max-height` computed from the board height.
+Board height stays fixed.
+
+## Scope
+
+### Frontend
+
+- `src/frontend/src/pages/games/ChessPage.tsx` — board orientation, layout, AN display, captures panel; optimistic
+  rejection behavior (snap to server state + error on rejection)
+- `src/frontend/src/components/games/ChessBoard.tsx` — piece image rendering, board flip for Black
+
+### Backend
+
+- Chess game persistence: `board_state` → FEN, `move_list` → SAN array, PGN regenerated when needed
+- Alembic migration if the column schema changes (FEN string vs current JSON shape)
+
+## Acceptance Criteria
+
+- Player's pieces appear at the bottom regardless of chosen color
+- Piece images rendered from `/public/images/` (not letter fallbacks)
+- Captured pieces panel uses scaled piece images grouped by type
+- `board_state` is a valid FEN string after every persisted move
+- Move list displays SAN (not coordinate pairs)
+- PGN can be regenerated from `move_list` + session metadata
+- Page does not scroll at 1280×800 with 10+ moves and captures on both sides
+- Rejected optimistic moves snap to server state with user-visible error; no success animation
+
+## Test Cases
+
+| Tier            | Test name                                         | Scenario                                                                                         |
+| --------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| Unit (Frontend) | `ChessBoard > renders piece images not letters`   | Piece element is an `<img>`, not text                                                            |
+| Unit (Frontend) | `ChessBoard > flips board for black player`       | Rank 1 appears at bottom when playerColor=black                                                  |
+| Unit (Python)   | `test_chess_move_stores_fen`                      | After each move, `board_state` is a valid FEN string                                             |
+| Unit (Python)   | `test_chess_pgn_regenerated_from_moves`           | Given SAN `move_list` and metadata, regenerated PGN matches expected movetext/headers            |
+| API             | `test_chess_move_response_has_algebraic_notation` | Move response includes AN string                                                                 |
+| Unit (Frontend) | `optimisticMoveRejectedSnapsState`                | On move error response, board matches server payload and error UI shown; no completion animation |
+| Manual          | Chess layout                                      | No scrollbar at 1280×800 viewport with 10+ moves and captures on both sides                      |
+
+## Notes
+
+- The backend migration for FEN/SAN is the highest-risk part of this spec. Recommend implementing and testing it
+  independently before touching frontend display bugs.
+- Existing chess sessions with non-FEN `board_state` values will need a migration or graceful fallback on resume.

--- a/features/per-game-bugs-connect4/spec.md
+++ b/features/per-game-bugs-connect4/spec.md
@@ -1,0 +1,41 @@
+# Connect 4 Bug Fixes
+
+**Status: ready**
+
+## Background
+
+Bugs from issue #97. Implement after `ux-game-standardization` and `ai-delay-config` are merged.
+
+## Bugs
+
+### Bug 1: Column click target too narrow
+
+Clicking on the board column body does nothing; only the small arrow button above the column works.
+
+**Fix**: Make each column a clickable drop zone. The `onClick` handler should fire for clicks anywhere in the column,
+not only on the arrow button.
+
+### Bug 2: No column hover preview
+
+Hovering over a column (or its button) should show a preview piece at the top of that column with reduced opacity,
+matching the player's color.
+
+**Fix**: Track `hoveredCol` state. When hovering, render a preview piece (50% opacity) in the top cell of that column if
+the column is not full and the game is in the player's turn.
+
+## Scope
+
+- `src/frontend/src/pages/games/Connect4Page.tsx` — column click zone, hover preview
+
+## Acceptance Criteria
+
+- Clicking anywhere in a column drops a piece (not only the arrow button)
+- Hovering a column shows a 50% opacity preview piece at the top when it is the player's turn and the column is not full
+
+## Test Cases
+
+| Tier            | Test name                                      | Scenario                                      |
+| --------------- | ---------------------------------------------- | --------------------------------------------- |
+| Unit (Frontend) | `Connect4Board > column click triggers drop`   | Click column body fires onColumnClick         |
+| Unit (Frontend) | `Connect4Board > hovered column shows preview` | hoveredCol state renders preview piece        |
+| E2E             | `connect4 > drop piece by clicking column`     | Click column body, piece lands in correct row |

--- a/features/per-game-bugs-dots-and-boxes/spec.md
+++ b/features/per-game-bugs-dots-and-boxes/spec.md
@@ -1,0 +1,35 @@
+# Dots and Boxes Bug Fixes
+
+**Status: ready**
+
+## Background
+
+Bugs from issue #96. Implement after `ux-game-standardization` is merged.
+
+## Bugs
+
+### Bug 1: Box fill icon
+
+When a player or AI claims a box, the box should show the claimer's icon in the center — use the player avatar icon and
+a bot icon, not a plain color fill.
+
+### Bug 2: Button alignment
+
+"Go first" / "Go second" buttons are slightly off-center to the left. Fix alignment.
+
+## Scope
+
+- `src/frontend/src/pages/games/DotsAndBoxesPage.tsx` — button alignment
+- `src/frontend/src/components/games/DotsAndBoxesBoard.tsx` — box fill icon rendering
+
+## Acceptance Criteria
+
+- Claimed boxes display the player avatar icon or a bot icon centered in the box cell
+- "Go first" / "Go second" buttons are horizontally centered
+
+## Test Cases
+
+| Tier            | Test name                                        | Scenario                                             |
+| --------------- | ------------------------------------------------ | ---------------------------------------------------- |
+| Unit (Frontend) | `DotsAndBoxesBoard > claimed box renders icon`   | Box element contains img/icon, not only a color fill |
+| E2E             | `dots-and-boxes > claimed box shows player icon` | After claiming a box, icon appears in the cell       |

--- a/features/per-game-bugs/spec.md
+++ b/features/per-game-bugs/spec.md
@@ -1,13 +1,23 @@
 # Per-Game Bug Fixes
 
-**Status: ready** — implement after ux-game-standardization merges
+**Status: done** — split into per-game specs; see below
 
 ## Background
 
 Bugs filed in issues #96-#99 from March 28, 2026. Items made obsolete by `features/ux-game-standardization` (game-over
-overlay, move-shown-immediately) are excluded here. This spec covers only the remaining game-specific bugs.
+overlay, move-shown-immediately) are excluded here.
 
-**Implement after `ux-game-standardization` is merged.**
+This omnibus spec has been split into per-game implementation specs, each intended as its own PR:
+
+- [`features/per-game-bugs-connect4/spec.md`](../per-game-bugs-connect4/spec.md) — column click zone, hover preview
+- [`features/per-game-bugs-dots-and-boxes/spec.md`](../per-game-bugs-dots-and-boxes/spec.md) — box fill icon, button
+  alignment
+- [`features/per-game-bugs-checkers/spec.md`](../per-game-bugs-checkers/spec.md) — forced capture visual, turn indicator
+- [`features/per-game-bugs-chess/spec.md`](../per-game-bugs-chess/spec.md) — board orientation, piece images, FEN/SAN
+  migration, AN notation, layout
+
+The global min event interval (Bug 3 in Checkers) is resolved by the `ai-delay-config` spec. The Games Page label fixes
+(GamesPage.tsx) were already implemented.
 
 Formal cross-cutting decisions (move storage vs PGN export, global event interval, optimistic UI): **`adr.md`**.
 


### PR DESCRIPTION
## Summary

Splits the omnibus `per-game-bugs` spec into four focused implementation specs, one per game. No code changes — spec files only.

**New specs (each `ready`, each intended as its own PR):**

- `features/per-game-bugs-connect4/` — column click zone, hover preview
- `features/per-game-bugs-dots-and-boxes/` — box fill icon, button alignment
- `features/per-game-bugs-checkers/` — forced capture visual dimming, turn indicator (pacing already resolved by ai-delay-config)
- `features/per-game-bugs-chess/` — board orientation, piece images, FEN/SAN backend migration, AN notation, layout scroll fix

The original `features/per-game-bugs/spec.md` is marked `done` and updated with links to the new per-game specs.

## Why

Chess alone has a backend FEN/SAN migration + 5 frontend bugs — too large and risky to bundle with the other games. Each game spec can now be implemented in a dedicated conversation with full context.