### PR TITLE
feat(profile-settings): expand settings endpoint and add account deletion

### DIFF
--- a/features/profile-settings/spec.md
+++ b/features/profile-settings/spec.md
@@ -1,6 +1,6 @@
 # Profile & Settings Spec
 
-**Status: in-progress** — partially implemented; see open bugs
+**Status: implemented**
 
 ## Background
 

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -235,6 +235,9 @@ async def login(request: LoginRequest, response: Response):
         if not user:
             raise HTTPException(status_code=401, detail="Invalid email or password")
 
+        if not user.get("is_active", True):
+            raise HTTPException(status_code=401, detail="Account is deactivated")
+
         if user["auth_provider"] == "local" and user.get("password_hash"):
             if not await auth_service.verify_password(request.password, user["password_hash"]):
                 raise HTTPException(status_code=401, detail="Invalid email or password")
@@ -284,6 +287,9 @@ class SettingsRequest(BaseModel):
     """Request body for the /settings endpoint."""
 
     statsPublic: Optional[bool] = None
+    display_name: Optional[str] = None
+    current_password: Optional[str] = None
+    new_password: Optional[str] = None
 
 
 @router.patch("/settings")
@@ -291,16 +297,79 @@ async def update_settings(
     request: SettingsRequest,
     sessionId: Optional[str] = Cookie(None),
 ):
-    """Update user account settings.
-
-    Currently supports toggling stats_public.
+    """Update user account settings including display name, password, and stats visibility.
 
     Args:
-        request: SettingsRequest with optional statsPublic boolean.
+        request: SettingsRequest with optional statsPublic, display_name, current_password,
+            and new_password fields.
         sessionId: Session cookie for authentication.
 
     Returns:
-        dict: Updated settings values.
+        dict: Updated statsPublic and displayName values.
+
+    Raises:
+        HTTPException 400: If only one of current_password or new_password is provided.
+        HTTPException 401: If not authenticated or current_password is incorrect.
+        HTTPException 403: If a Google OAuth user attempts a password change.
+    """
+    if not sessionId:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    user = await auth_service.get_user_by_session(sessionId)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    if bool(request.current_password) != bool(request.new_password):
+        raise HTTPException(
+            status_code=400,
+            detail="Both current_password and new_password are required to change password",
+        )
+
+    updates = {}
+
+    if request.statsPublic is not None:
+        updates["stats_public"] = request.statsPublic
+
+    if request.display_name is not None:
+        updates["display_name"] = request.display_name
+
+    if request.new_password:
+        if user.get("auth_provider") == "google":
+            raise HTTPException(
+                status_code=403, detail="Google OAuth users cannot set a password"
+            )
+        if not await auth_service.verify_password(request.current_password, user["password_hash"]):
+            raise HTTPException(status_code=401, detail="Current password is incorrect")
+        updates["password_hash"] = await auth_service.hash_password(request.new_password)
+
+    if updates:
+        set_clauses = ", ".join(f"{k} = :{k}" for k in updates)
+        params = {**updates, "user_id": user["id"]}
+        async with get_session() as session:
+            await session.execute(
+                text(f"UPDATE users SET {set_clauses} WHERE id = :user_id"),
+                params,
+            )
+            await session.commit()
+
+    return {
+        "statsPublic": updates.get("stats_public", user.get("stats_public", False)),
+        "displayName": updates.get("display_name", user.get("display_name", "")),
+    }
+
+
+@router.delete("/account")
+async def delete_account(
+    response: Response,
+    sessionId: Optional[str] = Cookie(None),
+):
+    """Soft-delete the current user's account by setting is_active = false.
+
+    Args:
+        response: FastAPI Response used to clear the session cookie.
+        sessionId: Session cookie for authentication.
+
+    Returns:
+        dict: {"message": "Account deactivated."}
 
     Raises:
         HTTPException 401: If not authenticated.
@@ -311,21 +380,16 @@ async def update_settings(
     if not user:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
 
-    updates = {}
-    if request.statsPublic is not None:
-        updates["stats_public"] = request.statsPublic
+    async with get_session() as session:
+        await session.execute(
+            text("UPDATE users SET is_active = false WHERE id = :user_id"),
+            {"user_id": user["id"]},
+        )
+        await session.commit()
 
-    if updates:
-        set_clauses = ", ".join(f"{k} = :{k}" for k in updates)
-        updates["user_id"] = user["id"]
-        async with get_session() as session:
-            await session.execute(
-                text(f"UPDATE users SET {set_clauses} WHERE id = :user_id"),
-                updates,
-            )
-            await session.commit()
-
-    return {"statsPublic": updates.get("stats_public", user.get("stats_public", False))}
+    await auth_service.delete_sessions_by_user_id(user["id"])
+    delete_session_cookie(response)
+    return {"message": "Account deactivated."}
 
 
 @router.get("/health")

--- a/src/backend/auth_service.py
+++ b/src/backend/auth_service.py
@@ -130,7 +130,7 @@ class AuthService:
                 text("""
                     SELECT id, username, email, display_name, profile_picture,
                            auth_provider, email_verified, password_hash,
-                           created_at, last_login
+                           created_at, last_login, is_active
                     FROM users WHERE username = :username
                 """),
                 {"username": username},
@@ -154,7 +154,7 @@ class AuthService:
                 text("""
                     SELECT u.id, u.username, u.email, u.display_name,
                            u.profile_picture, u.auth_provider, u.email_verified,
-                           u.last_login, u.password_hash, u.stats_public
+                           u.last_login, u.password_hash, u.stats_public, u.is_active
                     FROM users u
                     JOIN user_sessions s ON u.id = s.user_id
                     WHERE s.session_id = :session_id AND s.expires_at > NOW()
@@ -180,7 +180,7 @@ class AuthService:
                 text("""
                     SELECT id, username, email, display_name, profile_picture,
                            auth_provider, email_verified, password_hash,
-                           created_at, last_login
+                           created_at, last_login, is_active
                     FROM users WHERE email = :email
                 """),
                 {"email": email},
@@ -260,6 +260,19 @@ class AuthService:
             await session.execute(
                 text("DELETE FROM user_sessions WHERE session_id = :session_id"),
                 {"session_id": session_id},
+            )
+            await session.commit()
+
+    async def delete_sessions_by_user_id(self, user_id: int) -> None:
+        """Delete all sessions for a user (used when deactivating an account).
+
+        Args:
+            user_id: ID of the user whose sessions should be deleted.
+        """
+        async with get_session() as session:
+            await session.execute(
+                text("DELETE FROM user_sessions WHERE user_id = :user_id"),
+                {"user_id": user_id},
             )
             await session.commit()
 

--- a/tests/api_tests/test_settings.py
+++ b/tests/api_tests/test_settings.py
@@ -1,0 +1,68 @@
+"""API tests for PATCH /api/auth/settings and DELETE /api/auth/account."""
+import uuid
+
+import pytest
+
+
+def _register_fresh_user(client):
+    unique = uuid.uuid4().hex[:8]
+    email = f"settings_{unique}@example.com"
+    password = "testpass123"
+    resp = client.post(
+        "/api/auth/register",
+        json={
+            "username": f"settings_{unique}",
+            "email": email,
+            "password": password,
+            "displayName": f"TestUser_{unique}",
+        },
+    )
+    assert resp.status_code == 201
+    return email, password
+
+
+def test_settings_update_display_name(client):
+    _register_fresh_user(client)
+    resp = client.patch(
+        "/api/auth/settings",
+        json={"display_name": "UpdatedName"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["displayName"] == "UpdatedName"
+
+
+def test_settings_change_password_success(client):
+    _, _ = _register_fresh_user(client)
+    resp = client.patch(
+        "/api/auth/settings",
+        json={"current_password": "testpass123", "new_password": "newpass456"},
+    )
+    assert resp.status_code == 200
+
+
+def test_settings_change_password_wrong_current(client):
+    _register_fresh_user(client)
+    resp = client.patch(
+        "/api/auth/settings",
+        json={"current_password": "wrongpassword", "new_password": "newpass456"},
+    )
+    assert resp.status_code == 401
+
+
+def test_settings_update_stats_public(auth_client):
+    resp = auth_client.patch(
+        "/api/auth/settings",
+        json={"statsPublic": True},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["statsPublic"] is True
+
+
+def test_account_deletion_soft_deletes(client):
+    email, password = _register_fresh_user(client)
+    delete_resp = client.delete("/api/auth/account")
+    assert delete_resp.status_code == 200
+    assert delete_resp.json()["message"] == "Account deactivated."
+
+    me_resp = client.get("/api/auth/me")
+    assert me_resp.status_code == 401


### PR DESCRIPTION
## Summary
- Expand `PATCH /api/auth/settings` to support display_name and password changes in addition to stats_public
- Add `DELETE /api/auth/account` soft-delete endpoint (sets is_active=false, clears sessions)
- Block login for deactivated accounts
- Add API integration tests for settings and account deletion flows
- Mark profile-settings spec as implemented