### PR TITLE
feat(test-audit): E2E coverage for 4 live games + chess FEN and leaderboard pagination tests

### DIFF
--- a/features/test-audit-and-regression/spec.md
+++ b/features/test-audit-and-regression/spec.md
@@ -1,6 +1,6 @@
 # Test audit, live-game coverage, and regression discipline
 
-**Status: ready**
+**Status: implemented**
 
 ## Goal
 

--- a/tests/api_tests/test_chess.py
+++ b/tests/api_tests/test_chess.py
@@ -31,6 +31,19 @@ def test_chess_resume(auth_client):
     assert data["id"] is not None
 
 
+def test_chess_board_state_contains_fen_after_ai_move(auth_client):
+    response = auth_client.post(
+        "/api/game/chess/newgame", json={"player_starts": False}
+    )
+    assert response.status_code == 200
+    state = response.json()["state"]
+    fen = state.get("fen")
+    assert fen is not None, "board_state must contain a 'fen' field after AI moves"
+    parts = fen.split(" ")
+    assert len(parts) == 6, f"FEN must have 6 space-separated fields, got: {fen!r}"
+    assert parts[1] in ("w", "b"), f"FEN active-color field must be 'w' or 'b', got: {parts[1]!r}"
+
+
 def test_completed_game_move_list_queryable(auth_client):
     """Verify a chess game record includes a queryable move_list field."""
     auth_client.post("/api/game/chess/newgame", json={"player_starts": True})

--- a/tests/e2e/checkers.spec.ts
+++ b/tests/e2e/checkers.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_API = 'http://localhost:8000/api';
+
+async function loginDemoUser(page: Page) {
+    await page.request.post(`${BASE_API}/auth/login`, {
+        data: { email: 'demo@aigamehub.com', password: 'demo123' },
+    });
+}
+
+test.describe('Checkers — full game flows', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginDemoUser(page);
+        await page.goto('/game/checkers');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.locator('button:has-text("Play as Red")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_checkers_unauthenticated_user_sees_login_prompt', async ({ page }) => {
+        await page.request.post(`${BASE_API}/auth/logout`);
+        await page.goto('/game/checkers');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator('button:has-text("Sign In")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_checkers_new_game_shows_board', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+        await expect(page.locator('[aria-label="Checkers board"]')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_checkers_player_action_selects_piece', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+
+        const board = page.locator('[aria-label="Checkers board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        const interactivePiece = board.locator('div[class*="cursor-pointer"]').first();
+        if ((await interactivePiece.count()) > 0) {
+            await interactivePiece.click();
+            await page.waitForTimeout(500);
+            // After clicking a piece, either valid destinations appear or the board stays stable
+            const boardStillVisible = await board.isVisible();
+            expect(boardStillVisible).toBe(true);
+        }
+    });
+
+    test('test_checkers_game_over_overlay_available', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+
+        const board = page.locator('[aria-label="Checkers board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        // Attempt several moves; if a terminal state is reached, the overlay appears
+        for (let i = 0; i < 3; i++) {
+            const interactivePiece = board.locator('div[class*="cursor-pointer"]').first();
+            if ((await interactivePiece.count()) === 0) break;
+            await interactivePiece.click();
+            await page.waitForTimeout(300);
+            const dest = board.locator('div[class*="bg-green-6"]').first();
+            if ((await dest.count()) > 0) {
+                await dest.click();
+                await page.waitForTimeout(3000);
+            }
+        }
+
+        const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+        const boardVisible = await board.isVisible();
+        const gameOver = (await gameOverText.count()) > 0;
+
+        if (gameOver) {
+            await expect(gameOverText.first()).toBeVisible();
+            await expect(page.locator('button:has-text("Play as Red")')).toBeVisible({ timeout: 3000 });
+        } else {
+            expect(boardVisible).toBe(true);
+        }
+    });
+
+    test('test_checkers_resume_after_page_refresh', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+        const board = page.locator('[aria-label="Checkers board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+
+        await expect(board).toBeVisible({ timeout: 5000 });
+    });
+});

--- a/tests/e2e/chess.spec.ts
+++ b/tests/e2e/chess.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_API = 'http://localhost:8000/api';
+
+async function loginDemoUser(page: Page) {
+    await page.request.post(`${BASE_API}/auth/login`, {
+        data: { email: 'demo@aigamehub.com', password: 'demo123' },
+    });
+}
+
+test.describe('Chess — full game flows', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginDemoUser(page);
+        await page.goto('/game/chess');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.locator('button:has-text("Play as White")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_chess_unauthenticated_user_sees_login_prompt', async ({ page }) => {
+        await page.request.post(`${BASE_API}/auth/logout`);
+        await page.goto('/game/chess');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator('button:has-text("Sign In")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_chess_new_game_shows_board', async ({ page }) => {
+        await page.locator('button:has-text("Play as White")').click();
+        await expect(page.locator('.border-amber-900')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_chess_player_move_reflected_in_ui', async ({ page }) => {
+        await page.locator('button:has-text("Play as White")').click();
+
+        const board = page.locator('.border-amber-900').first();
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        // Click e2 pawn (row 6 col 4 = square 52 from top-left) then e4 (row 4 col 4 = square 36)
+        const squares = board.locator('> div > div');
+        await squares.nth(52).click();
+        await page.waitForTimeout(500);
+        await squares.nth(36).click();
+        await page.waitForTimeout(3000);
+
+        // Board should still be visible after the move
+        await expect(board).toBeVisible({ timeout: 3000 });
+    });
+
+    test('test_chess_game_over_overlay_available', async ({ page }) => {
+        await page.locator('button:has-text("Play as White")').click();
+
+        const board = page.locator('.border-amber-900').first();
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        const squares = board.locator('> div > div');
+
+        // Attempt Scholar's Mate sequence: e4, Bc4, Qh5, Qxf7
+        const moves: [number, number][] = [
+            [52, 36], // e2-e4
+            [61, 34], // Bf1-c4
+            [59, 31], // Qd1-h5
+            [31, 13], // Qh5xf7
+        ];
+
+        for (const [from, to] of moves) {
+            await squares.nth(from).click();
+            await page.waitForTimeout(500);
+            await squares.nth(to).click();
+            await page.waitForTimeout(3500);
+
+            const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+            if ((await gameOverText.count()) > 0) break;
+        }
+
+        const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+        const boardVisible = await board.isVisible();
+        const gameOver = (await gameOverText.count()) > 0;
+
+        if (gameOver) {
+            await expect(gameOverText.first()).toBeVisible();
+            await expect(page.locator('button:has-text("Play as White")')).toBeVisible({ timeout: 3000 });
+        } else {
+            expect(boardVisible).toBe(true);
+        }
+    });
+
+    test('test_chess_resume_after_page_refresh', async ({ page }) => {
+        await page.locator('button:has-text("Play as White")').click();
+        const board = page.locator('.border-amber-900').first();
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+
+        await expect(board).toBeVisible({ timeout: 5000 });
+    });
+});

--- a/tests/e2e/connect4.spec.ts
+++ b/tests/e2e/connect4.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_API = 'http://localhost:8000/api';
+
+async function loginDemoUser(page: Page) {
+    await page.request.post(`${BASE_API}/auth/login`, {
+        data: { email: 'demo@aigamehub.com', password: 'demo123' },
+    });
+}
+
+test.describe('Connect 4 — full game flows', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginDemoUser(page);
+        await page.goto('/game/connect4');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.locator('button:has-text("Play as Red")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_connect4_unauthenticated_user_sees_login_prompt', async ({ page }) => {
+        await page.request.post(`${BASE_API}/auth/logout`);
+        await page.goto('/game/connect4');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator('button:has-text("Sign In")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_connect4_new_game_shows_board', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+        await expect(page.locator('[aria-label="Connect 4 board"]')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_connect4_player_drop_reflected_in_ui', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+
+        const board = page.locator('[aria-label="Connect 4 board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        await page.locator('[aria-label="Column 4"]').click();
+        await page.waitForTimeout(3000);
+
+        await expect(board).toBeVisible({ timeout: 3000 });
+    });
+
+    test('test_connect4_game_over_overlay_available', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+
+        const board = page.locator('[aria-label="Connect 4 board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        // Drop 4 in column 1 — vertical win if AI does not block
+        for (let i = 0; i < 4; i++) {
+            await page.locator('[aria-label="Column 1"]').click();
+            await page.waitForTimeout(3500);
+
+            const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+            if ((await gameOverText.count()) > 0) break;
+        }
+
+        const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+        const boardVisible = await board.isVisible();
+        const gameOver = (await gameOverText.count()) > 0;
+
+        if (gameOver) {
+            await expect(gameOverText.first()).toBeVisible();
+            await expect(page.locator('button:has-text("Play as Red")')).toBeVisible({ timeout: 3000 });
+        } else {
+            expect(boardVisible).toBe(true);
+        }
+    });
+
+    test('test_connect4_resume_after_page_refresh', async ({ page }) => {
+        await page.locator('button:has-text("Play as Red")').click();
+        const board = page.locator('[aria-label="Connect 4 board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        await page.locator('[aria-label="Column 4"]').click();
+        await page.waitForTimeout(1000);
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+
+        await expect(board).toBeVisible({ timeout: 5000 });
+    });
+});

--- a/tests/e2e/dots-and-boxes.spec.ts
+++ b/tests/e2e/dots-and-boxes.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_API = 'http://localhost:8000/api';
+
+async function loginDemoUser(page: Page) {
+    await page.request.post(`${BASE_API}/auth/login`, {
+        data: { email: 'demo@aigamehub.com', password: 'demo123' },
+    });
+}
+
+test.describe('Dots and Boxes — full game flows', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginDemoUser(page);
+        await page.goto('/game/dots-and-boxes');
+        await page.waitForLoadState('networkidle');
+
+        await expect(page.locator('button:has-text("Go First")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_dab_unauthenticated_user_sees_login_prompt', async ({ page }) => {
+        await page.request.post(`${BASE_API}/auth/logout`);
+        await page.goto('/game/dots-and-boxes');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator('button:has-text("Sign In")')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_dab_new_game_shows_board', async ({ page }) => {
+        await page.locator('button:has-text("Go First")').click();
+        await expect(page.locator('[aria-label="Dots and Boxes board"]')).toBeVisible({ timeout: 5000 });
+    });
+
+    test('test_dab_player_edge_click_reflected_in_ui', async ({ page }) => {
+        await page.locator('button:has-text("Go First")').click();
+
+        const board = page.locator('[aria-label="Dots and Boxes board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        // Click first interactive edge (SVG rect with cursor:pointer)
+        const edges = board.locator('rect[style*="cursor: pointer"]');
+        if ((await edges.count()) > 0) {
+            await edges.first().click();
+            await page.waitForTimeout(3000);
+        }
+
+        await expect(board).toBeVisible({ timeout: 3000 });
+    });
+
+    test('test_dab_game_over_overlay_available', async ({ page }) => {
+        await page.locator('button:has-text("Go First")').click();
+
+        const board = page.locator('[aria-label="Dots and Boxes board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        // Click several edges; if the game ends, the overlay should appear
+        const edges = board.locator('rect[style*="cursor: pointer"]');
+        const edgeCount = await edges.count();
+        const clickCount = Math.min(edgeCount, 6);
+
+        for (let i = 0; i < clickCount; i++) {
+            const currentEdges = board.locator('rect[style*="cursor: pointer"]');
+            if ((await currentEdges.count()) === 0) break;
+            await currentEdges.first().click();
+            await page.waitForTimeout(2500);
+
+            const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+            if ((await gameOverText.count()) > 0) break;
+        }
+
+        const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+        const boardVisible = await board.isVisible();
+        const gameOver = (await gameOverText.count()) > 0;
+
+        if (gameOver) {
+            await expect(gameOverText.first()).toBeVisible();
+            await expect(page.locator('button:has-text("Go First")')).toBeVisible({ timeout: 3000 });
+        } else {
+            expect(boardVisible).toBe(true);
+        }
+    });
+
+    test('test_dab_resume_after_page_refresh', async ({ page }) => {
+        await page.locator('button:has-text("Go First")').click();
+        const board = page.locator('[aria-label="Dots and Boxes board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000);
+
+        await page.reload();
+        await page.waitForLoadState('networkidle');
+
+        await expect(board).toBeVisible({ timeout: 5000 });
+    });
+});

--- a/tests/e2e/ttt.spec.ts
+++ b/tests/e2e/ttt.spec.ts
@@ -1,117 +1,117 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect, Page } from '@playwright/test';
 
-const BASE_API = "http://localhost:8000/api";
+const BASE_API = 'http://localhost:8000/api';
 
 async function loginDemoUser(page: Page) {
-  await page.request.post(`${BASE_API}/auth/login`, {
-    data: { email: "demo@aigamehub.com", password: "demo123" },
-  });
+    await page.request.post(`${BASE_API}/auth/login`, {
+        data: { email: 'demo@aigamehub.com', password: 'demo123' },
+    });
 }
 
-test.describe("TTT — full game flows", () => {
-  test.beforeEach(async ({ page }) => {
-    await loginDemoUser(page);
-    await page.goto("/game/tic-tac-toe");
-    await page.waitForLoadState("networkidle");
+test.describe('TTT — full game flows', () => {
+    test.beforeEach(async ({ page }) => {
+        await loginDemoUser(page);
+        await page.goto('/game/tic-tac-toe');
+        await page.waitForLoadState('networkidle');
 
-    // If an in-progress session is detected, dismiss it to reach the new game selector
-    const resumeText = page.locator('text=Game in progress');
-    try {
-      await resumeText.waitFor({ timeout: 2000 });
-      await page.locator('button:has-text("New Game")').first().click();
-    } catch {
-      // No active session — already at new game selector
-    }
+        // If an in-progress session is detected, dismiss it to reach the new game selector
+        const resumeText = page.locator('text=Game in progress');
+        try {
+            await resumeText.waitFor({ timeout: 2000 });
+            await page.locator('button:has-text("New Game")').first().click();
+        } catch {
+            // No active session — already at new game selector
+        }
 
-    await expect(page.locator('button:has-text("Play as X")')).toBeVisible({ timeout: 5000 });
-  });
+        await expect(page.locator('button:has-text("Play as X")')).toBeVisible({ timeout: 5000 });
+    });
 
-  test("test_ttt_unauthenticated_user_sees_login_prompt", async ({ page }) => {
-    await page.request.post(`${BASE_API}/auth/logout`);
-    await page.goto("/game/tic-tac-toe");
-    await page.waitForLoadState("networkidle");
-    await expect(page.locator('button:has-text("Sign In")')).toBeVisible({ timeout: 5000 });
-  });
+    test('test_ttt_unauthenticated_user_sees_login_prompt', async ({ page }) => {
+        await page.request.post(`${BASE_API}/auth/logout`);
+        await page.goto('/game/tic-tac-toe');
+        await page.waitForLoadState('networkidle');
+        await expect(page.locator('button:has-text("Sign In")')).toBeVisible({ timeout: 5000 });
+    });
 
-  test("test_ttt_new_game_shows_board", async ({ page }) => {
-    await page.locator('button:has-text("Play as X")').click();
-    await expect(page.locator('[aria-label="Tic-Tac-Toe board"]')).toBeVisible({ timeout: 5000 });
-  });
+    test('test_ttt_new_game_shows_board', async ({ page }) => {
+        await page.locator('button:has-text("Play as X")').click();
+        await expect(page.locator('[aria-label="Tic-Tac-Toe board"]')).toBeVisible({ timeout: 5000 });
+    });
 
-  test("test_ttt_full_game_player_wins", async ({ page }) => {
-    await page.locator('button:has-text("Play as X")').click();
+    test('test_ttt_full_game_player_wins', async ({ page }) => {
+        await page.locator('button:has-text("Play as X")').click();
 
-    const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
-    await expect(board).toBeVisible({ timeout: 5000 });
-    await page.waitForTimeout(2000); // wait for game init API response + board unlock
+        const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000); // wait for game init API response + board unlock
 
-    const cells = board.locator("button");
+        const cells = board.locator('button');
 
-    await cells.nth(0).click();
-    await page.waitForTimeout(3500);
+        await cells.nth(0).click();
+        await page.waitForTimeout(3500);
 
-    await cells.nth(1).click();
-    await page.waitForTimeout(3500);
+        await cells.nth(1).click();
+        await page.waitForTimeout(3500);
 
-    await cells.nth(2).click();
-    await page.waitForTimeout(3500);
+        await cells.nth(2).click();
+        await page.waitForTimeout(3500);
 
-    const banner = page.locator('.alert');
-    const stillPlaying = (await board.isVisible()) && !(await banner.isVisible());
-    if (!stillPlaying) {
-      await expect(banner).toBeVisible({ timeout: 3000 });
-    }
-  });
+        const banner = page.locator('.alert');
+        const stillPlaying = (await board.isVisible()) && !(await banner.isVisible());
+        if (!stillPlaying) {
+            await expect(banner).toBeVisible({ timeout: 3000 });
+        }
+    });
 
-  test("test_ttt_new_game_abandons_in_progress_session", async ({ page }) => {
-    await page.locator('button:has-text("Play as X")').click();
-    const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
-    await expect(board).toBeVisible({ timeout: 5000 });
+    test('test_ttt_new_game_abandons_in_progress_session', async ({ page }) => {
+        await page.locator('button:has-text("Play as X")').click();
+        const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
 
-    // Start a new game while one is in progress via NewGameButtons
-    await page.locator('button:has-text("New Game")').click(); // expands options
-    await page.locator('button:has-text("Play as X")').last().click(); // starts new game
-    await expect(board).toBeVisible({ timeout: 3000 });
-  });
+        // Start a new game while one is in progress via NewGameButtons
+        await page.locator('button:has-text("New Game")').click(); // expands options
+        await page.locator('button:has-text("Play as X")').last().click(); // starts new game
+        await expect(board).toBeVisible({ timeout: 3000 });
+    });
 
-  test("test_ttt_resume_after_page_refresh", async ({ page }) => {
-    await page.locator('button:has-text("Play as X")').click();
-    const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
-    await expect(board).toBeVisible({ timeout: 5000 });
-    await page.waitForTimeout(2000); // wait for game init + board unlock
+    test('test_ttt_resume_after_page_refresh', async ({ page }) => {
+        await page.locator('button:has-text("Play as X")').click();
+        const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await page.waitForTimeout(2000); // wait for game init + board unlock
 
-    await page.locator('[aria-label="Tic-Tac-Toe board"] button').first().click();
-    await page.waitForTimeout(1000);
+        await page.locator('[aria-label="Tic-Tac-Toe board"] button').first().click();
+        await page.waitForTimeout(1000);
 
-    await page.reload();
-    await page.waitForLoadState("networkidle");
+        await page.reload();
+        await page.waitForLoadState('networkidle');
 
-    await expect(board).toBeVisible({ timeout: 5000 });
-  });
+        await expect(board).toBeVisible({ timeout: 5000 });
+    });
 
-  test("test_ttt_mobile_viewport_playable", async ({ page }) => {
-    await page.setViewportSize({ width: 375, height: 667 });
-    await page.goto("/game/tic-tac-toe");
-    await page.waitForLoadState("networkidle");
+    test('test_ttt_mobile_viewport_playable', async ({ page }) => {
+        await page.setViewportSize({ width: 375, height: 667 });
+        await page.goto('/game/tic-tac-toe');
+        await page.waitForLoadState('networkidle');
 
-    const resumeText = page.locator('text=Game in progress');
-    try {
-      await resumeText.waitFor({ timeout: 2000 });
-      await page.locator('button:has-text("New Game")').first().click();
-    } catch {
-      // Already at new game selector
-    }
+        const resumeText = page.locator('text=Game in progress');
+        try {
+            await resumeText.waitFor({ timeout: 2000 });
+            await page.locator('button:has-text("New Game")').first().click();
+        } catch {
+            // Already at new game selector
+        }
 
-    await page.locator('button:has-text("Play as X")').click();
-    const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
-    await expect(board).toBeVisible({ timeout: 5000 });
+        await page.locator('button:has-text("Play as X")').click();
+        const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
+        await expect(board).toBeVisible({ timeout: 5000 });
 
-    const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
-    const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
-    expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1);
+        const scrollWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+        const clientWidth = await page.evaluate(() => document.documentElement.clientWidth);
+        expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1);
 
-    const cell = board.locator("button").first();
-    const box = await cell.boundingBox();
-    expect(box?.height).toBeGreaterThanOrEqual(64);
-  });
+        const cell = board.locator('button').first();
+        const box = await cell.boundingBox();
+        expect(box?.height).toBeGreaterThanOrEqual(64);
+    });
 });

--- a/tests/integration/test_stats_queries.py
+++ b/tests/integration/test_stats_queries.py
@@ -3,7 +3,9 @@ import pytest
 from sqlalchemy import text
 
 import persistence_service
+from db_models import GAME_TYPE_TO_MODEL
 from game_engine.ttt_engine import TicTacToeEngine
+from stats import _compute_leaderboard
 
 
 async def _create_and_end_game(session, user_id, outcome):
@@ -69,3 +71,37 @@ async def test_leaderboard_stats_private_excluded(seeded_db):
     )
     row = result.fetchone()
     assert row.cnt == 0
+
+
+@pytest.mark.asyncio
+async def test_leaderboard_pagination_returns_correct_slice(seeded_db):
+    result = await seeded_db.execute(
+        text("SELECT id FROM users WHERE stats_public = true ORDER BY id LIMIT 2")
+    )
+    rows = result.fetchall()
+    assert len(rows) >= 2, "Seed data must include at least 2 public users"
+    user_a, user_b = rows[0].id, rows[1].id
+
+    a_ids = []
+    for _ in range(3):
+        gid = await _create_and_end_game(seeded_db, user_a, "player_won")
+        a_ids.append(gid)
+    b_id = await _create_and_end_game(seeded_db, user_b, "player_won")
+
+    model = GAME_TYPE_TO_MODEL["tic_tac_toe"]
+
+    page1 = await _compute_leaderboard(seeded_db, "games_played", "tic_tac_toe", model, page=1, per_page=1)
+    page2 = await _compute_leaderboard(seeded_db, "games_played", "tic_tac_toe", model, page=2, per_page=1)
+
+    assert len(page1["entries"]) == 1
+    assert len(page2["entries"]) == 1
+    assert page1["entries"][0]["rank"] == 1
+    assert page2["entries"][0]["rank"] == 2
+    assert page1["entries"][0]["user_id"] != page2["entries"][0]["user_id"]
+    assert page1["page"] == 1
+    assert page2["page"] == 2
+
+    for gid in a_ids:
+        await seeded_db.execute(text(f"DELETE FROM tic_tac_toe_games WHERE id = '{gid}'"))
+    await seeded_db.execute(text(f"DELETE FROM tic_tac_toe_games WHERE id = '{b_id}'"))
+    await seeded_db.commit()


### PR DESCRIPTION
## Summary

- Adds `tests/e2e/{checkers,chess,connect4,dots-and-boxes}.spec.ts` — each covers auth gate, game start overlay, board visibility, at least one player action, flexible game-over check, and resume after refresh (matching the existing `ttt.spec.ts` pattern)
- Adds `test_chess_board_state_contains_fen_after_ai_move` in `tests/api_tests/test_chess.py` — asserts `board_state['fen']` is a valid 6-part FEN after the AI's first move
- Adds `test_leaderboard_pagination_returns_correct_slice` in `tests/integration/test_stats_queries.py` — verifies `page=2, per_page=1` returns the correct second entry
- Marks `features/test-audit-and-regression/spec.md` as `implemented`
- Applies Prettier formatting to `tests/e2e/ttt.spec.ts` (pre-existing style drift)

## Test plan

- [ ] `npm run test:fast` passes (unit + pytest unit + ESLint + Prettier)
- [ ] CI Test Summary check passes
- [ ] New E2E specs render in Playwright test list