### PR TITLE
fix(e2e): add ENVIRONMENT=test to restore deterministic AI in nightly tests

### DIFF
--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -48,6 +48,7 @@ jobs:
           DB_USER=testuser
           DB_PASSWORD=testpassword
           NODE_ENV=test
+          ENVIRONMENT=test
           PORT=8000
           WEBSITE_URL=http://localhost:8000
           DOTENV

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -90,6 +90,7 @@ module.exports = defineConfig({
             timeout: 120 * 1000,
             env: {
                 NODE_ENV: 'test',
+                ENVIRONMENT: 'test',
                 PORT: '8000',
             },
         };

--- a/tests/e2e/checkers.spec.ts
+++ b/tests/e2e/checkers.spec.ts
@@ -30,16 +30,16 @@ test.describe('Checkers — full game flows', () => {
     });
 
     test('test_checkers_player_action_selects_piece', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/checkers/newgame'));
         await page.locator('button:has-text("Play as Red")').click();
 
         const board = page.locator('[aria-label="Checkers board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         const interactivePiece = board.locator('div[class*="cursor-pointer"]').first();
         if ((await interactivePiece.count()) > 0) {
             await interactivePiece.click();
-            await page.waitForTimeout(500);
+            await page.waitForTimeout(300);
             // After clicking a piece, either valid destinations appear or the board stays stable
             const boardStillVisible = await board.isVisible();
             expect(boardStillVisible).toBe(true);
@@ -47,11 +47,11 @@ test.describe('Checkers — full game flows', () => {
     });
 
     test('test_checkers_game_over_overlay_available', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/checkers/newgame'));
         await page.locator('button:has-text("Play as Red")').click();
 
         const board = page.locator('[aria-label="Checkers board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         // Attempt several moves; if a terminal state is reached, the overlay appears
         for (let i = 0; i < 3; i++) {
@@ -62,7 +62,7 @@ test.describe('Checkers — full game flows', () => {
             const dest = board.locator('div[class*="bg-green-6"]').first();
             if ((await dest.count()) > 0) {
                 await dest.click();
-                await page.waitForTimeout(3000);
+                await page.waitForTimeout(1500);
             }
         }
 
@@ -79,10 +79,10 @@ test.describe('Checkers — full game flows', () => {
     });
 
     test('test_checkers_resume_after_page_refresh', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/checkers/newgame'));
         await page.locator('button:has-text("Play as Red")').click();
         const board = page.locator('[aria-label="Checkers board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         await page.reload();
         await page.waitForLoadState('networkidle');

--- a/tests/e2e/chess.spec.ts
+++ b/tests/e2e/chess.spec.ts
@@ -30,29 +30,29 @@ test.describe('Chess — full game flows', () => {
     });
 
     test('test_chess_player_move_reflected_in_ui', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/chess/newgame'));
         await page.locator('button:has-text("Play as White")').click();
 
         const board = page.locator('.border-amber-900').first();
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         // Click e2 pawn (row 6 col 4 = square 52 from top-left) then e4 (row 4 col 4 = square 36)
         const squares = board.locator('> div > div');
         await squares.nth(52).click();
-        await page.waitForTimeout(500);
+        await page.waitForTimeout(300);
         await squares.nth(36).click();
-        await page.waitForTimeout(3000);
+        await page.waitForTimeout(1500);
 
         // Board should still be visible after the move
         await expect(board).toBeVisible({ timeout: 3000 });
     });
 
     test('test_chess_game_over_overlay_available', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/chess/newgame'));
         await page.locator('button:has-text("Play as White")').click();
 
         const board = page.locator('.border-amber-900').first();
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         const squares = board.locator('> div > div');
 
@@ -66,9 +66,9 @@ test.describe('Chess — full game flows', () => {
 
         for (const [from, to] of moves) {
             await squares.nth(from).click();
-            await page.waitForTimeout(500);
+            await page.waitForTimeout(300);
             await squares.nth(to).click();
-            await page.waitForTimeout(3500);
+            await page.waitForTimeout(1500);
 
             const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
             if ((await gameOverText.count()) > 0) break;
@@ -87,10 +87,10 @@ test.describe('Chess — full game flows', () => {
     });
 
     test('test_chess_resume_after_page_refresh', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/chess/newgame'));
         await page.locator('button:has-text("Play as White")').click();
         const board = page.locator('.border-amber-900').first();
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         await page.reload();
         await page.waitForLoadState('networkidle');

--- a/tests/e2e/connect4.spec.ts
+++ b/tests/e2e/connect4.spec.ts
@@ -30,29 +30,29 @@ test.describe('Connect 4 — full game flows', () => {
     });
 
     test('test_connect4_player_drop_reflected_in_ui', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/connect4/newgame'));
         await page.locator('button:has-text("Play as Red")').click();
 
         const board = page.locator('[aria-label="Connect 4 board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         await page.locator('[aria-label="Column 4"]').click();
-        await page.waitForTimeout(3000);
+        await page.waitForTimeout(1500);
 
         await expect(board).toBeVisible({ timeout: 3000 });
     });
 
     test('test_connect4_game_over_overlay_available', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/connect4/newgame'));
         await page.locator('button:has-text("Play as Red")').click();
 
         const board = page.locator('[aria-label="Connect 4 board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         // Drop 4 in column 1 — vertical win if AI does not block
         for (let i = 0; i < 4; i++) {
             await page.locator('[aria-label="Column 1"]').click();
-            await page.waitForTimeout(3500);
+            await page.waitForTimeout(1500);
 
             const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
             if ((await gameOverText.count()) > 0) break;
@@ -71,13 +71,13 @@ test.describe('Connect 4 — full game flows', () => {
     });
 
     test('test_connect4_resume_after_page_refresh', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/connect4/newgame'));
         await page.locator('button:has-text("Play as Red")').click();
         const board = page.locator('[aria-label="Connect 4 board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         await page.locator('[aria-label="Column 4"]').click();
-        await page.waitForTimeout(1000);
+        await page.waitForTimeout(500);
 
         await page.reload();
         await page.waitForLoadState('networkidle');

--- a/tests/e2e/dots-and-boxes.spec.ts
+++ b/tests/e2e/dots-and-boxes.spec.ts
@@ -30,28 +30,28 @@ test.describe('Dots and Boxes — full game flows', () => {
     });
 
     test('test_dab_player_edge_click_reflected_in_ui', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/dots-and-boxes/newgame'));
         await page.locator('button:has-text("Go First")').click();
 
         const board = page.locator('[aria-label="Dots and Boxes board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         // Click first interactive edge (SVG rect with cursor:pointer)
         const edges = board.locator('rect[style*="cursor: pointer"]');
         if ((await edges.count()) > 0) {
             await edges.first().click();
-            await page.waitForTimeout(3000);
+            await page.waitForTimeout(1500);
         }
 
         await expect(board).toBeVisible({ timeout: 3000 });
     });
 
     test('test_dab_game_over_overlay_available', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/dots-and-boxes/newgame'));
         await page.locator('button:has-text("Go First")').click();
 
         const board = page.locator('[aria-label="Dots and Boxes board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         // Click several edges; if the game ends, the overlay should appear
         const edges = board.locator('rect[style*="cursor: pointer"]');
@@ -62,7 +62,7 @@ test.describe('Dots and Boxes — full game flows', () => {
             const currentEdges = board.locator('rect[style*="cursor: pointer"]');
             if ((await currentEdges.count()) === 0) break;
             await currentEdges.first().click();
-            await page.waitForTimeout(2500);
+            await page.waitForTimeout(1500);
 
             const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
             if ((await gameOverText.count()) > 0) break;
@@ -81,10 +81,10 @@ test.describe('Dots and Boxes — full game flows', () => {
     });
 
     test('test_dab_resume_after_page_refresh', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/dots-and-boxes/newgame'));
         await page.locator('button:has-text("Go First")').click();
         const board = page.locator('[aria-label="Dots and Boxes board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000);
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         await page.reload();
         await page.waitForLoadState('networkidle');

--- a/tests/e2e/ttt.spec.ts
+++ b/tests/e2e/ttt.spec.ts
@@ -39,22 +39,22 @@ test.describe('TTT — full game flows', () => {
     });
 
     test('test_ttt_full_game_player_wins', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/tic-tac-toe/newgame'));
         await page.locator('button:has-text("Play as X")').click();
 
         const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000); // wait for game init API response + board unlock
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         const cells = board.locator('button');
 
         await cells.nth(0).click();
-        await page.waitForTimeout(3500);
+        await page.waitForTimeout(1500);
 
         await cells.nth(1).click();
-        await page.waitForTimeout(3500);
+        await page.waitForTimeout(1500);
 
         await cells.nth(2).click();
-        await page.waitForTimeout(3500);
+        await page.waitForTimeout(1500);
 
         const banner = page.locator('.alert');
         const stillPlaying = (await board.isVisible()) && !(await banner.isVisible());
@@ -75,13 +75,13 @@ test.describe('TTT — full game flows', () => {
     });
 
     test('test_ttt_resume_after_page_refresh', async ({ page }) => {
+        const newgameResp = page.waitForResponse(r => r.url().includes('/tic-tac-toe/newgame'));
         await page.locator('button:has-text("Play as X")').click();
         const board = page.locator('[aria-label="Tic-Tac-Toe board"]');
-        await expect(board).toBeVisible({ timeout: 5000 });
-        await page.waitForTimeout(2000); // wait for game init + board unlock
+        await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
 
         await page.locator('[aria-label="Tic-Tac-Toe board"] button').first().click();
-        await page.waitForTimeout(1000);
+        await page.waitForTimeout(500);
 
         await page.reload();
         await page.waitForLoadState('networkidle');


### PR DESCRIPTION
## Summary

- `ENVIRONMENT=test` was missing from both the nightly workflow `.env` block and the Playwright `webServer` env — the root cause of the nightly failures
- Without it, `_is_test_env` evaluated to `False` at module load time in `games.py`, disabling `X-AI-Moves` header injection and leaving the AI delay at 2500ms (vs 50ms in test mode), making game outcomes non-deterministic and timing-based assertions unreliable
- Replaced 2000ms `waitForTimeout` game-init waits with `waitForResponse` on each `/newgame` endpoint (REST, responds synchronously with initial board state)
- Halved post-move AI response waits from 3500ms → 1500ms (still 30× headroom over the 50ms test-mode AI delay)

## Test plan

- [ ] Nightly E2E workflow passes on all three browsers (chromium, firefox, webkit)
- [ ] `npm run test:fast` passes locally (67 Vitest + 181 pytest, confirmed)
- [ ] Verify in CI artifact logs that backend starts with `ENVIRONMENT=test` visible