### PR TITLE
fix(chess): move list, resume history, eval bar, and board interactions

### DIFF
--- a/src/backend/app.py
+++ b/src/backend/app.py
@@ -1,5 +1,6 @@
 """Main entry point for the game-ai backend application."""
 import logging
+import mimetypes
 import os
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -78,10 +79,13 @@ app.add_middleware(
 )
 
 # Serve Vite build assets (only present after `npm run build`)
+mimetypes.add_type("application/wasm", ".wasm")
 if (DIST_DIR / "assets").exists():
     app.mount("/assets", StaticFiles(directory=str(DIST_DIR / "assets")), name="assets")
 if (DIST_DIR / "images").exists():
     app.mount("/images", StaticFiles(directory=str(DIST_DIR / "images")), name="images")
+if (DIST_DIR / "engine").exists():
+    app.mount("/engine", StaticFiles(directory=str(DIST_DIR / "engine")), name="engine")
 
 app.include_router(about_router, prefix="/api/about", tags=["About"])
 app.include_router(auth_router, prefix="/api/auth", tags=["Authentication"])

--- a/src/backend/games.py
+++ b/src/backend/games.py
@@ -1173,7 +1173,8 @@ async def chess_resume(
         return {"id": None, "state": None}
 
     span.set_attribute("game.id", str(game.id))
-    return {"id": str(game.id), "state": game.board_state}
+    state = {**game.board_state, "move_history": game.move_list or []}
+    return {"id": str(game.id), "state": state}
 
 
 @router.post("/game/chess/newgame")

--- a/src/frontend/src/api/chess.ts
+++ b/src/frontend/src/api/chess.ts
@@ -27,6 +27,7 @@ export interface ChessGameState {
         notation: string;
     } | null;
     in_check: boolean;
+    move_history?: string[];
 }
 
 export interface ChessMoveData extends Partial<ChessGameState> {

--- a/src/frontend/src/components/games/ChessBoard.test.tsx
+++ b/src/frontend/src/components/games/ChessBoard.test.tsx
@@ -51,6 +51,33 @@ describe('ChessBoard', () => {
         expect(onSquareClick).toHaveBeenCalled();
     });
 
+    it('lets the player click an empty destination square to move, not just drag', async () => {
+        const user = userEvent.setup();
+        const onSquareClick = vi.fn();
+        const { container } = render(
+            <ChessBoard
+                {...defaultProps}
+                selectedSquare={[6, 4]}
+                legalDestinations={[[4, 4]]}
+                onSquareClick={onSquareClick}
+            />
+        );
+        const squares = container.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        await user.click(squares[36]);
+        expect(onSquareClick).toHaveBeenCalledWith(4, 4);
+    });
+
+    it('highlights king-from, king-to and rook-to squares for a castling last move', () => {
+        const { container } = render(
+            <ChessBoard {...defaultProps} lastMove={{ fromRow: 7, fromCol: 4, toRow: 7, toCol: 6, isCastling: true }} />
+        );
+        const squares = container.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        expect(squares[60].className).toContain('yellow');
+        expect(squares[62].className).toContain('yellow');
+        expect(squares[61].className).toContain('yellow');
+        expect(squares[63].className).not.toContain('yellow');
+    });
+
     it('renders board structure', () => {
         const { container } = render(<ChessBoard {...defaultProps} />);
         expect(container.querySelector('[class*="border-amber"]')).toBeInTheDocument();

--- a/src/frontend/src/components/games/ChessBoard.tsx
+++ b/src/frontend/src/components/games/ChessBoard.tsx
@@ -5,7 +5,7 @@ interface ChessBoardProps {
     playerColor: 'white' | 'black';
     selectedSquare: [number, number] | null;
     legalDestinations: [number, number][];
-    lastMove: { fromRow: number; fromCol: number; toRow: number; toCol: number } | null;
+    lastMove: { fromRow: number; fromCol: number; toRow: number; toCol: number; isCastling?: boolean } | null;
     inCheck: boolean;
     locked: boolean;
     onSquareClick: (row: number, col: number) => void;
@@ -90,7 +90,7 @@ export default function ChessBoard({
             if (!drag) return;
             const dx = e.clientX - drag.startX;
             const dy = e.clientY - drag.startY;
-            if (!drag.active && Math.sqrt(dx * dx + dy * dy) > 8) {
+            if (!drag.active && drag.piece && Math.sqrt(dx * dx + dy * dy) > 8) {
                 drag.active = true;
                 onSquareClickRef.current(drag.fromRow, drag.fromCol);
             }
@@ -127,9 +127,16 @@ export default function ChessBoard({
 
     const isLegalDest = (r: number, c: number) => legalDestinations.some(([lr, lc]) => lr === r && lc === c);
 
-    const isLastMove = (r: number, c: number) =>
-        lastMove !== null &&
-        ((lastMove.fromRow === r && lastMove.fromCol === c) || (lastMove.toRow === r && lastMove.toCol === c));
+    const isLastMove = (r: number, c: number) => {
+        if (lastMove === null) return false;
+        if (lastMove.fromRow === r && lastMove.fromCol === c) return true;
+        if (lastMove.toRow === r && lastMove.toCol === c) return true;
+        if (lastMove.isCastling && lastMove.fromRow === r) {
+            const rookCol = lastMove.toCol > lastMove.fromCol ? lastMove.toCol - 1 : lastMove.toCol + 1;
+            if (rookCol === c) return true;
+        }
+        return false;
+    };
 
     const isKingInCheck = (r: number, c: number) => {
         if (!inCheck || !kingInCheckColor || !kingPositions) return false;
@@ -150,8 +157,6 @@ export default function ChessBoard({
 
     const handleMouseDown = (r: number, c: number, e: React.MouseEvent) => {
         if (lockedRef.current) return;
-        const piece = board[r][c];
-        if (!piece) return;
         e.preventDefault();
         dragRef.current = {
             fromRow: r,
@@ -159,7 +164,7 @@ export default function ChessBoard({
             startX: e.clientX,
             startY: e.clientY,
             active: false,
-            piece,
+            piece: board[r][c] ?? '',
         };
     };
 

--- a/src/frontend/src/pages/games/ChessPage.tsx
+++ b/src/frontend/src/pages/games/ChessPage.tsx
@@ -92,9 +92,13 @@ export default function ChessPage() {
     });
     const [selectedSquare, setSelectedSquare] = useState<[number, number] | null>(null);
     const [legalDestinations, setLegalDestinations] = useState<[number, number][]>([]);
-    const [lastMove, setLastMove] = useState<{ fromRow: number; fromCol: number; toRow: number; toCol: number } | null>(
-        null
-    );
+    const [lastMove, setLastMove] = useState<{
+        fromRow: number;
+        fromCol: number;
+        toRow: number;
+        toCol: number;
+        isCastling?: boolean;
+    } | null>(null);
     const [statusText, setStatusText] = useState<string>('');
     const [boardLocked, setBoardLocked] = useState(false);
     const [winner, setWinner] = useState<string | null>(null);
@@ -136,8 +140,24 @@ export default function ChessPage() {
             const es = chessSubscribeSSE(sid, {
                 onStatus: msg => setStatusText(msg),
                 onPlayerMove: (data: ChessMoveData) => {
-                    if (data.fen) setCurrentFen(data.fen);
+                    applyStateFromData(data);
                     if (data.notation) setMoveHistory(h => [...h, data.notation!]);
+                    if (
+                        data.toRow !== null &&
+                        data.toRow !== undefined &&
+                        data.fromRow !== null &&
+                        data.fromRow !== undefined
+                    ) {
+                        setLastMove({
+                            fromRow: data.fromRow!,
+                            fromCol: data.fromCol!,
+                            toRow: data.toRow!,
+                            toCol: data.toCol!,
+                            isCastling: data.is_castling ?? false,
+                        });
+                    }
+                    setSelectedSquare(null);
+                    setLegalDestinations([]);
                 },
                 onMove: (data: ChessMoveData) => {
                     applyStateFromData(data);
@@ -153,6 +173,7 @@ export default function ChessPage() {
                             fromCol: data.fromCol!,
                             toRow: data.toRow!,
                             toCol: data.toCol!,
+                            isCastling: data.is_castling ?? false,
                         });
                     }
                     setSelectedSquare(null);
@@ -196,6 +217,7 @@ export default function ChessPage() {
                     setPlayerColor(state.player_color);
                     setInCheck(state.in_check ?? false);
                     setCapturedPieces(state.captured_pieces);
+                    setMoveHistory(state.move_history ?? []);
                     if (state.king_positions) setKingPositions(state.king_positions);
                     if (state.last_move) {
                         setLastMove({
@@ -203,6 +225,7 @@ export default function ChessPage() {
                             fromCol: state.last_move.fromCol,
                             toRow: state.last_move.toRow,
                             toCol: state.last_move.toCol,
+                            isCastling: state.last_move.is_castling,
                         });
                     }
                     setSessionId(id);
@@ -273,6 +296,7 @@ export default function ChessPage() {
         setPlayerColor(state.player_color);
         setInCheck(state.in_check ?? false);
         setCapturedPieces(state.captured_pieces);
+        setMoveHistory(state.move_history ?? []);
         if (state.king_positions) setKingPositions(state.king_positions);
         if (state.last_move) {
             setLastMove({
@@ -280,6 +304,7 @@ export default function ChessPage() {
                 fromCol: state.last_move.fromCol,
                 toRow: state.last_move.toRow,
                 toCol: state.last_move.toCol,
+                isCastling: state.last_move.is_castling,
             });
         }
         const isPlayerTurn = state.current_player === state.player_color;
@@ -324,6 +349,7 @@ export default function ChessPage() {
                     fromCol: state.last_move.fromCol,
                     toRow: state.last_move.toRow,
                     toCol: state.last_move.toCol,
+                    isCastling: state.last_move.is_castling,
                 });
                 if (state.last_move.notation) {
                     setMoveHistory([state.last_move.notation]);
@@ -356,7 +382,7 @@ export default function ChessPage() {
         setSelectedSquare(null);
         setLegalDestinations([]);
         setBoardLocked(true);
-        setStatusText('');
+        setStatusText('Sending move...');
 
         const newBoard = board.map(r => [...r]);
         newBoard[fromRow][fromCol] = null;
@@ -379,7 +405,13 @@ export default function ChessPage() {
         }
 
         setBoard(newBoard);
-        setLastMove({ fromRow, fromCol, toRow, toCol });
+        setLastMove({
+            fromRow,
+            fromCol,
+            toRow,
+            toCol,
+            isCastling: movingPiece?.toLowerCase() === 'k' && Math.abs(toCol - fromCol) === 2,
+        });
 
         try {
             await chessMove(fromRow, fromCol, toRow, toCol, promotionPiece ?? undefined);
@@ -492,8 +524,6 @@ export default function ChessPage() {
     };
 
     const showInfo = phase === 'resumeprompt' || phase === 'playing' || phase === 'terminal';
-    const aiColor = playerColor === 'white' ? 'Black' : 'White';
-    const playerColorLabel = playerColor === 'white' ? 'White' : 'Black';
 
     const playerResult: 'win' | 'loss' | 'draw' | null =
         phase === 'terminal' && winner !== null
@@ -553,14 +583,12 @@ export default function ChessPage() {
     return (
         <div className='container mx-auto px-4 py-4 max-w-4xl'>
             <PageMeta title='Chess' description='Challenge an adaptive AI in a game of Chess.' noindex />
-            <h1 className='mb-3 text-3xl font-bold text-center'>Chess</h1>
 
             <div className='flex gap-4 items-stretch'>
                 <div className='flex flex-col'>
                     <PlayerCard
                         name='AI Opponent'
                         isAi
-                        symbol={showInfo ? aiColor : undefined}
                         statusText={phase === 'playing' ? statusText : undefined}
                         result={aiResult}
                     />
@@ -663,12 +691,7 @@ export default function ChessPage() {
                         </div>
                     )}
 
-                    <PlayerCard
-                        name={user.displayName}
-                        avatarUrl={user.profilePicture}
-                        symbol={showInfo ? playerColorLabel : undefined}
-                        result={playerResult}
-                    />
+                    <PlayerCard name={user.displayName} avatarUrl={user.profilePicture} result={playerResult} />
                 </div>
 
                 {showInfo && (

--- a/tests/api_tests/test_chess.py
+++ b/tests/api_tests/test_chess.py
@@ -53,6 +53,15 @@ def test_chess_invalid_move_returns_422(auth_client):
     assert response.status_code == 422
 
 
+def test_chess_resume_includes_move_history(auth_client):
+    auth_client.post("/api/game/chess/newgame", json={"player_starts": False})
+    response = auth_client.get("/api/game/chess/resume")
+    assert response.status_code == 200
+    state = response.json()["state"]
+    assert isinstance(state.get("move_history"), list)
+    assert len(state["move_history"]) >= 1
+
+
 def test_completed_game_move_list_queryable(auth_client):
     """Verify a chess game record includes a queryable move_list field."""
     auth_client.post("/api/game/chess/newgame", json={"player_starts": True})


### PR DESCRIPTION
Addresses a batch of chess page bugs.

- **Eval bar stuck at 0.0**: the backend mounted `/assets` and `/images` but not `/engine`, so `/engine/stockfish-nnue-16-single.js` fell through to the SPA catch-all and returned `index.html`. The client Stockfish worker loaded HTML as JS and failed silently, leaving the bar centered at 0.0. Now serves `/engine` (with `application/wasm` for the `.wasm`). Verified: `/engine/*.js` returns `application/javascript`, `.wasm` returns `application/wasm`, SPA routes still return HTML.
- **Resume loses move history**: `/game/chess/resume` now returns the full `move_history`; the UI restores the move list on resume and on loading a finished game.
- **Resume last-move highlight**: the last move is highlighted on resume, including castling.
- **Castling highlight**: a castling last move now highlights the king's origin plus both the king's and rook's landing squares (previously only the king squares).
- **Eager move feedback**: the `player_move` SSE event now reconciles authoritative state, so check/capture from the player's move shows immediately, before the bot replies.
- **Pending status**: a "Sending move..." indicator shows on the opponent card between the player's move and the bot's "Thinking...".
- **Click-to-move**: clicking a piece then clicking a valid empty square now moves it; drag still works.
- **UI cleanup**: removed the redundant in-game "Chess" heading and the White/Black name labels.

Tests: ChessBoard unit tests for click-to-move and castling highlight; backend API test for resume move history. Full vitest (93) green; chess API tests (7) green against the test DB; ESLint/Prettier/pydocstyle clean.