### PR TITLE
feat(site-presence): real team content, expanded stats, cost transparency, footer links

### DIFF
--- a/src/backend/about.py
+++ b/src/backend/about.py
@@ -1,10 +1,11 @@
 """About page stats endpoint."""
 import logging
+import os
 import time
 from datetime import date
 
 from fastapi import APIRouter, Depends
-from sqlalchemy import func, select, union_all
+from sqlalchemy import func, select, text, union_all
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import db_dependency
@@ -21,9 +22,20 @@ _CACHE_TTL = 60
 
 
 async def _query_stats(db: AsyncSession) -> dict:
+    """Query aggregated platform statistics from the database.
+
+    Args:
+        db: The async database session.
+
+    Returns:
+        A dict with platform statistics including games played, moves analyzed,
+        registered and unique players, win rates, average moves per game,
+        days running, and monthly cost.
+    """
     games_played = 0
     moves_analyzed = 0
     ai_wins = 0
+    player_wins = 0
     decided_games = 0
 
     for model in GAME_TYPE_TO_MODEL.values():
@@ -39,6 +51,9 @@ async def _query_stats(db: AsyncSession) -> dict:
                     .filter(model.ai_won.is_(True))
                     .label("ai_wins"),
                     func.count()
+                    .filter(model.player_won.is_(True))
+                    .label("player_wins"),
+                    func.count()
                     .filter(
                         model.game_ended.is_(True),
                         model.is_draw.is_(False),
@@ -50,6 +65,7 @@ async def _query_stats(db: AsyncSession) -> dict:
         games_played += row.played
         moves_analyzed += row.moves
         ai_wins += row.ai_wins
+        player_wins += row.player_wins
         decided_games += row.decided
 
     unique_players_q = union_all(
@@ -64,15 +80,25 @@ async def _query_stats(db: AsyncSession) -> dict:
         )
     ).scalar_one()
 
+    registered_players = (
+        await db.execute(text("SELECT COUNT(*) FROM users WHERE is_active = true"))
+    ).scalar_one()
+
     ai_win_rate = round(ai_wins / decided_games, 3) if decided_games > 0 else 0.0
+    player_win_rate = round(player_wins / decided_games, 3) if decided_games > 0 else 0.0
+    avg_moves_per_game = round(moves_analyzed / games_played, 1) if games_played > 0 else 0.0
+    monthly_cost_usd = int(os.getenv("MONTHLY_COST_ESTIMATE", "20"))
 
     return {
         "games_played": games_played,
         "moves_analyzed": moves_analyzed,
+        "registered_players": registered_players,
         "unique_players": unique_players,
         "ai_win_rate": ai_win_rate,
-        "training_moves": moves_analyzed,
+        "player_win_rate": player_win_rate,
+        "avg_moves_per_game": avg_moves_per_game,
         "days_running": (date.today() - LAUNCH_DATE).days,
+        "monthly_cost_usd": monthly_cost_usd,
     }
 
 

--- a/src/frontend/src/api/about.ts
+++ b/src/frontend/src/api/about.ts
@@ -1,10 +1,13 @@
 export interface AboutStats {
     games_played: number;
     moves_analyzed: number;
+    registered_players: number;
     unique_players: number;
     ai_win_rate: number;
-    training_moves: number;
+    player_win_rate: number;
+    avg_moves_per_game: number;
     days_running: number;
+    monthly_cost_usd: number;
 }
 
 /** Fetches platform statistics for the About page. */

--- a/src/frontend/src/components/AboutPlatformStats.tsx
+++ b/src/frontend/src/components/AboutPlatformStats.tsx
@@ -1,8 +1,25 @@
 import { useCountUp } from '../hooks/useCountUp';
 
-function StatCard({ value, label, isFloat }: { value: number; label: string; isFloat?: boolean }) {
+function StatCard({
+    value,
+    label,
+    isFloat,
+    isDecimal,
+}: {
+    value: number;
+    label: string;
+    isFloat?: boolean;
+    isDecimal?: boolean;
+}) {
     const animated = useCountUp(value);
-    const display = isFloat ? `${(animated * 100).toFixed(1)}%` : animated.toLocaleString();
+    let display: string;
+    if (isFloat) {
+        display = `${(animated * 100).toFixed(1)}%`;
+    } else if (isDecimal) {
+        display = animated.toFixed(1);
+    } else {
+        display = animated.toLocaleString();
+    }
 
     return (
         <div className='card bg-base-200 shadow-sm'>
@@ -17,30 +34,36 @@ function StatCard({ value, label, isFloat }: { value: number; label: string; isF
 export type AboutPlatformStatsProps = {
     gamesPlayed: number;
     movesAnalyzed: number;
+    registeredPlayers: number;
     uniquePlayers: number;
     aiWinRate: number;
-    trainingMoves: number;
+    playerWinRate: number;
+    avgMovesPerGame: number;
     daysRunning: number;
 };
 
 /**
- * Live platform statistics grid shared by the home and about pages.
+ * Live platform statistics grid for the About page.
  */
 export default function AboutPlatformStats({
     gamesPlayed,
     movesAnalyzed,
+    registeredPlayers,
     uniquePlayers,
     aiWinRate,
-    trainingMoves,
+    playerWinRate,
+    avgMovesPerGame,
     daysRunning,
 }: AboutPlatformStatsProps) {
     return (
         <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
             <StatCard value={gamesPlayed} label='Games Played' />
             <StatCard value={movesAnalyzed} label='Moves Analyzed' />
-            <StatCard value={uniquePlayers} label='Players' />
+            <StatCard value={registeredPlayers} label='Registered Players' />
+            <StatCard value={uniquePlayers} label='Active Players' />
             <StatCard value={aiWinRate} label='AI Win Rate' isFloat />
-            <StatCard value={trainingMoves} label='Training Moves' />
+            <StatCard value={playerWinRate} label='Player Win Rate' isFloat />
+            <StatCard value={avgMovesPerGame} label='Avg. Moves/Game' isDecimal />
             <StatCard value={daysRunning} label='Days Running' />
         </div>
     );

--- a/src/frontend/src/components/Footer.test.tsx
+++ b/src/frontend/src/components/Footer.test.tsx
@@ -4,17 +4,10 @@ import { renderWithProviders } from '../test-utils';
 import Footer from './Footer';
 
 describe('Footer', () => {
-    it('renders copyright without duplicate nav links', () => {
+    it('footer_renders_all_links', () => {
         renderWithProviders(<Footer />);
-        expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('link', { name: 'Games' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('link', { name: 'About' })).not.toBeInTheDocument();
-        expect(screen.queryByRole('link', { name: 'Stats' })).not.toBeInTheDocument();
-    });
-
-    it('renders copyright text', () => {
-        renderWithProviders(<Footer />);
-        const year = new Date().getFullYear();
-        expect(screen.getByText(new RegExp(`${year}`))).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /about/i })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: /support/i })).toBeInTheDocument();
+        expect(screen.getByText(/discord/i)).toBeInTheDocument();
     });
 });

--- a/src/frontend/src/components/Footer.tsx
+++ b/src/frontend/src/components/Footer.tsx
@@ -1,10 +1,30 @@
+import { Link } from 'react-router-dom';
+
 /**
- * Site-wide footer with copyright notice.
+ * Site-wide footer with copyright, navigation links, and support CTA.
  */
 export default function Footer() {
     return (
         <footer className='footer footer-center bg-base-300 p-6 text-base-content'>
-            <p className='text-sm opacity-60'>&copy; {new Date().getFullYear()} AI Game Hub</p>
+            <div className='flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-sm'>
+                <span className='opacity-60'>&copy; {new Date().getFullYear()} AI Game Hub</span>
+                <span className='opacity-30'>·</span>
+                <Link to='/about' className='link link-hover opacity-70'>
+                    About
+                </Link>
+                <span className='opacity-30'>·</span>
+                <a
+                    href='https://buymeacoffee.com/aigamehub'
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='link link-hover opacity-70'>
+                    Support
+                </a>
+                <span className='opacity-30'>·</span>
+                <span className='cursor-not-allowed opacity-40' title='Coming soon'>
+                    Discord
+                </span>
+            </div>
         </footer>
     );
 }

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -100,10 +100,13 @@ export const handlers = [
         return HttpResponse.json({
             games_played: 1234,
             moves_analyzed: 56789,
+            registered_players: 100,
             unique_players: 42,
-            ai_win_rate: 65.5,
-            training_moves: 100000,
+            ai_win_rate: 0.655,
+            player_win_rate: 0.245,
+            avg_moves_per_game: 28.5,
             days_running: 30,
+            monthly_cost_usd: 20,
         });
     }),
 

--- a/src/frontend/src/pages/AboutPage.test.tsx
+++ b/src/frontend/src/pages/AboutPage.test.tsx
@@ -17,4 +17,41 @@ describe('AboutPage', () => {
             expect(screen.getByText(/team/i)).toBeInTheDocument();
         });
     });
+
+    it('renders_team_member_names', async () => {
+        renderWithProviders(<AboutPage />);
+        await waitFor(() => {
+            expect(screen.getByText(/kevin zookski/i)).toBeInTheDocument();
+            expect(screen.getByText(/brian waskevich/i)).toBeInTheDocument();
+        });
+    });
+
+    it('renders_eight_stat_cards', async () => {
+        renderWithProviders(<AboutPage />);
+        await waitFor(() => {
+            expect(screen.getByText(/games played/i)).toBeInTheDocument();
+            expect(screen.getByText(/moves analyzed/i)).toBeInTheDocument();
+            expect(screen.getByText(/registered players/i)).toBeInTheDocument();
+            expect(screen.getByText(/active players/i)).toBeInTheDocument();
+            expect(screen.getByText(/ai win rate/i)).toBeInTheDocument();
+            expect(screen.getByText(/player win rate/i)).toBeInTheDocument();
+            expect(screen.getByText(/avg\. moves\/game/i)).toBeInTheDocument();
+            expect(screen.getByText(/days running/i)).toBeInTheDocument();
+        });
+    });
+
+    it('renders_donation_buttons', async () => {
+        renderWithProviders(<AboutPage />);
+        await waitFor(() => {
+            expect(screen.getByRole('link', { name: /buy us a coffee/i })).toBeInTheDocument();
+            expect(screen.getByRole('link', { name: /support on patreon/i })).toBeInTheDocument();
+        });
+    });
+
+    it('renders_cost_line', async () => {
+        renderWithProviders(<AboutPage />);
+        await waitFor(() => {
+            expect(screen.getByText(/\$20\/month/i)).toBeInTheDocument();
+        });
+    });
 });

--- a/src/frontend/src/pages/AboutPage.tsx
+++ b/src/frontend/src/pages/AboutPage.tsx
@@ -1,52 +1,31 @@
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { fetchAboutStats } from '../api/about';
 import AboutPlatformStats from '../components/AboutPlatformStats';
 import PageMeta from '../components/PageMeta';
 import { StatGridSkeleton } from '../components/Skeleton';
-import { useCountUp } from '../hooks/useCountUp';
 
 const DONATE_URLS = {
-    buyMeACoffee: 'https://buymeacoffee.com/',
-    patreon: 'https://patreon.com/',
+    buyMeACoffee: 'https://buymeacoffee.com/aigamehub',
+    patreon: 'https://www.patreon.com/cw/AIGameHub',
 };
 
 const TEAM_MEMBERS = [
     {
-        name: 'Member One',
-        role: 'Full-Stack Developer',
-        bio: 'Passionate about game AI and building things people enjoy playing.',
-        photo: 'https://placehold.co/128x128/374151/e5e7eb?text=M1',
-        github: 'https://github.com/',
-        linkedin: 'https://linkedin.com/',
+        name: 'Kevin Zookski',
+        role: 'Architect & Engineer',
+        bio: 'Kevin has held roles across every layer of the stack over his career — product, design, frontend, backend, and database. He designed and built AI Game Hub from the ground up.',
+        initials: 'KZ',
+        // TODO: Brian to update
     },
     {
-        name: 'Member Two',
-        role: 'AI & Game Design',
-        bio: 'Loves exploring adaptive algorithms and making classic games feel fresh.',
-        photo: 'https://placehold.co/128x128/374151/e5e7eb?text=M2',
-        github: 'https://github.com/',
-        linkedin: 'https://linkedin.com/',
+        name: 'Brian Waskevich',
+        role: 'ML & Data',
+        bio: 'Brian has taken sole ownership of the ML models, training pipeline, and the database schema designed to let the AI adapt quickly to different playstyles.',
+        initials: 'BW',
+        // TODO: Brian to update — add social links when ready
     },
 ];
-
-function seededRandom(seed: number): number {
-    const x = Math.sin(seed) * 10000;
-    return x - Math.floor(x);
-}
-
-function PlaceholderStatCard({ value, label }: { value: number; label: string }) {
-    const animated = useCountUp(value);
-    return (
-        <div className='card bg-base-200 shadow-sm'>
-            <div className='card-body items-center p-4 text-center'>
-                <span className='text-3xl font-bold text-primary'>{animated.toLocaleString()}</span>
-                <span className='text-sm opacity-70'>{label}</span>
-            </div>
-        </div>
-    );
-}
 
 /** Renders the About page with live platform stats, team section, and donation links. */
 export default function AboutPage() {
@@ -59,14 +38,6 @@ export default function AboutPage() {
         queryFn: fetchAboutStats,
         staleTime: 60_000,
     });
-
-    const placeholders = useMemo(() => {
-        const seed = Date.now();
-        return {
-            aiIterations: Math.floor(seededRandom(seed) * 8999) + 1000,
-            bugsSquashed: Math.floor(seededRandom(seed + 1) * 450) + 50,
-        };
-    }, []);
 
     return (
         <div className='container mx-auto max-w-5xl px-4 py-10'>
@@ -94,20 +65,16 @@ export default function AboutPage() {
                 {isLoading && <StatGridSkeleton count={8} />}
                 {isError && <p className='text-error'>Could not load platform statistics.</p>}
                 {stats && (
-                    <div className='space-y-4'>
-                        <AboutPlatformStats
-                            gamesPlayed={stats.games_played}
-                            movesAnalyzed={stats.moves_analyzed}
-                            uniquePlayers={stats.unique_players}
-                            aiWinRate={stats.ai_win_rate}
-                            trainingMoves={stats.training_moves}
-                            daysRunning={stats.days_running}
-                        />
-                        <div className='grid grid-cols-2 gap-4 md:grid-cols-4'>
-                            <PlaceholderStatCard value={placeholders.aiIterations} label='AI Iterations' />
-                            <PlaceholderStatCard value={placeholders.bugsSquashed} label='Bugs Squashed' />
-                        </div>
-                    </div>
+                    <AboutPlatformStats
+                        gamesPlayed={stats.games_played}
+                        movesAnalyzed={stats.moves_analyzed}
+                        registeredPlayers={stats.registered_players}
+                        uniquePlayers={stats.unique_players}
+                        aiWinRate={stats.ai_win_rate}
+                        playerWinRate={stats.player_win_rate}
+                        avgMovesPerGame={stats.avg_moves_per_game}
+                        daysRunning={stats.days_running}
+                    />
                 )}
             </section>
 
@@ -117,31 +84,15 @@ export default function AboutPage() {
                     {TEAM_MEMBERS.map(member => (
                         <div key={member.name} className='card bg-base-200 shadow-sm'>
                             <div className='card-body flex-row items-center gap-4'>
-                                <div className='avatar'>
-                                    <div className='w-20 rounded-full'>
-                                        <img src={member.photo} alt={member.name} />
+                                <div className='avatar placeholder'>
+                                    <div className='w-20 rounded-full bg-neutral text-neutral-content'>
+                                        <span className='text-2xl'>{member.initials}</span>
                                     </div>
                                 </div>
                                 <div className='flex-1'>
                                     <h3 className='text-lg font-bold'>{member.name}</h3>
                                     <p className='text-sm opacity-60'>{member.role}</p>
                                     <p className='mt-1 text-sm'>{member.bio}</p>
-                                    <div className='mt-2 flex gap-3'>
-                                        <a
-                                            href={member.github}
-                                            target='_blank'
-                                            rel='noopener noreferrer'
-                                            className='link link-hover text-sm opacity-70'>
-                                            GitHub
-                                        </a>
-                                        <a
-                                            href={member.linkedin}
-                                            target='_blank'
-                                            rel='noopener noreferrer'
-                                            className='link link-hover text-sm opacity-70'>
-                                            LinkedIn
-                                        </a>
-                                    </div>
                                 </div>
                             </div>
                         </div>
@@ -153,6 +104,12 @@ export default function AboutPage() {
                 <p className='mb-3 text-sm opacity-60'>
                     If you are enjoying the games, contributions help keep the servers running.
                 </p>
+                {stats && (
+                    <p className='mb-3 text-sm opacity-70'>
+                        Hosting and AI model costs run ~${stats.monthly_cost_usd}/month. Contributions of any size help
+                        keep the games running.
+                    </p>
+                )}
                 <div className='flex gap-3'>
                     <a
                         href={DONATE_URLS.buyMeACoffee}

--- a/tests/api/about.spec.ts
+++ b/tests/api/about.spec.ts
@@ -10,10 +10,14 @@ test.describe('about stats', () => {
         const data = await res.json();
         expect(typeof data.games_played).toBe('number');
         expect(typeof data.moves_analyzed).toBe('number');
+        expect(typeof data.registered_players).toBe('number');
         expect(typeof data.unique_players).toBe('number');
         expect(typeof data.ai_win_rate).toBe('number');
-        expect(typeof data.training_moves).toBe('number');
+        expect(typeof data.player_win_rate).toBe('number');
+        expect(typeof data.avg_moves_per_game).toBe('number');
         expect(typeof data.days_running).toBe('number');
+        expect(typeof data.monthly_cost_usd).toBe('number');
+        expect(data.training_moves).toBeUndefined();
     });
 
     test('stats values are non-negative', async ({ request }) => {
@@ -22,10 +26,14 @@ test.describe('about stats', () => {
 
         expect(data.games_played).toBeGreaterThanOrEqual(0);
         expect(data.moves_analyzed).toBeGreaterThanOrEqual(0);
+        expect(data.registered_players).toBeGreaterThanOrEqual(0);
         expect(data.unique_players).toBeGreaterThanOrEqual(0);
         expect(data.ai_win_rate).toBeGreaterThanOrEqual(0);
         expect(data.ai_win_rate).toBeLessThanOrEqual(1);
-        expect(data.training_moves).toBeGreaterThanOrEqual(0);
+        expect(data.player_win_rate).toBeGreaterThanOrEqual(0);
+        expect(data.player_win_rate).toBeLessThanOrEqual(1);
+        expect(data.avg_moves_per_game).toBeGreaterThanOrEqual(0);
         expect(data.days_running).toBeGreaterThanOrEqual(0);
+        expect(data.monthly_cost_usd).toBeGreaterThanOrEqual(0);
     });
 });

--- a/tests/api_tests/test_about.py
+++ b/tests/api_tests/test_about.py
@@ -1,11 +1,41 @@
-"""API tests for /api/about/stats endpoint."""
+"""API integration tests for the about stats endpoint."""
+import os
+
+import about as about_module
+
+
+def test_about_stats_returns_all_fields(auth_client):
+    response = auth_client.get("/api/about/stats")
+    assert response.status_code == 200
+    data = response.json()
+    required = [
+        "games_played",
+        "moves_analyzed",
+        "registered_players",
+        "unique_players",
+        "ai_win_rate",
+        "player_win_rate",
+        "avg_moves_per_game",
+        "days_running",
+        "monthly_cost_usd",
+    ]
+    for field in required:
+        assert field in data, f"Missing field: {field}"
+    assert "training_moves" not in data
 
 
 def test_about_stats_returns_correct_aggregates(auth_client):
     response = auth_client.get("/api/about/stats")
     assert response.status_code == 200
     data = response.json()
-    assert "games_played" in data
-    assert "unique_players" in data
     assert isinstance(data["games_played"], int)
     assert isinstance(data["unique_players"], int)
+
+
+def test_about_stats_monthly_cost(monkeypatch, auth_client):
+    about_module._cache["data"] = None
+    monkeypatch.setenv("MONTHLY_COST_ESTIMATE", "42")
+    response = auth_client.get("/api/about/stats")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["monthly_cost_usd"] == 42


### PR DESCRIPTION
## Summary
- About page: real names (Kevin Zookski, Brian Waskevich), initials avatars, Brian's bio/links marked TODO
- Stats: 4x2 grid with 3 new stats (registered_players, player_win_rate, avg_moves_per_game); removes training_moves and fake placeholder cards
- Cost transparency: monthly cost line sourced from MONTHLY_COST_ESTIMATE env var (default $20)
- Donations: Buy Me a Coffee (buymeacoffee.com/aigamehub) + Patreon (patreon.com/cw/AIGameHub)
- Footer: About + Support + Discord (coming soon) links
- Tests: Vitest unit tests for About page and Footer; API integration tests for stats endpoint

## Test plan
- [ ] `npm run test:fast` passes (23 vitest suites, 181 pytest unit tests, Prettier clean)
- [ ] AboutPage renders all 8 stat cards, team names, donation buttons, cost line
- [ ] Footer renders About, Support, Discord links
- [ ] API integration tests verify all 9 fields present and monthly_cost_usd env override