### PR TITLE
fix(chess): make the eval bar's white side white

### DIFF
--- a/src/frontend/src/components/games/EvalBar.tsx
+++ b/src/frontend/src/components/games/EvalBar.tsx
@@ -17,10 +17,10 @@ const EvalBar = ({ cp, mate, perspective }: EvalBarProps) => {
             style={{ display: 'flex', flexDirection: perspective === 'white' ? 'column-reverse' : 'column' }}>
             <div
                 data-testid='eval-bar-white'
-                className='w-full bg-base-100 transition-[height] duration-300'
+                className='w-full bg-white transition-[height] duration-300'
                 style={{ height: `${whitePct}%` }}
             />
-            <span className='pointer-events-none absolute inset-x-0 bottom-0.5 text-center text-[9px] font-semibold text-neutral-content'>
+            <span className='pointer-events-none absolute inset-x-0 bottom-0.5 text-center text-[9px] font-semibold text-white mix-blend-difference'>
                 {label}
             </span>
         </div>


### PR DESCRIPTION
The eval bar's white portion used `bg-base-100` (the site background), so in dark mode it matched the page instead of reading as "white".

- White fill now uses `bg-white`.
- The eval label switches to `mix-blend-difference` so it stays legible over both the white half and the dark half (otherwise the light label would disappear on the now-white fill, which is the default white-perspective case).

EvalBar unit tests green; ESLint/Prettier clean.