### PR TITLE
fix(dots-and-boxes): replace player P text with person SVG icon in claimed boxes

### DIFF
--- a/features/per-game-bugs-dots-and-boxes/spec.md
+++ b/features/per-game-bugs-dots-and-boxes/spec.md
@@ -1,6 +1,6 @@
 # Dots and Boxes Bug Fixes
 
-**Status: ready**
+**Status: implemented**
 
 ## Background
 

--- a/src/frontend/src/components/games/DotsAndBoxesBoard.test.tsx
+++ b/src/frontend/src/components/games/DotsAndBoxesBoard.test.tsx
@@ -40,7 +40,15 @@ describe('DotsAndBoxesBoard', () => {
                 boxes={{ '0,0': 'player' }}
             />
         );
-        const filledBoxes = container.querySelectorAll('rect[fill*="blue"], rect[class*="blue"]');
         expect(container.querySelector('svg')).toBeInTheDocument();
+    });
+
+    it('claimed box renders icon', () => {
+        const { container } = render(<DotsAndBoxesBoard {...defaultProps} boxes={{ '0,0': 'player', '1,1': 'ai' }} />);
+        const svgGroups = container.querySelectorAll('g[transform*="translate"]');
+        expect(svgGroups.length).toBeGreaterThan(0);
+        const hasCircle = container.querySelector('circle') !== null;
+        const hasRect = container.querySelector('g[transform] rect') !== null;
+        expect(hasCircle || hasRect).toBe(true);
     });
 });

--- a/src/frontend/src/components/games/DotsAndBoxesBoard.tsx
+++ b/src/frontend/src/components/games/DotsAndBoxesBoard.tsx
@@ -84,16 +84,10 @@ export default function DotsAndBoxesBoard({
                 <g key={`box-${r}-${c}`}>
                     <rect x={bx} y={by} width={bw} height={bh} fill={owner === 'player' ? PLAYER_FILL : AI_FILL} />
                     {owner === 'player' ? (
-                        <text
-                            x={iconCx}
-                            y={iconCy + 6}
-                            textAnchor='middle'
-                            fontSize={22}
-                            fontWeight='bold'
-                            fill={PLAYER_COLOR}
-                            opacity={0.7}>
-                            P
-                        </text>
+                        <g transform={`translate(${iconCx - 10}, ${iconCy - 10})`} opacity={0.7}>
+                            <circle cx={10} cy={5} r={4} fill={PLAYER_COLOR} />
+                            <path d='M2 20 C2 14 18 14 18 20' fill={PLAYER_COLOR} />
+                        </g>
                     ) : (
                         <g transform={`translate(${iconCx - 10}, ${iconCy - 10})`} opacity={0.7}>
                             <rect x={2} y={4} width={16} height={12} rx={3} fill={AI_COLOR} />


### PR DESCRIPTION
## Summary
- Replaces the plain `P` text label in player-claimed boxes with an inline person SVG icon, matching the existing robot icon used for AI-claimed boxes
- Adds `DotsAndBoxesBoard > claimed box renders icon` unit test per spec

## Test plan
- [ ] `npm run test:fast` passes (61 tests)
- [ ] Claimed player boxes show a person silhouette icon (circle head + arc body) at 70% opacity
- [ ] Claimed AI boxes unchanged (robot icon still renders)
- [ ] Button alignment already resolved by ux-game-standardization (GameStartOverlay)