### PR TITLE
fix(connect4): add unit tests for column click and hover preview

### DIFF
--- a/features/per-game-bugs-connect4/spec.md
+++ b/features/per-game-bugs-connect4/spec.md
@@ -1,6 +1,6 @@
 # Connect 4 Bug Fixes
 
-**Status: ready**
+**Status: implemented**
 
 ## Background
 

--- a/src/frontend/src/components/games/Connect4Board.test.tsx
+++ b/src/frontend/src/components/games/Connect4Board.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import Connect4Board from './Connect4Board';
@@ -18,15 +18,25 @@ describe('Connect4Board', () => {
         onColumnClick: vi.fn(),
     };
 
-    it('connect4 board click calls move with column', async () => {
+    it('column click triggers drop', async () => {
         const user = userEvent.setup();
         const onColumnClick = vi.fn();
         const { container } = render(<Connect4Board {...defaultProps} onColumnClick={onColumnClick} />);
-        const clickableElements = container.querySelectorAll('[class*="cursor-pointer"]');
-        if (clickableElements.length > 0) {
-            await user.click(clickableElements[0]);
-            expect(onColumnClick).toHaveBeenCalled();
-        }
+        const boardGrid = container.querySelector('.bg-blue-700');
+        const cells = boardGrid?.querySelectorAll('.bg-blue-900');
+        expect(cells?.length).toBeGreaterThan(0);
+        await user.click(cells![0]);
+        expect(onColumnClick).toHaveBeenCalledWith(0);
+    });
+
+    it('hovered column shows preview', async () => {
+        const user = userEvent.setup();
+        const { container } = render(<Connect4Board {...defaultProps} />);
+        const boardGrid = container.querySelector('.bg-blue-700');
+        const cells = boardGrid?.querySelectorAll('.bg-blue-900');
+        await user.hover(cells![cells!.length - 7]);
+        const preview = container.querySelector('[class*="bg-red-400/50"], [class*="bg-yellow-300/50"]');
+        expect(preview).not.toBeNull();
     });
 
     it('connect4 board full column not clickable', () => {


### PR DESCRIPTION
## Summary

Both Connect4 bugs (column body click zone, hover preview) were already implemented in `Connect4Board.tsx` from prior work. This PR adds the two spec-required named unit tests and marks the spec implemented.

**New tests:**
- `Connect4Board > column click triggers drop` — clicking a board cell fires `onColumnClick` with the correct column index
- `Connect4Board > hovered column shows preview` — hovering a cell renders a 50%-opacity preview disc at the landing row

## Test plan

- [x] `npm run test:fast` — 23 frontend test files pass, 176 pytest pass