### PR TITLE
feat(google-oauth): add account linking and OAuth error-path tests

### DIFF
--- a/features/google-oauth/spec.md
+++ b/features/google-oauth/spec.md
@@ -1,6 +1,6 @@
 # Google OAuth Spec
 
-**Status: in-progress** — partially implemented; see open bugs
+**Status: implemented**
 
 ## Background
 
@@ -52,6 +52,20 @@ Audit and fix the full Google OAuth flow end-to-end for the React SPA architectu
   existing account, and the user retains their game history. No duplicate accounts are created.
 - **Client ID / secret rotation**: The Google OAuth client ID and secret live in GCP Secret Manager.
   No rotation concerns specific to this feature — normal Secret Manager versioning handles rotation.
+
+## Audit
+
+Conducted against `src/backend/auth.py` and `src/backend/auth_service.py`.
+
+- **Callback compatibility**: The `GET /api/auth/google/callback` route was already compatible with the
+  React SPA flow. It exchanges the authorization code, sets an httpOnly session cookie, and redirects to
+  the `state` param (defaulting to `/`). No Jinja2 rendering was present.
+- **Account linking**: Was missing. When `find_user_by_email` returned an existing local-auth user,
+  neither OAuth handler updated `google_id` or `auth_provider`. Fixed by adding `update_google_link`
+  to `AuthService` and calling it from both handlers when the found user's `auth_provider` is not
+  already `"google"`.
+- **Tests**: Added `tests/api_tests/test_google_oauth.py` covering the three testable error-path cases.
+  Positive-path tests require live Google credentials and are covered by the E2E test cases below.
 
 ## Known Requirements
 

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -453,6 +453,8 @@ async def google_auth(request: GoogleAuthRequest, response: Response):
                     display_name=idinfo.get("name", ""),
                     profile_picture=idinfo.get("picture", ""),
                 )
+            elif user.get("auth_provider") != "google":
+                await auth_service.update_google_link(user["id"], google_id)
 
             session_id = await auth_service.create_session(user["id"])
             set_session_cookie(response, session_id, max_age=30 * 24 * 60 * 60)
@@ -565,6 +567,8 @@ async def google_callback(code: str = None, error: str = None, state: str = "/")
                     profile_picture=google_user.get("picture", ""),
                 )
             else:
+                if user.get("auth_provider") != "google":
+                    await auth_service.update_google_link(user["id"], google_user["id"])
                 await auth_service.update_last_login(user["id"])
 
             session_id = await auth_service.create_session(user["id"])

--- a/src/backend/auth_service.py
+++ b/src/backend/auth_service.py
@@ -276,6 +276,29 @@ class AuthService:
             )
             await session.commit()
 
+    async def update_google_link(self, user_id: int, google_id: str) -> None:
+        """Link a Google identity to an existing local user account.
+
+        Sets google_id, auth_provider='google', and email_verified=True for the
+        given user. Used when a local-auth user signs in with Google for the first time.
+
+        Args:
+            user_id: ID of the existing user to update.
+            google_id: Google account subject identifier (sub field).
+        """
+        async with get_session() as session:
+            await session.execute(
+                text("""
+                    UPDATE users
+                    SET google_id = :google_id,
+                        auth_provider = 'google',
+                        email_verified = true
+                    WHERE id = :user_id
+                """),
+                {"google_id": google_id, "user_id": user_id},
+            )
+            await session.commit()
+
     async def check_database(self) -> str:
         """Test database connectivity with a lightweight query.
 

--- a/tests/api_tests/test_google_oauth.py
+++ b/tests/api_tests/test_google_oauth.py
@@ -1,0 +1,33 @@
+"""API tests for Google OAuth error-path handling."""
+
+
+def test_oauth_callback_redirects_to_root_on_error(client):
+    response = client.get(
+        "/api/auth/google/callback",
+        params={"error": "access_denied"},
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307)
+    location = response.headers["location"]
+    assert "error=google_auth_failed" in location
+
+
+def test_oauth_callback_redirects_on_missing_code(client):
+    response = client.get(
+        "/api/auth/google/callback",
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307)
+    location = response.headers["location"]
+    assert "error=google_auth_failed" in location
+
+
+def test_oauth_login_route_redirects_to_google(monkeypatch, client):
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    response = client.get(
+        "/api/auth/google",
+        follow_redirects=False,
+    )
+    assert response.status_code in (302, 307)
+    location = response.headers["location"]
+    assert "accounts.google.com" in location


### PR DESCRIPTION
## Summary
- Add `update_google_link` to `AuthService` — links an existing local account to a Google identity when the user signs in with Google for the first time using the same email
- Call `update_google_link` from both OAuth handlers (ID token route and code-exchange callback) when the found user's `auth_provider != "google"`
- Add error-path integration tests for the OAuth callback (error param, missing code, redirect-to-Google)
- Mark google-oauth spec as implemented; add audit section documenting findings