### PR TITLE
fix(auth): give the google sign-in button a white background

### DIFF
--- a/src/frontend/src/components/AuthModal.test.tsx
+++ b/src/frontend/src/components/AuthModal.test.tsx
@@ -126,4 +126,11 @@ describe('AuthModal', () => {
             expect(document.querySelector('svg path[fill="#EA4335"]')).not.toBeNull();
         });
     });
+
+    it('renders the google button with a white background to match the logo asset', () => {
+        renderWithProviders(<AuthModal open initialTab='login' onClose={() => {}} />);
+        const button = (document.querySelector('img') as HTMLImageElement).closest('a');
+        expect(button).not.toBeNull();
+        expect(button?.className).toContain('bg-white');
+    });
 });

--- a/src/frontend/src/components/AuthModal.tsx
+++ b/src/frontend/src/components/AuthModal.tsx
@@ -145,7 +145,9 @@ function GoogleLogoFallback() {
 function GoogleButton() {
     const [failed, setFailed] = useState(false);
     return (
-        <a href='/api/auth/google' className='btn btn-outline w-full gap-2'>
+        <a
+            href='/api/auth/google'
+            className='btn w-full gap-2 border-[#dadce0] bg-white text-[#1f1f1f] hover:border-[#dadce0] hover:bg-[#f8f9fa] hover:text-[#1f1f1f]'>
             {failed ? (
                 <GoogleLogoFallback />
             ) : (


### PR DESCRIPTION
## Summary
The Google `g-logo.png` asset we serve is opaque RGB with a solid white background (verified: corners 255,255,255, no alpha), so the colored G sat on a white square that clashed with the dark-mode outline button.

No transparent variant exists at that source, so per the agreed fallback the Google button now uses the standard white "light" style (white background, dark text). The white logo background blends in, and the inline multi-color SVG fallback also renders correctly on white.

## Test plan
- Vitest: AuthModal suite (10 tests), including a new assertion that the Google button carries a white background.
- ESLint + Prettier clean.