### PR TITLE
Persist chess model serving in prod deploy

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -76,7 +76,10 @@ steps:
           - '--add-cloudsql-instances=${_CLOUDSQL_INSTANCE}'
           - '--port=8000'
           - '--timeout=3600'
-          - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT},WEBSITE_URL=${_WEBSITE_URL},GOOGLE_REDIRECT_URI=${_WEBSITE_URL}/api/auth/google/callback'
+          - '--execution-environment=gen2'
+          - '--add-volume=name=models,type=cloud-storage,bucket=halogen-episode-455311-t4-models'
+          - '--add-volume-mount=volume=models,mount-path=/app/model_weights'
+          - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT},WEBSITE_URL=${_WEBSITE_URL},GOOGLE_REDIRECT_URI=${_WEBSITE_URL}/api/auth/google/callback,CHESS_AI_STRATEGY=model,CHESS_MODEL_DIR=/app/model_weights/chess/v0.1'
           - >-
               --set-secrets=DB_HOST=DB_HOST:latest,DB_NAME=DB_NAME:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,INTERNAL_API_KEY=INTERNAL_API_KEY:latest
 


### PR DESCRIPTION
Bakes the model-serving config into the Cloud Run deploy so it survives future deploys (it was applied manually via `gcloud run services update`, which the next autodeploy would revert).

Adds to the `deploy-service` step:
- `--execution-environment=gen2` (required for GCS volume mounts)
- GCS volume `models` (bucket `halogen-episode-455311-t4-models`) mounted at `/app/model_weights`
- `CHESS_AI_STRATEGY=model`, `CHESS_MODEL_DIR=/app/model_weights/chess/v0.1`

The artifact lives in GCS (`gs://.../chess/v0.1/`), decoupled from the image — swapping a model version is a path change, not a rebuild.