### PR TITLE
feat(chess): add get_state_fen and get_state_pgn public methods

### DIFF
--- a/src/backend/game_engine/chess_engine.py
+++ b/src/backend/game_engine/chess_engine.py
@@ -3,6 +3,7 @@ import copy
 from typing import Optional
 
 from game_engine.base import AIStrategy, GameEngine, GameState, Move
+from game_engine import chess_pgn
 from game_logic.chess import chess_game
 
 SEARCH_DEPTH = 2
@@ -398,6 +399,51 @@ class ChessEngine(GameEngine):
         """
         valid = chess_game._get_valid_moves(state, from_row, from_col)
         return [{"toRow": tr, "toCol": tc} for tr, tc in valid]
+
+    def get_state_fen(self, state: GameState) -> str:
+        """Serialize the current board position to a FEN string.
+
+        Args:
+            state: Current game state dict as produced by ChessEngine.
+
+        Returns:
+            FEN string representing the board, active color, castling rights,
+            en passant target, and placeholder half-move/full-move clocks.
+        """
+        return self._to_fen(state)
+
+    def get_state_pgn(
+        self,
+        state: GameState,
+        algebraic_moves: list[str],
+        white_name: str = "Player",
+        black_name: str = "AI",
+        result: Optional[str] = None,
+    ) -> str:
+        """Build a PGN string for the game associated with the given state.
+
+        The PGN is derived from ``algebraic_moves``, not re-parsed from the board.
+        ``state`` is accepted for interface consistency but is not read here.
+        Callers should supply the full SAN move history sourced from
+        ``chess_games.move_list_algebraic`` in the database.
+
+        Args:
+            state: Current game state dict (unused; present for interface consistency).
+            algebraic_moves: Ordered list of SAN move strings for the full game.
+            white_name: Name written to the PGN White header.
+            black_name: Name written to the PGN Black header.
+            result: PGN result token ("1-0", "0-1", "1/2-1/2"), or None for an
+                ongoing game (header will be "*").
+
+        Returns:
+            A PGN-formatted string with the standard seven-tag roster and move text.
+        """
+        return chess_pgn.moves_to_pgn(
+            algebraic_moves,
+            white_name=white_name,
+            black_name=black_name,
+            result=result,
+        )
 
     def outcome_to_persistence(self, state: GameState) -> Optional[str]:
         """Return the persistence outcome string for the given terminal state, or None."""

--- a/tests/unit/test_chess_engine.py
+++ b/tests/unit/test_chess_engine.py
@@ -144,3 +144,58 @@ def test_chess_move_stores_fen(engine, fresh_state):
     assert len(parts) == 6, f"FEN must have 6 space-separated fields, got: {fen}"
     assert parts[1] in ("w", "b"), f"Active color must be 'w' or 'b', got: {parts[1]}"
     assert re.match(r"^[KQRBNPkqrbnp1-8/]+$", parts[0]), f"Piece placement invalid: {parts[0]}"
+
+
+def test_get_state_fen_returns_six_field_fen(engine, fresh_state):
+    import re
+
+    fen = engine.get_state_fen(fresh_state)
+    parts = fen.split(" ")
+    assert len(parts) == 6
+    assert re.match(r"^[KQRBNPkqrbnp1-8/]+$", parts[0])
+    assert parts[1] in ("w", "b")
+
+
+def test_get_state_fen_matches_internal_to_fen(engine, fresh_state):
+    assert engine.get_state_fen(fresh_state) == engine._to_fen(fresh_state)
+
+
+def test_get_state_fen_reflects_active_color(engine, fresh_state):
+    move = {"fromRow": 6, "fromCol": 4, "toRow": 4, "toCol": 4}
+    after_white = engine.apply_move(fresh_state, move)
+    fen = engine.get_state_fen(after_white)
+    assert fen.split(" ")[1] == "b"
+
+
+def test_get_state_pgn_contains_headers(engine, fresh_state):
+    pgn = engine.get_state_pgn(fresh_state, ["e4", "e5"])
+    assert '[White "Player"]' in pgn
+    assert '[Black "AI"]' in pgn
+    assert "[Result" in pgn
+
+
+def test_get_state_pgn_contains_moves(engine, fresh_state):
+    pgn = engine.get_state_pgn(fresh_state, ["e4", "e5", "Nf3"])
+    assert "1. e4" in pgn
+    assert "e5" in pgn
+    assert "Nf3" in pgn
+
+
+def test_get_state_pgn_empty_move_list(engine, fresh_state):
+    pgn = engine.get_state_pgn(fresh_state, [])
+    assert "[Event" in pgn
+    assert "*" in pgn
+
+
+def test_get_state_pgn_custom_names_and_result(engine, fresh_state):
+    pgn = engine.get_state_pgn(
+        fresh_state, ["e4"], white_name="Alice", black_name="Bob", result="1-0"
+    )
+    assert '[White "Alice"]' in pgn
+    assert '[Black "Bob"]' in pgn
+    assert '[Result "1-0"]' in pgn
+
+
+def test_get_state_pgn_state_arg_not_required_to_have_moves(engine, fresh_state):
+    pgn = engine.get_state_pgn(fresh_state, ["d4", "d5"])
+    assert "1. d4" in pgn


### PR DESCRIPTION
Exposes FEN and PGN serialization on `ChessEngine` as dedicated public methods to support ML training workflows.

- `get_state_fen(state)` wraps the existing private `_to_fen`
- `get_state_pgn(state, algebraic_moves, ...)` delegates to `chess_pgn.moves_to_pgn`

## Test plan
- 8 new unit tests added to `tests/unit/test_chess_engine.py`
- All 221 unit tests pass locally