### PR TITLE
Model version registry + new artifact path scheme

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -79,7 +79,7 @@ steps:
           - '--execution-environment=gen2'
           - '--add-volume=name=models,type=cloud-storage,bucket=halogen-episode-455311-t4-models'
           - '--add-volume-mount=volume=models,mount-path=/app/model_weights'
-          - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT},WEBSITE_URL=${_WEBSITE_URL},GOOGLE_REDIRECT_URI=${_WEBSITE_URL}/api/auth/google/callback,CHESS_AI_STRATEGY=model,CHESS_MODEL_DIR=/app/model_weights/chess/v0.1'
+          - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT},WEBSITE_URL=${_WEBSITE_URL},GOOGLE_REDIRECT_URI=${_WEBSITE_URL}/api/auth/google/callback,CHESS_AI_STRATEGY=model,CHESS_MODEL_DIR=/app/model_weights/chess/untrained/0.1.0'
           - >-
               --set-secrets=DB_HOST=DB_HOST:latest,DB_NAME=DB_NAME:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,INTERNAL_API_KEY=INTERNAL_API_KEY:latest
 

--- a/scripts/migrations/versions/0009_add_model_versions.py
+++ b/scripts/migrations/versions/0009_add_model_versions.py
@@ -1,0 +1,50 @@
+"""Add model_versions registry table
+
+Tracks published model artifacts per game and difficulty, each tied to a GCS
+path and a semantic version, with an active flag. The serving layer selects the
+latest active version for the difficulty a player picks, and offers any
+difficulty that has at least one active version. Seeds the current chess
+"untrained" 0.1.0 artifact as the active version.
+
+Revision ID: 0009
+Revises: 0008
+Create Date: 2026-06-06
+"""
+
+from alembic import op
+
+revision = "0009"
+down_revision = "0008"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE model_versions (
+            id BIGSERIAL PRIMARY KEY,
+            game TEXT NOT NULL,
+            difficulty TEXT NOT NULL,
+            version TEXT NOT NULL,
+            gcs_path TEXT NOT NULL,
+            active BOOLEAN NOT NULL DEFAULT false,
+            class_count INTEGER,
+            source_commit TEXT,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            UNIQUE (game, difficulty, version)
+        )
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO model_versions
+            (game, difficulty, version, gcs_path, active, class_count, source_commit)
+        VALUES
+            ('chess', 'untrained', '0.1.0', 'chess/untrained/0.1.0', true, 1816, '5e38170')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE model_versions")


### PR DESCRIPTION
Establishes the versioning foundation and aligns the bucket to the `<game>/<difficulty>/<semver>/` scheme.

- **`0009` migration**: adds `model_versions` (game, difficulty, version, gcs_path, active, provenance), `UNIQUE(game,difficulty,version)`. Seeds the current artifact as `chess / untrained / 0.1.0` (active). Serving will later select the latest active version per chosen difficulty and offer any difficulty with an active version.
- **cloudbuild path**: `CHESS_MODEL_DIR` → `/app/model_weights/chess/untrained/0.1.0` (artifact re-homed in GCS from `chess/v0.1/`). The running service was already repointed; this persists it.

Serving still loads the fixed `CHESS_MODEL_DIR` for now — registry-driven selection + the difficulty UI are the next phase.