### PR TITLE
fix(chess): revert board on rejected move; add FEN/SAN/flip/piece-image tests

### DIFF
--- a/features/per-game-bugs-chess/spec.md
+++ b/features/per-game-bugs-chess/spec.md
@@ -1,6 +1,6 @@
 # Chess Bug Fixes
 
-**Status: ready**
+**Status: implemented**
 
 ## Background
 

--- a/src/frontend/src/components/games/ChessBoard.test.tsx
+++ b/src/frontend/src/components/games/ChessBoard.test.tsx
@@ -55,4 +55,24 @@ describe('ChessBoard', () => {
         const { container } = render(<ChessBoard {...defaultProps} />);
         expect(container.querySelector('[class*="border-amber"]')).toBeInTheDocument();
     });
+
+    it('renders piece images not letters', () => {
+        const { container } = render(<ChessBoard {...defaultProps} />);
+        const imgs = container.querySelectorAll('img[src*="/images/"]');
+        expect(imgs.length).toBeGreaterThan(0);
+        const pieceLetters = container.querySelectorAll('[class*="piece-letter"]');
+        expect(pieceLetters.length).toBe(0);
+    });
+
+    it('flips board for black player', () => {
+        const { container: whiteContainer } = render(<ChessBoard {...defaultProps} playerColor='white' />);
+        const { container: blackContainer } = render(<ChessBoard {...defaultProps} playerColor='black' />);
+        const whiteSquares = whiteContainer.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        const blackSquares = blackContainer.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        expect(whiteSquares.length).toBeGreaterThanOrEqual(64);
+        expect(blackSquares.length).toBeGreaterThanOrEqual(64);
+        const whiteFirstImg = whiteContainer.querySelector('img');
+        const blackFirstImg = blackContainer.querySelector('img');
+        expect(whiteFirstImg?.getAttribute('alt')).not.toBe(blackFirstImg?.getAttribute('alt'));
+    });
 });

--- a/src/frontend/src/pages/games/ChessPage.tsx
+++ b/src/frontend/src/pages/games/ChessPage.tsx
@@ -342,6 +342,7 @@ export default function ChessPage() {
         promotionPiece: string | null
     ) => {
         const movingPiece = board[fromRow][fromCol];
+        const prevBoard = board.map(r => [...r]);
         setSelectedSquare(null);
         setLegalDestinations([]);
         setBoardLocked(true);
@@ -374,8 +375,14 @@ export default function ChessPage() {
             await chessMove(fromRow, fromCol, toRow, toCol, promotionPiece ?? undefined);
         } catch (err) {
             const status = (err as { status?: number }).status;
-            if (status === 401) setShowAuthModal(true);
-            else setBoardLocked(false);
+            if (status === 401) {
+                setShowAuthModal(true);
+            } else {
+                setBoard(prevBoard);
+                setLastMove(null);
+                setStatusText('Move rejected — please try again.');
+                setBoardLocked(false);
+            }
         }
     };
 

--- a/tests/unit/test_chess_engine.py
+++ b/tests/unit/test_chess_engine.py
@@ -131,3 +131,16 @@ def test_chess_ai_returns_legal_move(engine, fresh_state):
     assert engine.validate_move(ai_state, move) is True
     assert eval_ is not None
     assert -1.0 <= eval_ <= 1.0
+
+
+def test_chess_move_stores_fen(engine, fresh_state):
+    import re
+
+    move = {"fromRow": 6, "fromCol": 4, "toRow": 4, "toCol": 4}
+    new_state = engine.apply_move(fresh_state, move)
+    fen = new_state.get("fen")
+    assert fen is not None, "state['fen'] must be set after apply_move"
+    parts = fen.split(" ")
+    assert len(parts) == 6, f"FEN must have 6 space-separated fields, got: {fen}"
+    assert parts[1] in ("w", "b"), f"Active color must be 'w' or 'b', got: {parts[1]}"
+    assert re.match(r"^[KQRBNPkqrbnp1-8/]+$", parts[0]), f"Piece placement invalid: {parts[0]}"

--- a/tests/unit/test_chess_pgn.py
+++ b/tests/unit/test_chess_pgn.py
@@ -97,6 +97,23 @@ class TestMovesToPgn:
         assert "5. O-O Be7" in pgn
 
 
+def test_chess_pgn_regenerated_from_moves():
+    moves = ["e4", "e5", "Nf3", "Nc6", "Bb5"]
+    pgn = moves_to_pgn(
+        moves,
+        white_name="Alice",
+        black_name="AI",
+        result="*",
+        game_date=FIXED_DATE,
+    )
+    assert '[White "Alice"]' in pgn
+    assert '[Black "AI"]' in pgn
+    assert "1. e4 e5" in pgn
+    assert "2. Nf3 Nc6" in pgn
+    assert "3. Bb5" in pgn
+    assert "[Result" in pgn
+
+
 class TestOutcomeToPgnResult:
     def test_player_won_as_white(self):
         assert outcome_to_pgn_result("player_won", "white") == "1-0"


### PR DESCRIPTION
## Summary
- Fixes optimistic move rejection: on API error, board reverts to pre-move state and status message shows "Move rejected — please try again." (previously only unlocked the board, leaving stale optimistic state)
- Adds `ChessBoard > renders piece images not letters` — verifies \`<img src="/images/...">\` tags used (not letters)
- Adds `ChessBoard > flips board for black player` — verifies board orientation differs for white vs black playerColor
- Adds `test_chess_move_stores_fen` — verifies state['fen'] is a valid 6-part FEN string after apply_move
- Adds `test_chess_pgn_regenerated_from_moves` — verifies PGN regenerated from SAN move_list + metadata has correct headers and movetext

Bugs 1–3, 5–6 were already implemented in earlier PRs (board flip, piece images, captures panel, SAN display, move list overflow-y). Bug 4 (FEN stored in board_state dict) was already implemented in chess_engine.py via state['fen']. This PR adds the missing test coverage and the one behavioral fix (optimistic rejection).

## Test plan
- [ ] `npm run test:fast` passes (64 frontend + 178 Python tests)
- [ ] Rejected chess moves revert to pre-move board state with error message
- [ ] Player's pieces always appear at bottom regardless of chosen color
- [ ] Piece images render from /images/ (not letters)