### PR TITLE
fix(checkers): add animated turn indicator; test dims non-playable pieces

### DIFF
--- a/features/per-game-bugs-checkers/spec.md
+++ b/features/per-game-bugs-checkers/spec.md
@@ -1,6 +1,6 @@
 # Checkers Bug Fixes
 
-**Status: ready**
+**Status: implemented**
 
 ## Background
 

--- a/src/frontend/src/components/games/CheckersBoard.test.tsx
+++ b/src/frontend/src/components/games/CheckersBoard.test.tsx
@@ -40,4 +40,13 @@ describe('CheckersBoard', () => {
         const { container } = render(<CheckersBoard {...defaultProps} />);
         expect(container.firstChild).toBeTruthy();
     });
+
+    it('dims non-playable pieces', () => {
+        const board = makeInitialBoard();
+        const { container } = render(
+            <CheckersBoard {...defaultProps} board={board} legalPieces={[40]} mustCapture={40} />
+        );
+        const dimmedPieces = container.querySelectorAll('[class*="opacity-35"]');
+        expect(dimmedPieces.length).toBeGreaterThan(0);
+    });
 });

--- a/src/frontend/src/pages/games/CheckersPage.tsx
+++ b/src/frontend/src/pages/games/CheckersPage.tsx
@@ -520,6 +520,14 @@ export default function CheckersPage() {
                         </div>
                     </div>
 
+                    {phase === 'playing' && currentTurn === 'player' && (
+                        <div className='flex items-center justify-center gap-2 py-2 animate-pulse text-primary font-semibold text-sm'>
+                            <span>&#9650;</span>
+                            <span>{mustCapture !== null ? 'Your turn — capture required' : 'Your turn'}</span>
+                            <span>&#9650;</span>
+                        </div>
+                    )}
+
                     <PlayerCard
                         name={user.displayName || user.username}
                         avatarUrl={user.profilePicture}


### PR DESCRIPTION
## Summary
- Adds an animated pulsing turn indicator anchored below the board on the player's side, visible during `phase === 'playing'` when `currentTurn === 'player'`; shows "capture required" text when `mustCapture` is set
- Adds `CheckersBoard > dims non-playable pieces` unit test verifying `opacity-35` is applied to non-interactive pieces during forced capture
- Forced-capture dimming (Bug 1) was already implemented via `isNonInteractivePiece` in CheckersBoard; server pacing (Bug 3) already resolved by ai-delay-config

## Test plan
- [ ] `npm run test:fast` passes (62 tests)
- [ ] During player turn, pulsing "Your turn" indicator visible below board
- [ ] When forced capture applies, indicator shows "Your turn — capture required"
- [ ] Indicator disappears when AI is thinking