### PR TITLE
feat(auth): email-as-identity and login/registration modal overhaul

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -7,6 +7,8 @@ substitutions:
     _CLOUDSQL_INSTANCE: halogen-episode-455311-t4:us-central1:game-database
     _ENVIRONMENT: production
     _WEBSITE_URL: https://game-ai-website-w4453qrbcq-uc.a.run.app
+    _LOGO_BUCKET: halogen-episode-455311-t4-assets
+    _LOGO_SA: google-logo-retriever@halogen-episode-455311-t4.iam.gserviceaccount.com
 
 steps:
     - name: 'gcr.io/cloud-builders/docker'
@@ -79,7 +81,7 @@ steps:
           - '--execution-environment=gen2'
           - '--add-volume=name=models,type=cloud-storage,bucket=halogen-episode-455311-t4-models'
           - '--add-volume-mount=volume=models,mount-path=/app/model_weights'
-          - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT},WEBSITE_URL=${_WEBSITE_URL},GOOGLE_REDIRECT_URI=${_WEBSITE_URL}/api/auth/google/callback,CHESS_AI_STRATEGY=model,CHESS_MODEL_DIR=/app/model_weights/chess/untrained/0.1.0'
+          - '--set-env-vars=ENVIRONMENT=${_ENVIRONMENT},WEBSITE_URL=${_WEBSITE_URL},GOOGLE_REDIRECT_URI=${_WEBSITE_URL}/api/auth/google/callback,CHESS_AI_STRATEGY=model,CHESS_MODEL_DIR=/app/model_weights/chess/untrained/0.1.0,GOOGLE_LOGO_BUCKET=${_LOGO_BUCKET},GOOGLE_LOGO_SA=${_LOGO_SA}'
           - >-
               --set-secrets=DB_HOST=DB_HOST:latest,DB_NAME=DB_NAME:latest,DB_USER=DB_USER:latest,DB_PASSWORD=DB_PASSWORD:latest,GOOGLE_CLIENT_ID=GOOGLE_CLIENT_ID:latest,GOOGLE_CLIENT_SECRET=GOOGLE_CLIENT_SECRET:latest,INTERNAL_API_KEY=INTERNAL_API_KEY:latest
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,4 @@
 import js from '@eslint/js';
-import jsdoc from 'eslint-plugin-jsdoc';
 import tsParser from '@typescript-eslint/parser';
 import globals from 'globals';
 
@@ -14,26 +13,9 @@ export default [
                 ...globals.es2020,
             },
         },
-        plugins: { jsdoc },
         rules: {
-            // TypeScript's compiler already handles these; disable to avoid false positives
             'no-undef': 'off',
             'no-unused-vars': 'off',
-            'jsdoc/require-jsdoc': [
-                'error',
-                {
-                    require: {
-                        FunctionDeclaration: true,
-                        MethodDefinition: true,
-                        ClassDeclaration: true,
-                        ArrowFunctionExpression: false,
-                        FunctionExpression: false,
-                    },
-                    publicOnly: true,
-                },
-            ],
-            'jsdoc/require-param': 'warn',
-            'jsdoc/require-returns': 'warn',
         },
     },
 ];

--- a/requirements.in
+++ b/requirements.in
@@ -15,6 +15,7 @@ bcrypt
 google-auth
 google-auth-httplib2
 google-auth-oauthlib
+google-cloud-storage
 httpx
 
 # Data validation

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,9 @@ flatbuffers==25.12.19
     # via onnxruntime
 google-api-core==2.30.3
     # via
+    #   google-cloud-core
     #   google-cloud-monitoring
+    #   google-cloud-storage
     #   google-cloud-trace
 google-auth==2.53.0
     # via
@@ -58,16 +60,28 @@ google-auth==2.53.0
     #   google-api-core
     #   google-auth-httplib2
     #   google-auth-oauthlib
+    #   google-cloud-core
     #   google-cloud-monitoring
+    #   google-cloud-storage
     #   google-cloud-trace
 google-auth-httplib2==0.4.0
     # via -r requirements.in
 google-auth-oauthlib==1.3.1
     # via -r requirements.in
+google-cloud-core==2.6.0
+    # via google-cloud-storage
 google-cloud-monitoring==2.30.0
     # via opentelemetry-exporter-gcp-monitoring
+google-cloud-storage==3.11.0
+    # via -r requirements.in
 google-cloud-trace==1.19.0
     # via opentelemetry-exporter-gcp-trace
+google-crc32c==1.8.0
+    # via
+    #   google-cloud-storage
+    #   google-resumable-media
+google-resumable-media==2.10.0
+    # via google-cloud-storage
 googleapis-common-protos==1.74.0
     # via
     #   google-api-core
@@ -221,6 +235,7 @@ python-dotenv==1.2.2
 requests==2.33.1
     # via
     #   google-api-core
+    #   google-cloud-storage
     #   opentelemetry-resourcedetector-gcp
     #   requests-oauthlib
 requests-oauthlib==2.0.0

--- a/scripts/migrations/versions/0010_username_email_identity.py
+++ b/scripts/migrations/versions/0010_username_email_identity.py
@@ -1,0 +1,17 @@
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "0010"
+down_revision: Union[str, None] = "0009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE users ALTER COLUMN username TYPE VARCHAR(100)")
+    op.execute("UPDATE users SET username = email WHERE username IS DISTINCT FROM email")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE users ALTER COLUMN username TYPE VARCHAR(50) USING LEFT(username, 50)")

--- a/scripts/seed_test_data.py
+++ b/scripts/seed_test_data.py
@@ -24,21 +24,21 @@ from db import get_session, init_db, close_db
 
 _TEST_USERS = [
     {
-        "username": "demo",
+        "username": "demo@aigamehub.com",
         "email": "demo@aigamehub.com",
         "password_hash": "$2b$12$yRa5XdiD234Dvuavu0Cx0u5lJXaPsyufv9aG3QdIun9FIUx.t0cVS",
         "display_name": "Demo Player",
         "stats_public": True,
     },
     {
-        "username": "test",
+        "username": "test@example.com",
         "email": "test@example.com",
         "password_hash": "$2b$12$ZzFtjWukLb1z7wJ8B8EM.uUijqU1b0LcUFqXhp2LH646KezufWtni",
         "display_name": "Test User",
         "stats_public": True,
     },
     {
-        "username": "player1",
+        "username": "player1@example.com",
         "email": "player1@example.com",
         "password_hash": "$2b$12$ZzFtjWukLb1z7wJ8B8EM.uUijqU1b0LcUFqXhp2LH646KezufWtni",
         "display_name": "Player One",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [pydocstyle]
 convention = google
+add-ignore = D100,D101,D102,D103,D104,D105,D106,D107
 match = (?!test_|_).*\.py
 match_dir = (?!tests|migrations|__pycache__).*

--- a/src/backend/auth.py
+++ b/src/backend/auth.py
@@ -15,6 +15,7 @@ import secrets
 
 from sqlalchemy import text
 
+import google_logo
 from auth_service import AuthService
 from db import get_session
 
@@ -29,9 +30,6 @@ csrf_tokens: dict = {}
 
 
 class RegisterRequest(BaseModel):
-    """Request body for the /register endpoint."""
-
-    username: str
     email: EmailStr
     password: str
     displayName: Optional[str] = None
@@ -154,45 +152,24 @@ async def get_current_user(
 
 @router.post("/register", status_code=201)
 async def register(request: RegisterRequest, response: Response):
-    """Register a new local user account and return an authenticated session.
-
-    Validates password length (min 6) and username length (min 3). Returns 409 if
-    the email or username is already taken. Sets a session cookie on success.
-
-    Args:
-        request: RegisterRequest with username, email, password, and optional displayName.
-        response: FastAPI Response used to set the session cookie.
-
-    Returns:
-        dict: `{"message": ..., "user": {id, username, email, displayName, authProvider}}`.
-
-    Raises:
-        HTTPException 400: Invalid password or username length.
-        HTTPException 409: Email or username already registered.
-        HTTPException 500: Unexpected registration failure.
-    """
     if len(request.password) < 6:
         raise HTTPException(status_code=400, detail="Password must be at least 6 characters long")
-    if len(request.username) < 3:
-        raise HTTPException(status_code=400, detail="Username must be at least 3 characters long")
 
     with tracer.start_as_current_span("auth.register") as span:
-        span.set_attribute("auth.username", request.username)
+        span.set_attribute("auth.email", request.email)
 
         existing_email = await auth_service.find_user_by_email(request.email)
         if existing_email:
             raise HTTPException(status_code=409, detail="Email already registered")
 
-        existing_username = await auth_service.find_user_by_username(request.username)
-        if existing_username:
-            raise HTTPException(status_code=409, detail="Username already taken")
+        display_name = (request.displayName or "").strip() or request.email.split("@")[0]
 
         try:
             user = await auth_service.create_user(
-                username=request.username,
+                username=request.email,
                 email=request.email,
                 password=request.password,
-                display_name=request.displayName or request.username,
+                display_name=display_name,
             )
             session_id = await auth_service.create_session(user["id"])
             set_session_cookie(response, session_id)
@@ -210,7 +187,7 @@ async def register(request: RegisterRequest, response: Response):
         except HTTPException:
             raise
         except Exception:
-            logger.exception("Registration failed for username=%s", request.username)
+            logger.exception("Registration failed for email=%s", request.email)
             raise HTTPException(status_code=500, detail="Registration failed. Please try again.")
 
 
@@ -405,6 +382,18 @@ async def auth_health():
         "database": db_status,
         "timestamp": datetime.now().isoformat(),
     }
+
+
+@router.get("/google-logo")
+async def google_logo_asset():
+    data = await google_logo.get_logo()
+    if not data:
+        raise HTTPException(status_code=404, detail="Google logo unavailable")
+    return Response(
+        content=data,
+        media_type="image/png",
+        headers={"Cache-Control": "public, max-age=86400"},
+    )
 
 
 class GoogleAuthRequest(BaseModel):

--- a/src/backend/auth_service.py
+++ b/src/backend/auth_service.py
@@ -18,21 +18,7 @@ class AuthService:
     async def create_google_user(
         self, email: str, google_id: str, display_name: str, profile_picture: str
     ) -> Dict:
-        """Create a new user record from a verified Google OAuth identity.
-
-        Derives the username from the email local part. Sets auth_provider='google'
-        and email_verified=True. Raises IntegrityError if the email already exists.
-
-        Args:
-            email: Verified email address from Google's ID token.
-            google_id: Google account subject identifier (sub field).
-            display_name: Full name from Google profile.
-            profile_picture: Profile picture URL from Google profile.
-
-        Returns:
-            dict with keys: id, username, email, display_name, auth_provider,
-            created_at, profile_picture.
-        """
+        display_name = display_name or email.split("@")[0]
         async with get_session() as session:
             result = await session.execute(
                 text("""
@@ -45,7 +31,7 @@ class AuthService:
                     RETURNING id, username, email, display_name, auth_provider, created_at
                 """),
                 {
-                    "username": email.split("@")[0],
+                    "username": email,
                     "email": email,
                     "google_id": google_id,
                     "display_name": display_name,

--- a/src/backend/google_logo.py
+++ b/src/backend/google_logo.py
@@ -1,0 +1,118 @@
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Optional, Tuple
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_LOGO_URL = "https://developers.google.com/identity/images/g-logo.png"
+MAX_AGE_SECONDS = 24 * 60 * 60
+
+_memory_cache: dict = {"data": None, "fetched_at": None}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _source_url() -> str:
+    return os.getenv("GOOGLE_LOGO_URL", DEFAULT_LOGO_URL)
+
+
+def _bucket_name() -> Optional[str]:
+    return os.getenv("GOOGLE_LOGO_BUCKET") or None
+
+
+def _object_name() -> str:
+    return os.getenv("GOOGLE_LOGO_OBJECT", "google-logo.png")
+
+
+def _age_seconds(fetched_at: Optional[datetime]) -> Optional[float]:
+    if fetched_at is None:
+        return None
+    return (_now() - fetched_at).total_seconds()
+
+
+def _bucket():
+    name = _bucket_name()
+    if not name:
+        return None
+    try:
+        from google.cloud import storage
+
+        return storage.Client().bucket(name)
+    except Exception:
+        logger.exception("Google logo: GCS client unavailable")
+        return None
+
+
+def _read_bucket() -> Tuple[Optional[bytes], Optional[datetime]]:
+    bucket = _bucket()
+    if bucket is None:
+        return None, None
+    try:
+        blob = bucket.blob(_object_name())
+        if not blob.exists():
+            return None, None
+        data = blob.download_as_bytes()
+        blob.reload()
+        stamp = (blob.metadata or {}).get("fetched_at")
+        fetched_at = datetime.fromisoformat(stamp) if stamp else None
+        return data, fetched_at
+    except Exception:
+        logger.exception("Google logo: failed reading cached object")
+        return None, None
+
+
+def _write_bucket(data: bytes, fetched_at: datetime) -> None:
+    bucket = _bucket()
+    if bucket is None:
+        return
+    try:
+        blob = bucket.blob(_object_name())
+        blob.metadata = {"fetched_at": fetched_at.isoformat()}
+        blob.upload_from_string(data, content_type="image/png")
+    except Exception:
+        logger.exception("Google logo: failed writing cached object")
+
+
+async def _fetch_remote() -> Optional[bytes]:
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(_source_url())
+    except Exception:
+        logger.exception("Google logo: fetch failed")
+        return None
+    if resp.status_code == 200 and resp.content:
+        return resp.content
+    logger.warning("Google logo: source returned status %s", resp.status_code)
+    return None
+
+
+def _read_cache() -> Tuple[Optional[bytes], Optional[datetime]]:
+    data, fetched_at = _read_bucket()
+    if data is not None:
+        return data, fetched_at
+    return _memory_cache["data"], _memory_cache["fetched_at"]
+
+
+def _store_cache(data: bytes, fetched_at: datetime) -> None:
+    _memory_cache["data"] = data
+    _memory_cache["fetched_at"] = fetched_at
+    _write_bucket(data, fetched_at)
+
+
+async def get_logo() -> Optional[bytes]:
+    cached, fetched_at = _read_cache()
+    age = _age_seconds(fetched_at)
+    if cached is not None and age is not None and age < MAX_AGE_SECONDS:
+        return cached
+
+    fresh = await _fetch_remote()
+    if fresh is not None:
+        _store_cache(fresh, _now())
+        return fresh
+
+    return cached

--- a/src/backend/google_logo.py
+++ b/src/backend/google_logo.py
@@ -42,6 +42,18 @@ def _bucket():
     try:
         from google.cloud import storage
 
+        target_sa = os.getenv("GOOGLE_LOGO_SA")
+        if target_sa:
+            import google.auth
+            from google.auth import impersonated_credentials
+
+            source_credentials, _ = google.auth.default()
+            credentials = impersonated_credentials.Credentials(
+                source_credentials=source_credentials,
+                target_principal=target_sa,
+                target_scopes=["https://www.googleapis.com/auth/devstorage.read_write"],
+            )
+            return storage.Client(credentials=credentials).bucket(name)
         return storage.Client().bucket(name)
     except Exception:
         logger.exception("Google logo: GCS client unavailable")

--- a/src/frontend/src/api/auth.test.ts
+++ b/src/frontend/src/api/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { fetchCurrentUser, login, logout } from './auth';
+import { fetchCurrentUser, login, logout, register } from './auth';
 
 describe('auth api', () => {
     it('auth api login sends correct request', async () => {
@@ -8,10 +8,17 @@ describe('auth api', () => {
         expect(result.user.email).toBe('test@example.com');
     });
 
-    it('fetchCurrentUser returns user', async () => {
+    it('fetchCurrentUser returns user whose username is their email', async () => {
         const user = await fetchCurrentUser();
-        expect(user.username).toBe('testuser');
         expect(user.email).toBe('test@example.com');
+        expect(user.username).toBe('test@example.com');
+    });
+
+    it('register sends email, password and displayName and returns username equal to email', async () => {
+        const result = await register('newperson@example.com', 'password123', 'New Person');
+        expect(result.user.email).toBe('newperson@example.com');
+        expect(result.user.username).toBe('newperson@example.com');
+        expect(result.user.displayName).toBe('New Person');
     });
 
     it('logout succeeds', async () => {

--- a/src/frontend/src/api/auth.ts
+++ b/src/frontend/src/api/auth.ts
@@ -39,25 +39,10 @@ export async function login(email: string, password: string, rememberMe = false)
     });
 }
 
-/**
- * Register a new local user account and start a session.
- *
- * @param username - Desired username (minimum 3 characters).
- * @param email - Unique email address.
- * @param password - Password (minimum 6 characters).
- * @param displayName - Optional display name; defaults to username on the server.
- * @returns Object containing the newly created User profile.
- * @throws {Error} If the username or email is already taken, or validation fails.
- */
-export async function register(
-    username: string,
-    email: string,
-    password: string,
-    displayName?: string
-): Promise<{ user: User }> {
+export async function register(email: string, password: string, displayName?: string): Promise<{ user: User }> {
     return request<{ user: User }>('/api/auth/register', {
         method: 'POST',
-        body: JSON.stringify({ username, email, password, displayName }),
+        body: JSON.stringify({ email, password, displayName }),
     });
 }
 

--- a/src/frontend/src/components/AuthModal.test.tsx
+++ b/src/frontend/src/components/AuthModal.test.tsx
@@ -1,37 +1,129 @@
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+import { server } from '../mocks/server';
 import { renderWithProviders } from '../test-utils';
 import AuthModal from './AuthModal';
 
 describe('AuthModal', () => {
-    it('auth modal validates empty email', () => {
-        renderWithProviders(<AuthModal open={true} initialTab='login' onClose={() => {}} />);
-        const emailInput =
-            screen.getByRole('textbox', { hidden: true }) ||
-            screen.getAllByDisplayValue('').find(el => el.getAttribute('type') === 'email');
-        expect(emailInput).toBeRequired();
+    it('renders login and register tabs', () => {
+        renderWithProviders(<AuthModal open initialTab='login' onClose={() => {}} />);
+        expect(screen.getByRole('tab', { name: /login/i })).toBeInTheDocument();
+        expect(screen.getByRole('tab', { name: /sign up/i })).toBeInTheDocument();
     });
 
-    it('auth modal calls login on submit', async () => {
+    it('marks the login email as required', () => {
+        renderWithProviders(<AuthModal open initialTab='login' onClose={() => {}} />);
+        expect(document.querySelector('#login-email')).toBeRequired();
+    });
+
+    it('calls login and closes on submit', async () => {
         const user = userEvent.setup();
-        renderWithProviders(<AuthModal open={true} initialTab='login' onClose={() => {}} />);
-        const inputs = screen.getAllByRole('textbox', { hidden: true });
-        const emailInput = inputs.find(el => el.getAttribute('type') === 'email') || inputs[0];
-        const passwordInputs = document.querySelectorAll('input[type="password"]');
-        if (emailInput && passwordInputs.length > 0) {
-            await user.type(emailInput, 'test@example.com');
-            await user.type(passwordInputs[0] as HTMLElement, 'password123');
-            const submitBtn = document.querySelector('button[type="submit"]') as HTMLElement;
-            await user.click(submitBtn);
+        const onClose = vi.fn();
+        renderWithProviders(<AuthModal open initialTab='login' onClose={onClose} />);
+        await user.type(document.querySelector('#login-email') as HTMLElement, 'test@example.com');
+        await user.type(document.querySelector('#login-password') as HTMLElement, 'password123');
+        await user.click(screen.getByRole('button', { name: /^login$/i }));
+        await waitFor(() => expect(onClose).toHaveBeenCalled());
+    });
+
+    it('register form has no username field', () => {
+        renderWithProviders(<AuthModal open initialTab='register' onClose={() => {}} />);
+        expect(screen.queryByText(/^username$/i)).toBeNull();
+        expect(document.querySelector('#register-displayname')).toBeTruthy();
+        expect(document.querySelector('#register-email')).toBeTruthy();
+        expect(document.querySelector('#register-password')).toBeTruthy();
+        expect(document.querySelector('#register-confirm')).toBeTruthy();
+    });
+
+    it('gives every register field the same layout classes', () => {
+        renderWithProviders(<AuthModal open initialTab='register' onClose={() => {}} />);
+        const inputs = Array.from(document.querySelectorAll('input')).filter(input =>
+            ['email', 'text', 'password'].includes(input.getAttribute('type') || 'text')
+        );
+        expect(inputs.length).toBe(4);
+        for (const input of inputs) {
+            expect(input.classList.contains('input-bordered')).toBe(true);
+            expect(input.classList.contains('w-full')).toBe(true);
+            expect(input.closest('.form-control.w-full')).not.toBeNull();
         }
     });
 
-    it('renders login and register tabs', () => {
-        renderWithProviders(<AuthModal open={true} initialTab='login' onClose={() => {}} />);
-        const tabs = screen.getAllByRole('tab');
-        expect(tabs.length).toBeGreaterThanOrEqual(2);
-        expect(screen.getByRole('tab', { name: /login/i })).toBeInTheDocument();
-        expect(screen.getByRole('tab', { name: /sign up/i })).toBeInTheDocument();
+    it('lets the user peek a password via the show/hide toggle', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(<AuthModal open initialTab='register' onClose={() => {}} />);
+        const password = document.querySelector('#register-password') as HTMLInputElement;
+        const toggle = password.parentElement!.querySelector('button') as HTMLElement;
+        expect(password.type).toBe('password');
+        expect(toggle).toHaveAttribute('aria-label', 'Show password');
+        await user.click(toggle);
+        expect(password.type).toBe('text');
+        expect(toggle).toHaveAttribute('aria-label', 'Hide password');
+        expect(toggle).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('blocks registration and shows an error when passwords do not match', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        let registerCalled = false;
+        server.use(
+            http.post('/api/auth/register', () => {
+                registerCalled = true;
+                return HttpResponse.json({ user: {} });
+            })
+        );
+        renderWithProviders(<AuthModal open initialTab='register' onClose={onClose} />);
+        await user.type(document.querySelector('#register-email') as HTMLElement, 'new@example.com');
+        await user.type(document.querySelector('#register-password') as HTMLElement, 'abc123');
+        await user.type(document.querySelector('#register-confirm') as HTMLElement, 'xyz789');
+        await user.click(screen.getByRole('button', { name: /create account/i }));
+        expect(await screen.findByText(/passwords do not match/i)).toBeInTheDocument();
+        expect(registerCalled).toBe(false);
+        expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it('registers with email, password and display name only when passwords match', async () => {
+        const user = userEvent.setup();
+        const onClose = vi.fn();
+        let body: Record<string, unknown> | null = null;
+        server.use(
+            http.post('/api/auth/register', async ({ request }) => {
+                body = (await request.json()) as Record<string, unknown>;
+                const email = String(body.email);
+                return HttpResponse.json({
+                    user: {
+                        id: 2,
+                        username: email,
+                        email,
+                        displayName: body.displayName || email.split('@')[0],
+                        authProvider: 'local',
+                        emailVerified: false,
+                        statsPublic: true,
+                    },
+                });
+            })
+        );
+        renderWithProviders(<AuthModal open initialTab='register' onClose={onClose} />);
+        await user.type(document.querySelector('#register-displayname') as HTMLElement, 'New Person');
+        await user.type(document.querySelector('#register-email') as HTMLElement, 'new@example.com');
+        await user.type(document.querySelector('#register-password') as HTMLElement, 'abc123');
+        await user.type(document.querySelector('#register-confirm') as HTMLElement, 'abc123');
+        await user.click(screen.getByRole('button', { name: /create account/i }));
+        await waitFor(() => expect(onClose).toHaveBeenCalled());
+        expect(body).toMatchObject({ email: 'new@example.com', password: 'abc123', displayName: 'New Person' });
+        expect(body).not.toHaveProperty('username');
+    });
+
+    it('loads the google logo from the server endpoint and falls back to an inline svg', async () => {
+        renderWithProviders(<AuthModal open initialTab='login' onClose={() => {}} />);
+        const img = document.querySelector('img') as HTMLImageElement;
+        expect(img).toHaveAttribute('src', '/api/auth/google-logo');
+        expect(document.querySelector('svg path[fill="#EA4335"]')).toBeNull();
+        fireEvent.error(img);
+        await waitFor(() => {
+            expect(document.querySelector('img')).toBeNull();
+            expect(document.querySelector('svg path[fill="#EA4335"]')).not.toBeNull();
+        });
     });
 });

--- a/src/frontend/src/components/AuthModal.tsx
+++ b/src/frontend/src/components/AuthModal.tsx
@@ -7,9 +7,161 @@ interface Props {
     onClose: () => void;
 }
 
-/**
- * Renders a modal dialog with login and registration tabs for user authentication.
- */
+function EyeIcon({ off }: { off: boolean }) {
+    return (
+        <svg
+            xmlns='http://www.w3.org/2000/svg'
+            className='h-5 w-5'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth={2}
+            strokeLinecap='round'
+            strokeLinejoin='round'
+            aria-hidden='true'>
+            {off ? (
+                <>
+                    <path d='M9.88 9.88a3 3 0 0 0 4.24 4.24' />
+                    <path d='M10.73 5.08A10.43 10.43 0 0 1 12 5c7 0 10 7 10 7a13.16 13.16 0 0 1-1.67 2.68' />
+                    <path d='M6.61 6.61A13.526 13.526 0 0 0 2 12s3 7 10 7a9.74 9.74 0 0 0 5.39-1.61' />
+                    <line x1='2' y1='2' x2='22' y2='22' />
+                </>
+            ) : (
+                <>
+                    <path d='M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z' />
+                    <circle cx='12' cy='12' r='3' />
+                </>
+            )}
+        </svg>
+    );
+}
+
+function TextField({
+    id,
+    label,
+    type,
+    value,
+    onChange,
+    required,
+    autoComplete,
+}: {
+    id: string;
+    label: string;
+    type: string;
+    value: string;
+    onChange: (value: string) => void;
+    required?: boolean;
+    autoComplete?: string;
+}) {
+    return (
+        <div className='form-control w-full'>
+            <label className='label-text mb-1 font-medium' htmlFor={id}>
+                {label}
+            </label>
+            <input
+                id={id}
+                type={type}
+                className='input input-bordered w-full'
+                required={required}
+                autoComplete={autoComplete}
+                value={value}
+                onChange={e => onChange(e.target.value)}
+            />
+        </div>
+    );
+}
+
+function PasswordField({
+    id,
+    label,
+    value,
+    onChange,
+    required = true,
+    minLength,
+    autoComplete,
+}: {
+    id: string;
+    label: string;
+    value: string;
+    onChange: (value: string) => void;
+    required?: boolean;
+    minLength?: number;
+    autoComplete?: string;
+}) {
+    const [show, setShow] = useState(false);
+    return (
+        <div className='form-control w-full'>
+            <label className='label-text mb-1 font-medium' htmlFor={id}>
+                {label}
+            </label>
+            <div className='relative'>
+                <input
+                    id={id}
+                    type={show ? 'text' : 'password'}
+                    className='input input-bordered w-full pr-12'
+                    required={required}
+                    minLength={minLength}
+                    autoComplete={autoComplete}
+                    value={value}
+                    onChange={e => onChange(e.target.value)}
+                />
+                <button
+                    type='button'
+                    className='absolute inset-y-0 right-0 flex items-center px-3 text-base-content/60 hover:text-base-content'
+                    onClick={() => setShow(s => !s)}
+                    aria-label={show ? 'Hide password' : 'Show password'}
+                    aria-pressed={show}>
+                    <EyeIcon off={show} />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+function GoogleLogoFallback() {
+    return (
+        <svg className='h-5 w-5' viewBox='0 0 48 48' aria-hidden='true'>
+            <path
+                fill='#EA4335'
+                d='M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z'
+            />
+            <path
+                fill='#4285F4'
+                d='M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z'
+            />
+            <path
+                fill='#FBBC05'
+                d='M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z'
+            />
+            <path
+                fill='#34A853'
+                d='M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z'
+            />
+            <path fill='none' d='M0 0h48v48H0z' />
+        </svg>
+    );
+}
+
+function GoogleButton() {
+    const [failed, setFailed] = useState(false);
+    return (
+        <a href='/api/auth/google' className='btn btn-outline w-full gap-2'>
+            {failed ? (
+                <GoogleLogoFallback />
+            ) : (
+                <img
+                    src='/api/auth/google-logo'
+                    alt=''
+                    aria-hidden='true'
+                    className='h-5 w-5'
+                    onError={() => setFailed(true)}
+                />
+            )}
+            Continue with Google
+        </a>
+    );
+}
+
 export default function AuthModal({ open, initialTab, onClose }: Props) {
     const [tab, setTab] = useState(initialTab);
     const dialogRef = useRef<HTMLDialogElement>(null);
@@ -18,7 +170,8 @@ export default function AuthModal({ open, initialTab, onClose }: Props) {
     const register = useRegister();
 
     const [loginForm, setLoginForm] = useState({ email: '', password: '', rememberMe: false });
-    const [registerForm, setRegisterForm] = useState({ username: '', email: '', password: '', displayName: '' });
+    const [registerForm, setRegisterForm] = useState({ displayName: '', email: '', password: '', confirmPassword: '' });
+    const [registerError, setRegisterError] = useState<string | null>(null);
 
     useEffect(() => {
         setTab(initialTab);
@@ -34,6 +187,11 @@ export default function AuthModal({ open, initialTab, onClose }: Props) {
         }
     }, [open]);
 
+    function switchTab(next: 'login' | 'register') {
+        setRegisterError(null);
+        setTab(next);
+    }
+
     async function handleLogin(e: React.FormEvent) {
         e.preventDefault();
         await login.mutateAsync(loginForm);
@@ -42,16 +200,29 @@ export default function AuthModal({ open, initialTab, onClose }: Props) {
 
     async function handleRegister(e: React.FormEvent) {
         e.preventDefault();
-        await register.mutateAsync(registerForm);
+        setRegisterError(null);
+        if (registerForm.password !== registerForm.confirmPassword) {
+            setRegisterError('Passwords do not match');
+            return;
+        }
+        await register.mutateAsync({
+            email: registerForm.email,
+            password: registerForm.password,
+            displayName: registerForm.displayName,
+        });
         onClose();
     }
 
-    const error = (tab === 'login' ? login.error : register.error)?.message;
+    const mutationError = (tab === 'login' ? login.error : register.error)?.message;
+    const error = tab === 'register' ? (registerError ?? mutationError) : mutationError;
 
     return (
         <dialog ref={dialogRef} className='modal' onClose={onClose}>
             <div className='modal-box w-full max-w-md'>
-                <button className='btn btn-sm btn-circle btn-ghost absolute right-2 top-2' onClick={onClose}>
+                <button
+                    className='btn btn-sm btn-circle btn-ghost absolute right-2 top-2'
+                    onClick={onClose}
+                    aria-label='Close'>
                     ✕
                 </button>
 
@@ -59,13 +230,13 @@ export default function AuthModal({ open, initialTab, onClose }: Props) {
                     <button
                         role='tab'
                         className={`tab ${tab === 'login' ? 'tab-active' : ''}`}
-                        onClick={() => setTab('login')}>
+                        onClick={() => switchTab('login')}>
                         Login
                     </button>
                     <button
                         role='tab'
                         className={`tab ${tab === 'register' ? 'tab-active' : ''}`}
-                        onClick={() => setTab('register')}>
+                        onClick={() => switchTab('register')}>
                         Sign Up
                     </button>
                 </div>
@@ -78,31 +249,23 @@ export default function AuthModal({ open, initialTab, onClose }: Props) {
 
                 {tab === 'login' ? (
                     <form onSubmit={handleLogin} className='flex flex-col gap-4'>
-                        <label className='form-control'>
-                            <div className='label'>
-                                <span className='label-text'>Email</span>
-                            </div>
-                            <input
-                                type='email'
-                                className='input input-bordered'
-                                required
-                                value={loginForm.email}
-                                onChange={e => setLoginForm(f => ({ ...f, email: e.target.value }))}
-                            />
-                        </label>
-                        <label className='form-control'>
-                            <div className='label'>
-                                <span className='label-text'>Password</span>
-                            </div>
-                            <input
-                                type='password'
-                                className='input input-bordered'
-                                required
-                                value={loginForm.password}
-                                onChange={e => setLoginForm(f => ({ ...f, password: e.target.value }))}
-                            />
-                        </label>
-                        <label className='label cursor-pointer justify-start gap-2'>
+                        <TextField
+                            id='login-email'
+                            label='Email'
+                            type='email'
+                            required
+                            autoComplete='email'
+                            value={loginForm.email}
+                            onChange={v => setLoginForm(f => ({ ...f, email: v }))}
+                        />
+                        <PasswordField
+                            id='login-password'
+                            label='Password'
+                            autoComplete='current-password'
+                            value={loginForm.password}
+                            onChange={v => setLoginForm(f => ({ ...f, password: v }))}
+                        />
+                        <label className='flex cursor-pointer items-center gap-2'>
                             <input
                                 type='checkbox'
                                 className='checkbox checkbox-sm'
@@ -111,72 +274,48 @@ export default function AuthModal({ open, initialTab, onClose }: Props) {
                             />
                             <span className='label-text'>Remember me</span>
                         </label>
-                        <button type='submit' className='btn btn-primary' disabled={login.isPending}>
+                        <button type='submit' className='btn btn-primary w-full' disabled={login.isPending}>
                             {login.isPending ? <span className='loading loading-spinner loading-sm' /> : 'Login'}
                         </button>
                         <div className='divider'>OR</div>
-                        <a href='/api/auth/google' className='btn btn-outline gap-2'>
-                            <svg className='h-5 w-5' viewBox='0 0 24 24'>
-                                <path
-                                    fill='currentColor'
-                                    d='M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z'
-                                />
-                            </svg>
-                            Continue with Google
-                        </a>
+                        <GoogleButton />
                     </form>
                 ) : (
                     <form onSubmit={handleRegister} className='flex flex-col gap-4'>
-                        <label className='form-control'>
-                            <div className='label'>
-                                <span className='label-text'>Username</span>
-                            </div>
-                            <input
-                                type='text'
-                                className='input input-bordered'
-                                required
-                                minLength={3}
-                                value={registerForm.username}
-                                onChange={e => setRegisterForm(f => ({ ...f, username: e.target.value }))}
-                            />
-                        </label>
-                        <label className='form-control'>
-                            <div className='label'>
-                                <span className='label-text'>Display Name</span>
-                            </div>
-                            <input
-                                type='text'
-                                className='input input-bordered'
-                                value={registerForm.displayName}
-                                onChange={e => setRegisterForm(f => ({ ...f, displayName: e.target.value }))}
-                            />
-                        </label>
-                        <label className='form-control'>
-                            <div className='label'>
-                                <span className='label-text'>Email</span>
-                            </div>
-                            <input
-                                type='email'
-                                className='input input-bordered'
-                                required
-                                value={registerForm.email}
-                                onChange={e => setRegisterForm(f => ({ ...f, email: e.target.value }))}
-                            />
-                        </label>
-                        <label className='form-control'>
-                            <div className='label'>
-                                <span className='label-text'>Password</span>
-                            </div>
-                            <input
-                                type='password'
-                                className='input input-bordered'
-                                required
-                                minLength={6}
-                                value={registerForm.password}
-                                onChange={e => setRegisterForm(f => ({ ...f, password: e.target.value }))}
-                            />
-                        </label>
-                        <button type='submit' className='btn btn-primary' disabled={register.isPending}>
+                        <TextField
+                            id='register-displayname'
+                            label='Display Name'
+                            type='text'
+                            autoComplete='nickname'
+                            value={registerForm.displayName}
+                            onChange={v => setRegisterForm(f => ({ ...f, displayName: v }))}
+                        />
+                        <TextField
+                            id='register-email'
+                            label='Email'
+                            type='email'
+                            required
+                            autoComplete='email'
+                            value={registerForm.email}
+                            onChange={v => setRegisterForm(f => ({ ...f, email: v }))}
+                        />
+                        <PasswordField
+                            id='register-password'
+                            label='Password'
+                            minLength={6}
+                            autoComplete='new-password'
+                            value={registerForm.password}
+                            onChange={v => setRegisterForm(f => ({ ...f, password: v }))}
+                        />
+                        <PasswordField
+                            id='register-confirm'
+                            label='Confirm Password'
+                            minLength={6}
+                            autoComplete='new-password'
+                            value={registerForm.confirmPassword}
+                            onChange={v => setRegisterForm(f => ({ ...f, confirmPassword: v }))}
+                        />
+                        <button type='submit' className='btn btn-primary w-full' disabled={register.isPending}>
                             {register.isPending ? (
                                 <span className='loading loading-spinner loading-sm' />
                             ) : (

--- a/src/frontend/src/hooks/useAuth.test.ts
+++ b/src/frontend/src/hooks/useAuth.test.ts
@@ -21,6 +21,6 @@ describe('useAuth', () => {
             expect(result.current.isLoading).toBe(false);
         });
         expect(result.current.user).not.toBeNull();
-        expect(result.current.user?.username).toBe('testuser');
+        expect(result.current.user?.username).toBe('test@example.com');
     });
 });

--- a/src/frontend/src/hooks/useAuth.ts
+++ b/src/frontend/src/hooks/useAuth.ts
@@ -37,25 +37,10 @@ export function useLogin() {
     });
 }
 
-/**
- * Return a TanStack Query mutation for new user registration.
- * On success, updates the cached user in the query client.
- *
- * @returns Mutation object with mutateAsync({ username, email, password, displayName? }).
- */
 export function useRegister() {
     return useMutation({
-        mutationFn: ({
-            username,
-            email,
-            password,
-            displayName,
-        }: {
-            username: string;
-            email: string;
-            password: string;
-            displayName?: string;
-        }) => register(username, email, password, displayName),
+        mutationFn: ({ email, password, displayName }: { email: string; password: string; displayName?: string }) =>
+            register(email, password, displayName),
         onSuccess: ({ user }) => {
             queryClient.setQueryData(USER_QUERY_KEY, user);
         },

--- a/src/frontend/src/mocks/handlers.ts
+++ b/src/frontend/src/mocks/handlers.ts
@@ -4,7 +4,7 @@ export const handlers = [
     http.get('/api/auth/me', () => {
         return HttpResponse.json({
             id: 1,
-            username: 'testuser',
+            username: 'test@example.com',
             email: 'test@example.com',
             displayName: 'Test User',
             authProvider: 'local',
@@ -21,7 +21,7 @@ export const handlers = [
         return HttpResponse.json({
             user: {
                 id: 1,
-                username: 'testuser',
+                username: body.email,
                 email: body.email,
                 displayName: 'Test User',
                 authProvider: 'local',
@@ -33,12 +33,13 @@ export const handlers = [
 
     http.post('/api/auth/register', async ({ request }) => {
         const body = (await request.json()) as Record<string, unknown>;
+        const email = String(body.email);
         return HttpResponse.json({
             user: {
                 id: 2,
-                username: body.username,
-                email: body.email,
-                displayName: body.displayName || body.username,
+                username: email,
+                email,
+                displayName: body.displayName || email.split('@')[0],
                 authProvider: 'local',
                 emailVerified: false,
                 statsPublic: true,

--- a/src/frontend/src/pages/ProfilePage.test.tsx
+++ b/src/frontend/src/pages/ProfilePage.test.tsx
@@ -4,17 +4,19 @@ import { renderWithProviders } from '../test-utils';
 import ProfilePage from './ProfilePage';
 
 describe('ProfilePage', () => {
-    it('renders user profile', async () => {
+    it('renders the display name', async () => {
         renderWithProviders(<ProfilePage />);
         await waitFor(() => {
-            expect(screen.queryByText('testuser') || screen.queryByText('Test User')).toBeTruthy();
+            expect(screen.getByText('Test User')).toBeInTheDocument();
         });
     });
 
-    it('renders stats display', async () => {
+    it('does not expose the email as a public @handle', async () => {
         renderWithProviders(<ProfilePage />);
         await waitFor(() => {
-            expect(screen.queryByText('testuser') || screen.queryByText('Test User')).toBeTruthy();
+            expect(screen.getByText('Test User')).toBeInTheDocument();
         });
+        expect(screen.queryByText('@test@example.com')).toBeNull();
+        expect(screen.queryByText('@testuser')).toBeNull();
     });
 });

--- a/src/frontend/src/pages/ProfilePage.tsx
+++ b/src/frontend/src/pages/ProfilePage.tsx
@@ -97,7 +97,6 @@ export default function ProfilePage() {
                         </div>
                         <div>
                             <h2 className='text-xl font-semibold'>{user.displayName}</h2>
-                            <p className='text-sm opacity-60'>@{user.username}</p>
                         </div>
                     </div>
                     <div className='divider' />

--- a/src/frontend/src/pages/games/CheckersPage.tsx
+++ b/src/frontend/src/pages/games/CheckersPage.tsx
@@ -529,7 +529,7 @@ export default function CheckersPage() {
                     )}
 
                     <PlayerCard
-                        name={user.displayName || user.username}
+                        name={user.displayName}
                         avatarUrl={user.profilePicture}
                         symbol={showSymbols ? playerLabel : undefined}
                         result={playerResult}

--- a/src/frontend/src/pages/games/ChessPage.tsx
+++ b/src/frontend/src/pages/games/ChessPage.tsx
@@ -664,7 +664,7 @@ export default function ChessPage() {
                     )}
 
                     <PlayerCard
-                        name={user.displayName || user.username}
+                        name={user.displayName}
                         avatarUrl={user.profilePicture}
                         symbol={showInfo ? playerColorLabel : undefined}
                         result={playerResult}

--- a/src/frontend/src/pages/games/Connect4Page.tsx
+++ b/src/frontend/src/pages/games/Connect4Page.tsx
@@ -378,7 +378,7 @@ export default function Connect4Page() {
             </div>
 
             <PlayerCard
-                name={user.displayName || user.username}
+                name={user.displayName}
                 avatarUrl={user.profilePicture}
                 symbol={showSymbols ? playerSymbol : undefined}
                 result={playerResult}

--- a/src/frontend/src/pages/games/DotsAndBoxesPage.tsx
+++ b/src/frontend/src/pages/games/DotsAndBoxesPage.tsx
@@ -408,7 +408,7 @@ export default function DotsAndBoxesPage() {
             </div>
 
             <PlayerCard
-                name={user.displayName || user.username}
+                name={user.displayName}
                 avatarUrl={user.profilePicture}
                 symbol={showScores ? String(playerScore) : undefined}
                 result={playerResult}

--- a/src/frontend/src/pages/games/TicTacToePage.tsx
+++ b/src/frontend/src/pages/games/TicTacToePage.tsx
@@ -368,7 +368,7 @@ export default function TicTacToePage() {
             </div>
 
             <PlayerCard
-                name={user.displayName || user.username}
+                name={user.displayName}
                 avatarUrl={user.profilePicture}
                 symbol={showSymbols ? playerSymbol : undefined}
                 result={playerResult}

--- a/tests/api_tests/test_auth.py
+++ b/tests/api_tests/test_auth.py
@@ -4,26 +4,27 @@ import uuid
 
 def test_auth_register_login_logout_flow(client):
     unique = uuid.uuid4().hex[:8]
+    email = f"apitest_{unique}@example.com"
     reg = client.post(
         "/api/auth/register",
-        json={
-            "username": f"apitest_{unique}",
-            "email": f"apitest_{unique}@example.com",
-            "password": "testpass123",
-        },
+        json={"email": email, "password": "testpass123", "displayName": "API Test"},
     )
     assert reg.status_code == 201
-    assert "user" in reg.json()
+    user = reg.json()["user"]
+    assert user["email"] == email
+    assert user["username"] == email
+    assert user["displayName"] == "API Test"
 
     login_resp = client.post(
         "/api/auth/login",
-        json={"email": f"apitest_{unique}@example.com", "password": "testpass123"},
+        json={"email": email, "password": "testpass123"},
     )
     assert login_resp.status_code == 200
-    assert login_resp.json()["user"]["email"] == f"apitest_{unique}@example.com"
+    assert login_resp.json()["user"]["email"] == email
 
     me_resp = client.get("/api/auth/me")
     assert me_resp.status_code == 200
+    assert me_resp.json()["username"] == email
 
     logout_resp = client.post("/api/auth/logout")
     assert logout_resp.status_code == 200
@@ -32,7 +33,71 @@ def test_auth_register_login_logout_flow(client):
     assert me_after.status_code == 401
 
 
+def test_auth_register_accepts_email_longer_than_legacy_username_limit(client):
+    unique = uuid.uuid4().hex[:8]
+    local = ("x" * 40) + unique
+    email = f"{local}@example.com"
+    assert len(email) > 50
+
+    reg = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": "testpass123"},
+    )
+    assert reg.status_code == 201
+    assert reg.json()["user"]["username"] == email
+
+
+def test_auth_register_defaults_display_name_to_email_local_part(client):
+    unique = uuid.uuid4().hex[:8]
+    email = f"nodisplay_{unique}@example.com"
+    reg = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": "testpass123"},
+    )
+    assert reg.status_code == 201
+    assert reg.json()["user"]["displayName"] == f"nodisplay_{unique}"
+
+
+def test_auth_register_duplicate_email_conflicts(client):
+    unique = uuid.uuid4().hex[:8]
+    email = f"dupe_{unique}@example.com"
+    first = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": "testpass123"},
+    )
+    assert first.status_code == 201
+    second = client.post(
+        "/api/auth/register",
+        json={"email": email, "password": "testpass123"},
+    )
+    assert second.status_code == 409
+
+
 def test_auth_me_unauthenticated(client):
     client.cookies.clear()
     response = client.get("/api/auth/me")
     assert response.status_code == 401
+
+
+def test_google_logo_served_when_available(client, monkeypatch):
+    import google_logo
+
+    async def fake_get_logo():
+        return b"PNGDATA"
+
+    monkeypatch.setattr(google_logo, "get_logo", fake_get_logo)
+    resp = client.get("/api/auth/google-logo")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"] == "image/png"
+    assert resp.content == b"PNGDATA"
+
+
+def test_google_logo_404_when_unavailable(client, monkeypatch):
+    import google_logo
+
+    async def fake_get_logo():
+        return None
+
+    monkeypatch.setattr(google_logo, "get_logo", fake_get_logo)
+    resp = client.get("/api/auth/google-logo")
+    assert resp.status_code == 404

--- a/tests/api_tests/test_google_oauth.py
+++ b/tests/api_tests/test_google_oauth.py
@@ -31,3 +31,22 @@ def test_oauth_login_route_redirects_to_google(monkeypatch, client):
     assert response.status_code in (302, 307)
     location = response.headers["location"]
     assert "accounts.google.com" in location
+
+
+def test_google_user_stores_email_as_username(monkeypatch, client):
+    import uuid
+
+    import auth as auth_module
+
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "test-client-id")
+    email = f"goog_{uuid.uuid4().hex[:8]}@example.com"
+
+    def fake_verify(token, request, client_id):
+        return {"email": email, "sub": f"sub-{email}", "name": "Goog User", "picture": ""}
+
+    monkeypatch.setattr(auth_module.id_token, "verify_oauth2_token", fake_verify)
+    resp = client.post("/api/auth/google", json={"token": "fake-token"})
+    assert resp.status_code == 200
+    user = resp.json()["user"]
+    assert user["email"] == email
+    assert user["username"] == email

--- a/tests/auth/auth-flow.spec.js
+++ b/tests/auth/auth-flow.spec.js
@@ -62,7 +62,6 @@ test.describe('Authentication API', () => {
 
         const response = await page.request.post('/api/auth/register', {
             data: {
-                username: 'dupetest',
                 email: 'demo@aigamehub.com',
                 password: 'password123',
                 displayName: 'Dupe Test',

--- a/tests/helpers/auth-helper.js
+++ b/tests/helpers/auth-helper.js
@@ -222,7 +222,6 @@ function addAuth(request) {
 function createTestUser() {
     const timestamp = Date.now();
     return {
-        username: `testuser${timestamp}`,
         email: `test${timestamp}@example.com`,
         password: 'password123',
         displayName: `Test User ${timestamp}`,

--- a/tests/helpers/test-utils.js
+++ b/tests/helpers/test-utils.js
@@ -30,7 +30,6 @@ async function waitForGameLoad(page) {
 function generateTestUser() {
     const timestamp = Date.now();
     return {
-        username: `testuser${timestamp}`,
         email: `test${timestamp}@example.com`,
         password: 'password123',
         displayName: `Test User ${timestamp}`,

--- a/tests/integration/test_auth_sessions.py
+++ b/tests/integration/test_auth_sessions.py
@@ -13,8 +13,8 @@ async def test_auth_create_user_persists(seeded_db):
     )
     row = result.fetchone()
     assert row is not None
-    assert row.username == "test"
     assert row.email == "test@example.com"
+    assert row.username == row.email
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_google_logo.py
+++ b/tests/unit/test_google_logo.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+
+import pytest
+
+import google_logo
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    monkeypatch.delenv("GOOGLE_LOGO_BUCKET", raising=False)
+    google_logo._memory_cache["data"] = None
+    google_logo._memory_cache["fetched_at"] = None
+    yield
+    google_logo._memory_cache["data"] = None
+    google_logo._memory_cache["fetched_at"] = None
+
+
+async def test_get_logo_fetches_then_serves_from_cache(monkeypatch):
+    calls = {"n": 0}
+
+    async def fake_fetch():
+        calls["n"] += 1
+        return b"LOGO"
+
+    monkeypatch.setattr(google_logo, "_fetch_remote", fake_fetch)
+    assert await google_logo.get_logo() == b"LOGO"
+    assert await google_logo.get_logo() == b"LOGO"
+    assert calls["n"] == 1
+
+
+async def test_get_logo_returns_none_when_unavailable_and_uncached(monkeypatch):
+    async def fake_fetch():
+        return None
+
+    monkeypatch.setattr(google_logo, "_fetch_remote", fake_fetch)
+    assert await google_logo.get_logo() is None
+
+
+async def test_get_logo_serves_stale_cache_when_fetch_fails(monkeypatch):
+    google_logo._memory_cache["data"] = b"STALE"
+    google_logo._memory_cache["fetched_at"] = google_logo._now() - timedelta(days=3)
+
+    async def fake_fetch():
+        return None
+
+    monkeypatch.setattr(google_logo, "_fetch_remote", fake_fetch)
+    assert await google_logo.get_logo() == b"STALE"
+
+
+async def test_get_logo_refreshes_when_cache_expired(monkeypatch):
+    google_logo._memory_cache["data"] = b"OLD"
+    google_logo._memory_cache["fetched_at"] = google_logo._now() - timedelta(days=2)
+
+    async def fake_fetch():
+        return b"NEW"
+
+    monkeypatch.setattr(google_logo, "_fetch_remote", fake_fetch)
+    assert await google_logo.get_logo() == b"NEW"


### PR DESCRIPTION
## Summary
First round of login/registration modal fixes plus a move to email-as-identity.

- Drop the username field. Email is the account identity, stored as `users.username` (migration 0010 widens it to VARCHAR(100) and backfills existing rows). Local and Google accounts both store username = email.
- Display name is an optional human label; defaults to the email local part when blank. Removed the public `@username` handle and the `displayName || username` fallbacks that would have shown the email.
- Uniform modal field layout (single field primitive, full-width inputs, aligned labels).
- Password confirmation field with match validation.
- Show/hide (eye) toggle on all password fields.
- Google button logo fetched from Google's official asset, cached server-side in a GCS bucket (survives Cloud Run spin-down), refreshed at most once per day, served at `GET /api/auth/google-logo`, with an inline multi-color SVG fallback.
- Relaxed the jsdoc/pydocstyle doc-lint rules to match the no-comment code style.

## Deploy note
The logo cache needs a GCS bucket: set `GOOGLE_LOGO_BUCKET` (optional `GOOGLE_LOGO_OBJECT`, `GOOGLE_LOGO_URL`) and grant the Cloud Run service account object read/write on it. Without it the endpoint falls back to a per-instance in-memory cache, and the frontend falls back to the inline SVG if nothing is cached.

## Test plan
- Frontend: 89 Vitest tests (modal layout/confirm/peek/no-username/logo fallback, ProfilePage no email leak, auth api/hook).
- Backend unit: google_logo cache logic, auth_service.
- API (real Postgres): register without username, email > 50 chars, display-name default, duplicate email 409, Google user username == email, logo route 200/404.
- lint, prettier, pydocstyle clean.