### PR TITLE
fix(chess): evaluate the player's move client-side immediately

### DIFF
--- a/src/frontend/src/hooks/useStockfishEval.test.ts
+++ b/src/frontend/src/hooks/useStockfishEval.test.ts
@@ -27,7 +27,7 @@ describe('useStockfishEval', () => {
             initialProps: { f: START as string | null },
         });
         expect(fake.posted).toContain(`position fen ${START}`);
-        expect(fake.posted).toContain('go movetime 500');
+        expect(fake.posted).toContain('go depth 15');
         act(() => fake.emit('info depth 12 score cp 30 pv e2e4'));
         expect(result.current.cp).toBe(30);
         expect(result.current.depth).toBe(12);

--- a/src/frontend/src/hooks/useStockfishEval.ts
+++ b/src/frontend/src/hooks/useStockfishEval.ts
@@ -8,7 +8,7 @@ export interface EvalState extends WhiteScore {
     ready: boolean;
 }
 
-const MOVETIME_MS = 500;
+const MAX_DEPTH = 15;
 
 export const useStockfishEval = (
     fen: string | null,
@@ -45,7 +45,7 @@ export const useStockfishEval = (
         setState(s => ({ ...s, cp: null, mate: null, depth: 0 }));
         engine.post('stop');
         engine.post(`position fen ${fen}`);
-        engine.post(`go movetime ${MOVETIME_MS}`);
+        engine.post(`go depth ${MAX_DEPTH}`);
     }, [fen]);
 
     return state;

--- a/src/frontend/src/lib/chessFen.test.ts
+++ b/src/frontend/src/lib/chessFen.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { boardToFen, type CastlingRights } from './chessFen';
+
+const FULL: CastlingRights = {
+    white: { kingside: true, queenside: true },
+    black: { kingside: true, queenside: true },
+};
+
+function startBoard(): (string | null)[][] {
+    const board: (string | null)[][] = Array.from({ length: 8 }, () => Array(8).fill(null));
+    board[0] = ['r', 'n', 'b', 'q', 'k', 'b', 'n', 'r'];
+    board[1] = Array(8).fill('p');
+    board[6] = Array(8).fill('P');
+    board[7] = ['R', 'N', 'B', 'Q', 'K', 'B', 'N', 'R'];
+    return board;
+}
+
+describe('boardToFen', () => {
+    it('serializes the starting position', () => {
+        expect(boardToFen(startBoard(), 'w', FULL, null)).toBe(
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1'
+        );
+    });
+
+    it('serializes side to move and the en passant square after a double pawn push', () => {
+        const board = startBoard();
+        board[6][4] = null;
+        board[4][4] = 'P';
+        expect(boardToFen(board, 'b', FULL, [5, 4])).toBe(
+            'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1'
+        );
+    });
+
+    it('serializes partial castling rights and a dash when none remain', () => {
+        const board = startBoard();
+        expect(
+            boardToFen(
+                board,
+                'w',
+                { white: { kingside: true, queenside: false }, black: { kingside: false, queenside: true } },
+                null
+            )
+        ).toContain(' w Kq - ');
+        expect(
+            boardToFen(
+                board,
+                'b',
+                { white: { kingside: false, queenside: false }, black: { kingside: false, queenside: false } },
+                null
+            )
+        ).toContain(' b - - ');
+    });
+});

--- a/src/frontend/src/lib/chessFen.ts
+++ b/src/frontend/src/lib/chessFen.ts
@@ -1,0 +1,39 @@
+const FILES = 'abcdefgh';
+
+export interface CastlingRights {
+    white: { kingside: boolean; queenside: boolean };
+    black: { kingside: boolean; queenside: boolean };
+}
+
+export const boardToFen = (
+    board: (string | null)[][],
+    side: 'w' | 'b',
+    castling: CastlingRights,
+    enPassant: [number, number] | null
+): string => {
+    const ranks = board.map(row => {
+        let str = '';
+        let empty = 0;
+        for (const cell of row) {
+            if (cell === null) {
+                empty += 1;
+            } else {
+                if (empty) {
+                    str += String(empty);
+                    empty = 0;
+                }
+                str += cell;
+            }
+        }
+        if (empty) str += String(empty);
+        return str;
+    });
+    let rights = '';
+    if (castling.white.kingside) rights += 'K';
+    if (castling.white.queenside) rights += 'Q';
+    if (castling.black.kingside) rights += 'k';
+    if (castling.black.queenside) rights += 'q';
+    if (!rights) rights = '-';
+    const ep = enPassant ? `${FILES[enPassant[1]]}${8 - enPassant[0]}` : '-';
+    return `${ranks.join('/')} ${side} ${rights} ${ep} 0 1`;
+};

--- a/src/frontend/src/pages/games/ChessPage.tsx
+++ b/src/frontend/src/pages/games/ChessPage.tsx
@@ -8,6 +8,7 @@ import ChessBoard from '../../components/games/ChessBoard';
 import EvalBar from '../../components/games/EvalBar';
 import { useAuth } from '../../hooks/useAuth';
 import { useStockfishEval } from '../../hooks/useStockfishEval';
+import { boardToFen } from '../../lib/chessFen';
 import {
     chessLegalMoves,
     chessMove,
@@ -90,6 +91,10 @@ export default function ChessPage() {
         white: [7, 4],
         black: [0, 4],
     });
+    const [castlingRights, setCastlingRights] = useState<ChessGameState['castling_rights']>({
+        white: { kingside: true, queenside: true },
+        black: { kingside: true, queenside: true },
+    });
     const [selectedSquare, setSelectedSquare] = useState<[number, number] | null>(null);
     const [legalDestinations, setLegalDestinations] = useState<[number, number][]>([]);
     const [lastMove, setLastMove] = useState<{
@@ -131,6 +136,7 @@ export default function ChessPage() {
         if ('in_check' in data && data.in_check !== undefined) setInCheck(data.in_check ?? false);
         if ('captured_pieces' in data && data.captured_pieces) setCapturedPieces(data.captured_pieces);
         if ('king_positions' in data && data.king_positions) setKingPositions(data.king_positions);
+        if ('castling_rights' in data && data.castling_rights) setCastlingRights(data.castling_rights);
         if ('fen' in data && data.fen) setCurrentFen(data.fen);
     }, []);
 
@@ -218,6 +224,7 @@ export default function ChessPage() {
                     setInCheck(state.in_check ?? false);
                     setCapturedPieces(state.captured_pieces);
                     setMoveHistory(state.move_history ?? []);
+                    if (state.castling_rights) setCastlingRights(state.castling_rights);
                     if (state.king_positions) setKingPositions(state.king_positions);
                     if (state.last_move) {
                         setLastMove({
@@ -297,6 +304,7 @@ export default function ChessPage() {
         setInCheck(state.in_check ?? false);
         setCapturedPieces(state.captured_pieces);
         setMoveHistory(state.move_history ?? []);
+        if (state.castling_rights) setCastlingRights(state.castling_rights);
         if (state.king_positions) setKingPositions(state.king_positions);
         if (state.last_move) {
             setLastMove({
@@ -342,6 +350,7 @@ export default function ChessPage() {
             setPlayerColor(state.player_color);
             setInCheck(state.in_check ?? false);
             setCapturedPieces(state.captured_pieces);
+            if (state.castling_rights) setCastlingRights(state.castling_rights);
             if (state.king_positions) setKingPositions(state.king_positions);
             if (state.last_move) {
                 setLastMove({
@@ -379,6 +388,7 @@ export default function ChessPage() {
     ) => {
         const movingPiece = board[fromRow][fromCol];
         const prevBoard = board.map(r => [...r]);
+        const prevFen = currentFen;
         setSelectedSquare(null);
         setLegalDestinations([]);
         setBoardLocked(true);
@@ -413,6 +423,24 @@ export default function ChessPage() {
             isCastling: movingPiece?.toLowerCase() === 'k' && Math.abs(toCol - fromCol) === 2,
         });
 
+        const moverLower = movingPiece?.toLowerCase();
+        const nextCastling = {
+            white: { ...castlingRights.white },
+            black: { ...castlingRights.black },
+        };
+        if (moverLower === 'k') {
+            nextCastling[playerColor].kingside = false;
+            nextCastling[playerColor].queenside = false;
+        } else if (moverLower === 'r') {
+            if (fromCol === 0) nextCastling[playerColor].queenside = false;
+            if (fromCol === 7) nextCastling[playerColor].kingside = false;
+        }
+        const nextEnPassant: [number, number] | null =
+            moverLower === 'p' && Math.abs(toRow - fromRow) === 2
+                ? [playerColor === 'white' ? fromRow - 1 : fromRow + 1, fromCol]
+                : null;
+        setCurrentFen(boardToFen(newBoard, playerColor === 'white' ? 'b' : 'w', nextCastling, nextEnPassant));
+
         try {
             await chessMove(fromRow, fromCol, toRow, toCol, promotionPiece ?? undefined);
         } catch (err) {
@@ -421,6 +449,7 @@ export default function ChessPage() {
                 setShowAuthModal(true);
             } else {
                 setBoard(prevBoard);
+                setCurrentFen(prevFen);
                 setLastMove(null);
                 setStatusText('Move rejected — please try again.');
                 setBoardLocked(false);


### PR DESCRIPTION
Follow-up to #249.

The eval bar is client-side Stockfish, but it was driven by `currentFen`, which only updated from SSE events. So the player's move did not re-evaluate until the server echoed the position back (arriving with the bot's reply), giving the impression the eval was computed server-side.

- `submitMove` now computes the post-move FEN on the client and sets it immediately, so Stockfish re-evaluates the instant a move is made, with no server dependency.
- The client FEN builder (`lib/chessFen.ts`) mirrors the backend `_to_fen` byte-for-byte (verified against the engine for the start and post-e4 positions), so the optimistic FEN equals the server's; the SSE echo causes no redundant restart.
- Castling rights are tracked from server payloads to build an accurate FEN; the en passant square is derived from the move itself.
- The client search is capped at `depth 15`.

Tests: `lib/chessFen.test.ts` (start position, en passant square, castling-rights serialization); `useStockfishEval` asserts `go depth 15`. Full vitest (96) green; ESLint/Prettier clean.