### PR TITLE
feat(games): board-centric full-viewport layout for the 5 games

### DIFF
--- a/src/frontend/src/components/Layout.tsx
+++ b/src/frontend/src/components/Layout.tsx
@@ -1,12 +1,33 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import Footer from './Footer';
 import Navbar from './Navbar';
 
-/**
- * Root layout component wrapping all pages with Navbar at the top and Footer at the bottom.
- * Child routes are rendered via the React Router Outlet.
- */
+const ACTIVE_GAME_ROUTES = [
+    '/game/tic-tac-toe',
+    '/game/chess',
+    '/game/checkers',
+    '/game/connect4',
+    '/game/dots-and-boxes',
+];
+
+export function isActiveGameRoute(pathname: string): boolean {
+    return ACTIVE_GAME_ROUTES.includes(pathname);
+}
+
 export default function Layout() {
+    const { pathname } = useLocation();
+
+    if (isActiveGameRoute(pathname)) {
+        return (
+            <div className='flex h-[100dvh] flex-col overflow-hidden'>
+                <Navbar />
+                <main className='min-h-0 flex-1'>
+                    <Outlet />
+                </main>
+            </div>
+        );
+    }
+
     return (
         <div className='flex min-h-screen flex-col'>
             <Navbar />

--- a/src/frontend/src/components/games/CheckersBoard.tsx
+++ b/src/frontend/src/components/games/CheckersBoard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface CheckersBoardProps {
     board: string[];
@@ -25,6 +26,7 @@ interface DragState {
     active: boolean;
     isRed: boolean;
     isKing: boolean;
+    size: number;
 }
 
 function PieceDisplay({ code }: { code: string }) {
@@ -61,7 +63,13 @@ export default function CheckersBoard({
 }: CheckersBoardProps) {
     const rows = flipped ? [7, 6, 5, 4, 3, 2, 1, 0] : [0, 1, 2, 3, 4, 5, 6, 7];
 
-    const [dragGhost, setDragGhost] = useState<{ x: number; y: number; isRed: boolean; isKing: boolean } | null>(null);
+    const [dragGhost, setDragGhost] = useState<{
+        x: number;
+        y: number;
+        isRed: boolean;
+        isKing: boolean;
+        size: number;
+    } | null>(null);
     const dragRef = useRef<DragState | null>(null);
     const squareRefs = useRef<(HTMLDivElement | null)[]>(Array(64).fill(null));
     const onPieceDragStartRef = useRef(onPieceDragStart);
@@ -99,7 +107,7 @@ export default function CheckersBoard({
                 onPieceDragStartRef.current(drag.fromPos);
             }
             if (drag.active) {
-                setDragGhost({ x: e.clientX, y: e.clientY, isRed: drag.isRed, isKing: drag.isKing });
+                setDragGhost({ x: e.clientX, y: e.clientY, isRed: drag.isRed, isKing: drag.isKing, size: drag.size });
             }
         };
 
@@ -138,13 +146,14 @@ export default function CheckersBoard({
             active: false,
             isRed: piece === 'R' || piece === 'r',
             isKing: piece === 'r' || piece === 'b',
+            size: (squareRefs.current[pos]?.getBoundingClientRect().width ?? 48) * 0.75,
         };
     };
 
     return (
         <div
-            className='inline-grid border-2 border-neutral-700'
-            style={{ gridTemplateColumns: 'repeat(8, 1fr)', width: '100%', maxWidth: '480px' }}
+            className='grid h-full w-full'
+            style={{ gridTemplateColumns: 'repeat(8, 1fr)', gridTemplateRows: 'repeat(8, 1fr)' }}
             aria-label='Checkers board'>
             {rows.map(row =>
                 [0, 1, 2, 3, 4, 5, 6, 7].map(col => {
@@ -213,36 +222,39 @@ export default function CheckersBoard({
                 })
             )}
 
-            {!hidePieces && dragGhost && (
-                <div
-                    style={{
-                        position: 'fixed',
-                        left: dragGhost.x - 20,
-                        top: dragGhost.y - 20,
-                        width: 40,
-                        height: 40,
-                        pointerEvents: 'none',
-                        zIndex: 9999,
-                        borderRadius: '50%',
-                        border: `2px solid ${dragGhost.isRed ? '#b91c1c' : '#44403c'}`,
-                        backgroundColor: dragGhost.isRed ? '#ef4444' : '#1c1917',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                    }}>
-                    {dragGhost.isKing && (
-                        <div
-                            style={{
-                                width: '50%',
-                                height: '50%',
-                                borderRadius: '50%',
-                                backgroundColor: 'rgba(255,255,255,0.4)',
-                                border: '1px solid rgba(255,255,255,0.6)',
-                            }}
-                        />
-                    )}
-                </div>
-            )}
+            {!hidePieces &&
+                dragGhost &&
+                createPortal(
+                    <div
+                        style={{
+                            position: 'fixed',
+                            left: dragGhost.x - dragGhost.size / 2,
+                            top: dragGhost.y - dragGhost.size / 2,
+                            width: dragGhost.size,
+                            height: dragGhost.size,
+                            pointerEvents: 'none',
+                            zIndex: 9999,
+                            borderRadius: '50%',
+                            border: `2px solid ${dragGhost.isRed ? '#b91c1c' : '#44403c'}`,
+                            backgroundColor: dragGhost.isRed ? '#ef4444' : '#1c1917',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                        }}>
+                        {dragGhost.isKing && (
+                            <div
+                                style={{
+                                    width: '50%',
+                                    height: '50%',
+                                    borderRadius: '50%',
+                                    backgroundColor: 'rgba(255,255,255,0.4)',
+                                    border: '1px solid rgba(255,255,255,0.6)',
+                                }}
+                            />
+                        )}
+                    </div>,
+                    document.body
+                )}
         </div>
     );
 }

--- a/src/frontend/src/components/games/ChessBoard.test.tsx
+++ b/src/frontend/src/components/games/ChessBoard.test.tsx
@@ -29,7 +29,7 @@ describe('ChessBoard', () => {
         const user = userEvent.setup();
         const onSquareClick = vi.fn();
         const { container } = render(<ChessBoard {...defaultProps} onSquareClick={onSquareClick} />);
-        const squares = container.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        const squares = container.querySelectorAll('[data-square]');
         expect(squares.length).toBeGreaterThanOrEqual(64);
         await user.click(squares[0]);
         expect(onSquareClick).toHaveBeenCalled();
@@ -46,7 +46,7 @@ describe('ChessBoard', () => {
                 onSquareClick={onSquareClick}
             />
         );
-        const squares = container.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        const squares = container.querySelectorAll('[data-square]');
         await user.click(squares[0]);
         expect(onSquareClick).toHaveBeenCalled();
     });
@@ -62,7 +62,7 @@ describe('ChessBoard', () => {
                 onSquareClick={onSquareClick}
             />
         );
-        const squares = container.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        const squares = container.querySelectorAll('[data-square]');
         await user.click(squares[36]);
         expect(onSquareClick).toHaveBeenCalledWith(4, 4);
     });
@@ -71,7 +71,7 @@ describe('ChessBoard', () => {
         const { container } = render(
             <ChessBoard {...defaultProps} lastMove={{ fromRow: 7, fromCol: 4, toRow: 7, toCol: 6, isCastling: true }} />
         );
-        const squares = container.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        const squares = container.querySelectorAll('[data-square]');
         expect(squares[60].className).toContain('yellow');
         expect(squares[62].className).toContain('yellow');
         expect(squares[61].className).toContain('yellow');
@@ -80,7 +80,7 @@ describe('ChessBoard', () => {
 
     it('renders board structure', () => {
         const { container } = render(<ChessBoard {...defaultProps} />);
-        expect(container.querySelector('[class*="border-amber"]')).toBeInTheDocument();
+        expect(container.querySelectorAll('[data-square]').length).toBe(64);
     });
 
     it('renders piece images not letters', () => {
@@ -94,8 +94,8 @@ describe('ChessBoard', () => {
     it('flips board for black player', () => {
         const { container: whiteContainer } = render(<ChessBoard {...defaultProps} playerColor='white' />);
         const { container: blackContainer } = render(<ChessBoard {...defaultProps} playerColor='black' />);
-        const whiteSquares = whiteContainer.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
-        const blackSquares = blackContainer.querySelectorAll('[class*="select-none"][class*="w-10"][class*="h-10"]');
+        const whiteSquares = whiteContainer.querySelectorAll('[data-square]');
+        const blackSquares = blackContainer.querySelectorAll('[data-square]');
         expect(whiteSquares.length).toBeGreaterThanOrEqual(64);
         expect(blackSquares.length).toBeGreaterThanOrEqual(64);
         const whiteFirstImg = whiteContainer.querySelector('img');

--- a/src/frontend/src/components/games/ChessBoard.tsx
+++ b/src/frontend/src/components/games/ChessBoard.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 interface ChessBoardProps {
     board: (string | null)[][];
@@ -37,11 +38,9 @@ interface DragState {
     startY: number;
     active: boolean;
     piece: string;
+    size: number;
 }
 
-/**
- * Renders the interactive Chess board with piece selection, legal move highlights, and drag-and-drop.
- */
 export default function ChessBoard({
     board,
     playerColor,
@@ -59,7 +58,7 @@ export default function ChessBoard({
     const rows = playerColor === 'black' ? [7, 6, 5, 4, 3, 2, 1, 0] : [0, 1, 2, 3, 4, 5, 6, 7];
     const cols = playerColor === 'black' ? [7, 6, 5, 4, 3, 2, 1, 0] : [0, 1, 2, 3, 4, 5, 6, 7];
 
-    const [dragGhost, setDragGhost] = useState<{ x: number; y: number; piece: string } | null>(null);
+    const [dragGhost, setDragGhost] = useState<{ x: number; y: number; piece: string; size: number } | null>(null);
     const dragRef = useRef<DragState | null>(null);
     const squareRefs = useRef<(HTMLDivElement | null)[][]>(Array.from({ length: 8 }, () => Array(8).fill(null)));
     const onSquareClickRef = useRef(onSquareClick);
@@ -95,7 +94,7 @@ export default function ChessBoard({
                 onSquareClickRef.current(drag.fromRow, drag.fromCol);
             }
             if (drag.active) {
-                setDragGhost({ x: e.clientX, y: e.clientY, piece: drag.piece });
+                setDragGhost({ x: e.clientX, y: e.clientY, piece: drag.piece, size: drag.size });
             }
         };
 
@@ -165,6 +164,7 @@ export default function ChessBoard({
             startY: e.clientY,
             active: false,
             piece: board[r][c] ?? '',
+            size: squareRefs.current[r][c]?.getBoundingClientRect().width ?? 56,
         };
     };
 
@@ -172,80 +172,72 @@ export default function ChessBoard({
     const getFileLabel = (c: number) => String.fromCharCode(97 + c);
 
     return (
-        <div className='inline-flex'>
-            <div className='flex flex-col justify-around pr-1'>
-                {rows.map(r => (
-                    <div
-                        key={r}
-                        className='flex items-center justify-center w-4 h-10 sm:h-12 md:h-14 text-xs text-base-content/50 select-none'>
-                        {getRankLabel(r)}
-                    </div>
-                ))}
-            </div>
+        <div className='grid h-full w-full select-none grid-cols-8 grid-rows-8'>
+            {rows.map((r, displayRow) =>
+                cols.map((c, displayCol) => {
+                    const piece = board[r][c];
+                    const imgSrc = piece ? PIECE_IMAGES[piece] : null;
+                    const isDragging = isDraggingFrom(r, c);
+                    const isLight = (r + c) % 2 === 0;
+                    const labelColor = isLight ? 'text-amber-800' : 'text-amber-100';
 
-            <div className='flex flex-col'>
-                <div className='border-2 border-amber-900 rounded'>
-                    {rows.map(r => (
-                        <div key={r} className='flex'>
-                            {cols.map(c => {
-                                const piece = board[r][c];
-                                const imgSrc = piece ? PIECE_IMAGES[piece] : null;
-                                const isDragging = isDraggingFrom(r, c);
-
-                                return (
-                                    <div
-                                        key={c}
-                                        ref={el => {
-                                            squareRefs.current[r][c] = el;
-                                        }}
-                                        className={`relative flex items-center justify-center w-10 h-10 sm:w-12 sm:h-12 md:w-14 md:h-14 select-none ${getSquareBg(r, c)} ${!locked ? 'cursor-pointer hover:opacity-90' : ''}`}
-                                        onMouseDown={e => handleMouseDown(r, c, e)}>
-                                        {!hidePieces && isLegalDest(r, c) && (
-                                            <div
-                                                className={`absolute rounded-full z-10 ${piece ? 'inset-0 border-4 border-black/30' : 'w-3 h-3 bg-black/30'}`}
-                                            />
-                                        )}
-                                        {!hidePieces && imgSrc && (
-                                            <img
-                                                src={imgSrc}
-                                                alt={piece ?? ''}
-                                                className={`w-8 h-8 sm:w-10 sm:h-10 md:w-12 md:h-12 z-20 object-contain drop-shadow-md pointer-events-none${isDragging ? ' opacity-30' : ''}`}
-                                            />
-                                        )}
-                                    </div>
-                                );
-                            })}
-                        </div>
-                    ))}
-                </div>
-
-                <div className='flex pt-1'>
-                    {cols.map(c => (
+                    return (
                         <div
-                            key={c}
-                            className='flex items-center justify-center w-10 sm:w-12 md:w-14 h-4 text-xs text-base-content/50 select-none'>
-                            {getFileLabel(c)}
+                            key={`${r}-${c}`}
+                            data-square={`${r}-${c}`}
+                            ref={el => {
+                                squareRefs.current[r][c] = el;
+                            }}
+                            className={`relative flex items-center justify-center ${getSquareBg(r, c)} ${!locked ? 'cursor-pointer hover:opacity-90' : ''}`}
+                            onMouseDown={e => handleMouseDown(r, c, e)}>
+                            {displayCol === 0 && (
+                                <span
+                                    className={`pointer-events-none absolute left-0.5 top-0 text-[0.55rem] font-semibold ${labelColor}`}>
+                                    {getRankLabel(r)}
+                                </span>
+                            )}
+                            {displayRow === 7 && (
+                                <span
+                                    className={`pointer-events-none absolute bottom-0 right-0.5 text-[0.55rem] font-semibold ${labelColor}`}>
+                                    {getFileLabel(c)}
+                                </span>
+                            )}
+                            {!hidePieces && isLegalDest(r, c) && (
+                                <div
+                                    className={`absolute z-10 rounded-full ${piece ? 'inset-0 border-4 border-black/30' : 'h-1/4 w-1/4 bg-black/30'}`}
+                                />
+                            )}
+                            {!hidePieces && imgSrc && (
+                                <img
+                                    src={imgSrc}
+                                    alt={piece ?? ''}
+                                    className={`pointer-events-none z-20 h-[85%] w-[85%] object-contain drop-shadow-md${isDragging ? ' opacity-30' : ''}`}
+                                />
+                            )}
                         </div>
-                    ))}
-                </div>
-            </div>
-
-            {!hidePieces && dragGhost && (
-                <img
-                    src={PIECE_IMAGES[dragGhost.piece]}
-                    alt=''
-                    style={{
-                        position: 'fixed',
-                        left: dragGhost.x - 24,
-                        top: dragGhost.y - 24,
-                        width: 48,
-                        height: 48,
-                        pointerEvents: 'none',
-                        zIndex: 9999,
-                        objectFit: 'contain',
-                    }}
-                />
+                    );
+                })
             )}
+
+            {!hidePieces &&
+                dragGhost &&
+                createPortal(
+                    <img
+                        src={PIECE_IMAGES[dragGhost.piece]}
+                        alt=''
+                        style={{
+                            position: 'fixed',
+                            left: dragGhost.x - dragGhost.size / 2,
+                            top: dragGhost.y - dragGhost.size / 2,
+                            width: dragGhost.size,
+                            height: dragGhost.size,
+                            pointerEvents: 'none',
+                            zIndex: 9999,
+                            objectFit: 'contain',
+                        }}
+                    />,
+                    document.body
+                )}
         </div>
     );
 }

--- a/src/frontend/src/components/games/Connect4Board.tsx
+++ b/src/frontend/src/components/games/Connect4Board.tsx
@@ -82,10 +82,10 @@ export default function Connect4Board({
 
     return (
         <div
-            className='w-full max-w-sm mx-auto select-none'
+            className='flex h-full w-full flex-col select-none'
             aria-label='Connect 4 board'
             onMouseLeave={() => setHoveredCol(null)}>
-            <div className='grid grid-cols-7 mb-1'>
+            <div className='grid grid-cols-7 mb-1 shrink-0'>
                 {Array.from({ length: 7 }, (_, col) => {
                     const full = isColumnFull(col);
                     const clickable = isInteractive && !full;
@@ -112,8 +112,8 @@ export default function Connect4Board({
                 })}
             </div>
 
-            <div className='bg-blue-700 rounded-lg p-2'>
-                <div className='grid grid-cols-7 gap-1'>
+            <div className='min-h-0 flex-1 rounded-lg bg-blue-700 p-2'>
+                <div className='grid h-full w-full grid-cols-7 grid-rows-6 gap-1'>
                     {board.map((rowArr, rowIdx) =>
                         rowArr.map((cell, colIdx) => {
                             const winning = isWinningCell(rowIdx, colIdx);
@@ -133,7 +133,7 @@ export default function Connect4Board({
                             return (
                                 <div
                                     key={`${rowIdx}-${colIdx}`}
-                                    className='aspect-square rounded-full bg-blue-900 flex items-center justify-center p-0.5'
+                                    className='mx-auto flex aspect-square h-full max-w-full items-center justify-center rounded-full bg-blue-900 p-0.5'
                                     style={{ cursor: cellClickable ? 'pointer' : 'default' }}
                                     onMouseEnter={() => setHoveredCol(colIdx)}
                                     onClick={() => cellClickable && onColumnClick(colIdx)}>

--- a/src/frontend/src/components/games/DotsAndBoxesBoard.tsx
+++ b/src/frontend/src/components/games/DotsAndBoxesBoard.tsx
@@ -214,11 +214,7 @@ export default function DotsAndBoxesBoard({
     }
 
     return (
-        <svg
-            viewBox={`0 0 ${svgSize} ${svgSize}`}
-            width='100%'
-            style={{ display: 'block', maxWidth: svgSize }}
-            aria-label='Dots and Boxes board'>
+        <svg viewBox={`0 0 ${svgSize} ${svgSize}`} className='block h-full w-full' aria-label='Dots and Boxes board'>
             {!hidePieces && boxFills}
             {horizontalLineElements}
             {verticalLineElements}

--- a/src/frontend/src/components/games/GameLayout.tsx
+++ b/src/frontend/src/components/games/GameLayout.tsx
@@ -1,0 +1,52 @@
+import type { CSSProperties, ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+
+interface GameLayoutProps {
+    aspect?: number;
+    board: ReactNode;
+    opponent: ReactNode;
+    player: ReactNode;
+    controls: ReactNode;
+}
+
+function GameFooter() {
+    return (
+        <div className='flex flex-wrap items-center justify-center gap-x-3 gap-y-1 text-xs text-base-content/50'>
+            <span>&copy; {new Date().getFullYear()} AI Game Hub</span>
+            <Link to='/about' className='link link-hover'>
+                About
+            </Link>
+            <a
+                href='https://buymeacoffee.com/aigamehub'
+                target='_blank'
+                rel='noopener noreferrer'
+                className='link link-hover'>
+                Support
+            </a>
+        </div>
+    );
+}
+
+export default function GameLayout({ aspect = 1, board, opponent, player, controls }: GameLayoutProps) {
+    return (
+        <div
+            className='flex h-full min-h-0 flex-col gap-2 p-2 [container-type:size] lg:flex-row lg:items-stretch lg:justify-center lg:gap-3 lg:p-3'
+            style={{ '--board-aspect': String(aspect) } as CSSProperties}>
+            <div className='flex shrink-0 items-stretch gap-2 lg:w-44 lg:flex-col lg:justify-between'>
+                <div className='flex min-w-0 flex-1 justify-end lg:flex-none'>{opponent}</div>
+                <div className='flex min-w-0 flex-1 justify-end lg:flex-none'>{player}</div>
+            </div>
+
+            <div className='game-board-box relative shrink-0 self-center overflow-hidden rounded-lg border-2 border-base-content/20 shadow-lg'>
+                {board}
+            </div>
+
+            <aside className='flex shrink-0 flex-col gap-2 lg:w-72 lg:max-w-xs'>
+                <div className='flex min-h-0 flex-1 flex-col items-center justify-center gap-3 rounded-lg border border-base-content/10 bg-base-200/40 p-3'>
+                    {controls}
+                </div>
+                <GameFooter />
+            </aside>
+        </div>
+    );
+}

--- a/src/frontend/src/components/games/TicTacToeBoard.tsx
+++ b/src/frontend/src/components/games/TicTacToeBoard.tsx
@@ -19,7 +19,7 @@ export default function TicTacToeBoard({
     hidePieces = false,
 }: TicTacToeBoardProps) {
     return (
-        <div className='grid grid-cols-3 gap-2 w-full max-w-xs sm:max-w-sm mx-auto' aria-label='Tic-Tac-Toe board'>
+        <div className='grid grid-cols-3 grid-rows-3 gap-2 w-full h-full' aria-label='Tic-Tac-Toe board'>
             {board.map((cell, index) => {
                 const isWinning = winningPositions?.includes(index) ?? false;
                 const isLast = !isWinning && lastPosition === index && cell !== null;
@@ -33,8 +33,8 @@ export default function TicTacToeBoard({
                         disabled={!isClickable}
                         onClick={() => isClickable && onCellClick(index)}
                         className={[
-                            'aspect-square min-h-[64px] flex items-center justify-center',
-                            'text-4xl font-bold rounded-lg border-2 transition-colors',
+                            'flex items-center justify-center',
+                            'text-4xl sm:text-5xl md:text-6xl font-bold rounded-lg border-2 transition-colors',
                             isWinning
                                 ? 'border-primary bg-primary/20'
                                 : isLast

--- a/src/frontend/src/pages/games/CheckersPage.tsx
+++ b/src/frontend/src/pages/games/CheckersPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import AuthModal from '../../components/AuthModal';
 import GameStatsPanel from '../../components/games/GameStatsPanel';
 import GameStartOverlay from '../../components/games/GameStartOverlay';
+import GameLayout from '../../components/games/GameLayout';
 import NewGameButtons from '../../components/games/NewGameButtons';
 import PlayerCard from '../../components/PlayerCard';
 import CheckersBoard from '../../components/games/CheckersBoard';
@@ -446,12 +447,65 @@ export default function CheckersPage() {
     void sessionId;
 
     return (
-        <div className='container mx-auto px-4 py-6 max-w-4xl'>
+        <>
             <PageMeta title='Checkers' description='Play Checkers against an AI opponent.' noindex />
-            <h1 className='mb-4 text-4xl font-bold text-center'>Checkers</h1>
+            <GameLayout
+                aspect={1}
+                board={
+                    <div className='relative h-full w-full'>
+                        <CheckersBoard
+                            board={board}
+                            playerSymbol={playerSymbol}
+                            currentTurn={currentTurn}
+                            selectedPiece={selectedPiece}
+                            validDestinations={validDestinations}
+                            legalPieces={legalPieces}
+                            mustCapture={mustCapture}
+                            locked={
+                                boardLocked || phase === 'terminal' || phase === 'newgame' || phase === 'resumeprompt'
+                            }
+                            flipped={flipped}
+                            lastMove={lastMove}
+                            hidePieces={phase !== 'playing'}
+                            onPieceClick={handlePieceClick}
+                            onPieceDragStart={handlePieceDragStart}
+                            onSquareClick={handleSquareClick}
+                            onSquareDrop={handleSquareClick}
+                        />
 
-            <div className='flex gap-4 items-stretch'>
-                <div className='flex flex-col flex-1 min-w-0'>
+                        {phase === 'loading' && (
+                            <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
+                                <span className='loading loading-spinner loading-lg' />
+                            </div>
+                        )}
+
+                        {(phase === 'newgame' || phase === 'resumeprompt') && (
+                            <GameStartOverlay
+                                canResume={phase === 'resumeprompt'}
+                                onResume={handleResume}
+                                optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
+
+                        {phase === 'terminal' && !showGameOverOverlay && (
+                            <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
+                                <p className='text-2xl font-bold'>{playerResult === 'win' ? 'You Win!' : 'You Lose'}</p>
+                            </div>
+                        )}
+
+                        {phase === 'terminal' && showGameOverOverlay && (
+                            <GameStartOverlay
+                                title={playerResult === 'win' ? 'You Win!' : 'You Lose'}
+                                canResume={false}
+                                onResume={() => {}}
+                                optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
+                    </div>
+                }
+                opponent={
                     <PlayerCard
                         name='AI Opponent'
                         isAi
@@ -459,122 +513,58 @@ export default function CheckersPage() {
                         statusText={phase === 'playing' ? statusText : undefined}
                         result={aiResult}
                     />
-
-                    <div className='relative my-4 flex justify-center'>
-                        <div className='relative w-full max-w-sm'>
-                            <CheckersBoard
-                                board={board}
-                                playerSymbol={playerSymbol}
-                                currentTurn={currentTurn}
-                                selectedPiece={selectedPiece}
-                                validDestinations={validDestinations}
-                                legalPieces={legalPieces}
-                                mustCapture={mustCapture}
-                                locked={
-                                    boardLocked ||
-                                    phase === 'terminal' ||
-                                    phase === 'newgame' ||
-                                    phase === 'resumeprompt'
-                                }
-                                flipped={flipped}
-                                lastMove={lastMove}
-                                hidePieces={phase !== 'playing'}
-                                onPieceClick={handlePieceClick}
-                                onPieceDragStart={handlePieceDragStart}
-                                onSquareClick={handleSquareClick}
-                                onSquareDrop={handleSquareClick}
-                            />
-
-                            {phase === 'loading' && (
-                                <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
-                                    <span className='loading loading-spinner loading-lg' />
-                                </div>
-                            )}
-
-                            {(phase === 'newgame' || phase === 'resumeprompt') && (
-                                <GameStartOverlay
-                                    canResume={phase === 'resumeprompt'}
-                                    onResume={handleResume}
-                                    optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
-                                    optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
-                                />
-                            )}
-
-                            {phase === 'terminal' && !showGameOverOverlay && (
-                                <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
-                                    <p className='text-2xl font-bold'>
-                                        {playerResult === 'win' ? 'You Win!' : 'You Lose'}
-                                    </p>
-                                </div>
-                            )}
-
-                            {phase === 'terminal' && showGameOverOverlay && (
-                                <GameStartOverlay
-                                    title={playerResult === 'win' ? 'You Win!' : 'You Lose'}
-                                    canResume={false}
-                                    onResume={() => {}}
-                                    optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
-                                    optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
-                                />
-                            )}
-                        </div>
-                    </div>
-
-                    {phase === 'playing' && currentTurn === 'player' && (
-                        <div className='flex items-center justify-center gap-2 py-2 animate-pulse text-primary font-semibold text-sm'>
-                            <span>&#9650;</span>
-                            <span>{mustCapture !== null ? 'Your turn — capture required' : 'Your turn'}</span>
-                            <span>&#9650;</span>
-                        </div>
-                    )}
-
+                }
+                player={
                     <PlayerCard
                         name={user.displayName}
                         avatarUrl={user.profilePicture}
                         symbol={showSymbols ? playerLabel : undefined}
                         result={playerResult}
                     />
-                </div>
+                }
+                controls={
+                    <>
+                        {showSidePanel && (
+                            <div className='flex w-full flex-col items-center gap-2'>
+                                <div className='flex min-h-5 flex-wrap justify-center gap-1'>
+                                    {Array.from({ length: aiCaptures }, (_, i) => (
+                                        <div
+                                            key={i}
+                                            className={`h-4 w-4 rounded-full border ${isPlayerRed ? 'bg-red-500 border-red-700' : 'bg-neutral-800 border-neutral-600'}`}
+                                        />
+                                    ))}
+                                </div>
+                                <div className='h-px w-full bg-base-content/20' />
+                                <div className='flex min-h-5 flex-wrap justify-center gap-1'>
+                                    {Array.from({ length: playerCaptures }, (_, i) => (
+                                        <div
+                                            key={i}
+                                            className={`h-4 w-4 rounded-full border ${isAiRed ? 'bg-red-500 border-red-700' : 'bg-neutral-800 border-neutral-600'}`}
+                                        />
+                                    ))}
+                                </div>
+                            </div>
+                        )}
 
-                {showSidePanel && (
-                    <div className='flex flex-col overflow-hidden bg-base-200 rounded-lg p-3 w-32 shrink-0'>
-                        <div className='flex flex-wrap gap-1 min-h-6 shrink-0'>
-                            {Array.from({ length: aiCaptures }, (_, i) => (
-                                <div
-                                    key={i}
-                                    className={`w-4 h-4 rounded-full border ${isPlayerRed ? 'bg-red-500 border-red-700' : 'bg-neutral-800 border-neutral-600'}`}
-                                />
-                            ))}
-                        </div>
-
-                        <div className='h-px bg-base-content/20 my-2 shrink-0' />
-
-                        <div className='flex-1' />
-
-                        <div className='h-px bg-base-content/20 my-2 shrink-0' />
-
-                        <div className='flex flex-wrap gap-1 min-h-6 shrink-0'>
-                            {Array.from({ length: playerCaptures }, (_, i) => (
-                                <div
-                                    key={i}
-                                    className={`w-4 h-4 rounded-full border ${isAiRed ? 'bg-red-500 border-red-700' : 'bg-neutral-800 border-neutral-600'}`}
-                                />
-                            ))}
-                        </div>
+                        {phase === 'playing' && currentTurn === 'player' && (
+                            <div className='animate-pulse text-center text-sm font-semibold text-primary'>
+                                {mustCapture !== null ? 'Your turn — capture required' : 'Your turn'}
+                            </div>
+                        )}
 
                         {phase === 'playing' && (
                             <NewGameButtons
-                                className='mt-2'
+                                className='flex flex-wrap justify-center gap-2'
                                 optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
                                 optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
                                 onResign={handleResign}
                             />
                         )}
-                    </div>
-                )}
-            </div>
 
-            <GameStatsPanel gameType='checkers' />
+                        <GameStatsPanel gameType='checkers' />
+                    </>
+                }
+            />
 
             {showAuthModal && (
                 <AuthModal
@@ -587,6 +577,6 @@ export default function CheckersPage() {
                     }}
                 />
             )}
-        </div>
+        </>
     );
 }

--- a/src/frontend/src/pages/games/ChessPage.tsx
+++ b/src/frontend/src/pages/games/ChessPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import AuthModal from '../../components/AuthModal';
 import GameStatsPanel from '../../components/games/GameStatsPanel';
 import GameStartOverlay from '../../components/games/GameStartOverlay';
+import GameLayout from '../../components/games/GameLayout';
 import NewGameButtons from '../../components/games/NewGameButtons';
 import PlayerCard from '../../components/PlayerCard';
 import ChessBoard from '../../components/games/ChessBoard';
@@ -610,23 +611,18 @@ export default function ChessPage() {
     void sessionId;
 
     return (
-        <div className='container mx-auto px-4 py-4 max-w-4xl'>
+        <>
             <PageMeta title='Chess' description='Challenge an adaptive AI in a game of Chess.' noindex />
-
-            <div className='flex gap-4 items-stretch'>
-                <div className='flex flex-col'>
-                    <PlayerCard
-                        name='AI Opponent'
-                        isAi
-                        statusText={phase === 'playing' ? statusText : undefined}
-                        result={aiResult}
-                    />
-
-                    <div className='relative my-2 flex items-stretch justify-center gap-2'>
-                        {phase === 'playing' && (
-                            <EvalBar cp={evalState.cp} mate={evalState.mate} perspective={playerColor} />
-                        )}
-                        <div className='relative'>
+            <GameLayout
+                aspect={1.03}
+                board={
+                    <div className='flex h-full w-full items-stretch gap-1'>
+                        <div className='flex w-5 shrink-0'>
+                            {phase === 'playing' && (
+                                <EvalBar cp={evalState.cp} mate={evalState.mate} perspective={playerColor} />
+                            )}
+                        </div>
+                        <div className='relative min-w-0 flex-1'>
                             <ChessBoard
                                 board={board}
                                 playerColor={playerColor}
@@ -686,9 +682,9 @@ export default function ChessPage() {
                             )}
 
                             {showPromotionModal && pendingPromotion && (
-                                <div className='absolute inset-0 flex items-center justify-center bg-base-100/80 backdrop-blur-sm rounded-lg z-30'>
-                                    <div className='bg-base-200 rounded-xl p-4 shadow-lg'>
-                                        <p className='text-sm font-medium text-center mb-3'>Promote pawn to:</p>
+                                <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/80 backdrop-blur-sm'>
+                                    <div className='rounded-xl bg-base-200 p-4 shadow-lg'>
+                                        <p className='mb-3 text-center text-sm font-medium'>Promote pawn to:</p>
                                         <div className='flex gap-2'>
                                             {PROMOTION_PIECES.map(({ piece, label }) => {
                                                 const imgKey =
@@ -696,13 +692,13 @@ export default function ChessPage() {
                                                 return (
                                                     <button
                                                         key={piece}
-                                                        className='btn btn-outline btn-square w-14 h-14'
+                                                        className='btn btn-outline btn-square h-14 w-14'
                                                         title={label}
                                                         onClick={() => handlePromotion(piece)}>
                                                         <img
                                                             src={PIECE_IMG[imgKey]}
                                                             alt={label}
-                                                            className='w-10 h-10 object-contain'
+                                                            className='h-10 w-10 object-contain'
                                                         />
                                                     </button>
                                                 );
@@ -713,58 +709,62 @@ export default function ChessPage() {
                             )}
                         </div>
                     </div>
-
-                    {showInfo && inCheck && currentPlayer === playerColor && phase === 'playing' && (
-                        <div className='text-center mb-1'>
-                            <span className='badge badge-error badge-lg'>Check!</span>
-                        </div>
-                    )}
-
-                    <PlayerCard name={user.displayName} avatarUrl={user.profilePicture} result={playerResult} />
-                </div>
-
-                {showInfo && (
-                    <div className='flex flex-col flex-1 min-h-0 overflow-hidden bg-base-200 rounded-lg p-3'>
-                        <div className='flex flex-wrap gap-1 min-h-6 shrink-0'>
-                            {capturedPieces.ai.map((p, i) => (
-                                <img key={i} src={PIECE_IMG[p]} alt={p} className='w-5 h-5 object-contain' />
-                            ))}
-                        </div>
-
-                        <div className='h-px bg-base-content/20 my-2 shrink-0' />
-
-                        <div ref={moveListRef} className='flex-1 min-h-0 max-h-[50vh] overflow-y-auto'>
-                            {movePairs.map((pair, i) => (
-                                <div key={i} className='flex text-xs gap-1 leading-5'>
-                                    <span className='w-6 text-base-content/50 shrink-0'>{i + 1}.</span>
-                                    <span className='flex-1'>{pair.white ?? ''}</span>
-                                    <span className='flex-1'>{pair.black ?? ''}</span>
+                }
+                opponent={
+                    <PlayerCard
+                        name='AI Opponent'
+                        isAi
+                        statusText={phase === 'playing' ? statusText : undefined}
+                        result={aiResult}
+                    />
+                }
+                player={<PlayerCard name={user.displayName} avatarUrl={user.profilePicture} result={playerResult} />}
+                controls={
+                    <div className='flex h-full w-full flex-col gap-2'>
+                        {showInfo && (
+                            <>
+                                {inCheck && currentPlayer === playerColor && phase === 'playing' && (
+                                    <div className='shrink-0 text-center'>
+                                        <span className='badge badge-error badge-sm'>Check!</span>
+                                    </div>
+                                )}
+                                <div className='flex min-h-6 shrink-0 flex-wrap gap-1'>
+                                    {capturedPieces.ai.map((p, i) => (
+                                        <img key={i} src={PIECE_IMG[p]} alt={p} className='h-5 w-5 object-contain' />
+                                    ))}
                                 </div>
-                            ))}
-                        </div>
-
-                        <div className='h-px bg-base-content/20 my-2 shrink-0' />
-
-                        <div className='flex flex-wrap gap-1 min-h-6 shrink-0'>
-                            {capturedPieces.player.map((p, i) => (
-                                <img key={i} src={PIECE_IMG[p]} alt={p} className='w-5 h-5 object-contain' />
-                            ))}
-                        </div>
+                                <div className='h-px shrink-0 bg-base-content/20' />
+                                <div ref={moveListRef} className='min-h-0 flex-1 overflow-y-auto'>
+                                    {movePairs.map((pair, i) => (
+                                        <div key={i} className='flex gap-1 text-xs leading-5'>
+                                            <span className='w-6 shrink-0 text-base-content/50'>{i + 1}.</span>
+                                            <span className='flex-1'>{pair.white ?? ''}</span>
+                                            <span className='flex-1'>{pair.black ?? ''}</span>
+                                        </div>
+                                    ))}
+                                </div>
+                                <div className='h-px shrink-0 bg-base-content/20' />
+                                <div className='flex min-h-6 shrink-0 flex-wrap gap-1'>
+                                    {capturedPieces.player.map((p, i) => (
+                                        <img key={i} src={PIECE_IMG[p]} alt={p} className='h-5 w-5 object-contain' />
+                                    ))}
+                                </div>
+                            </>
+                        )}
 
                         {phase === 'playing' && (
-                            <div className='mt-2 shrink-0'>
-                                <NewGameButtons
-                                    optionA={{ label: 'Play as White', onClick: () => handleStartGame(true) }}
-                                    optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
-                                    onResign={handleResign}
-                                />
-                            </div>
+                            <NewGameButtons
+                                className='flex flex-wrap justify-center gap-2'
+                                optionA={{ label: 'Play as White', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
+                                onResign={handleResign}
+                            />
                         )}
-                    </div>
-                )}
-            </div>
 
-            <GameStatsPanel gameType='chess' />
+                        <GameStatsPanel gameType='chess' />
+                    </div>
+                }
+            />
 
             {showAuthModal && (
                 <AuthModal
@@ -777,6 +777,6 @@ export default function ChessPage() {
                     }}
                 />
             )}
-        </div>
+        </>
     );
 }

--- a/src/frontend/src/pages/games/Connect4Page.tsx
+++ b/src/frontend/src/pages/games/Connect4Page.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import AuthModal from '../../components/AuthModal';
 import GameStatsPanel from '../../components/games/GameStatsPanel';
 import GameStartOverlay from '../../components/games/GameStartOverlay';
+import GameLayout from '../../components/games/GameLayout';
 import NewGameButtons from '../../components/games/NewGameButtons';
 import PlayerCard from '../../components/PlayerCard';
 import Connect4Board from '../../components/games/Connect4Board';
@@ -319,81 +320,96 @@ export default function Connect4Page() {
     void sessionId;
 
     return (
-        <div className='container mx-auto px-4 py-6 max-w-lg'>
+        <>
             <PageMeta title='Connect 4' description='Drop pieces and outsmart the AI in Connect 4.' noindex />
-            <h1 className='mb-4 text-4xl font-bold text-center'>Connect 4</h1>
+            <GameLayout
+                aspect={7 / 6}
+                board={
+                    <div className='relative h-full w-full'>
+                        <Connect4Board
+                            board={board}
+                            playerStarts={playerStarts}
+                            currentTurn={currentTurn}
+                            locked={
+                                boardLocked || phase === 'terminal' || phase === 'newgame' || phase === 'resumeprompt'
+                            }
+                            winningCells={winningCells}
+                            lastDrop={lastDrop}
+                            onColumnClick={handleColumnClick}
+                            hidePieces={phase !== 'playing'}
+                        />
 
-            <PlayerCard
-                name='AI Opponent'
-                isAi
-                symbol={showSymbols ? aiSymbol : undefined}
-                statusText={phase === 'playing' ? statusText : undefined}
-                result={aiResult}
-            />
+                        {phase === 'loading' && (
+                            <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
+                                <span className='loading loading-spinner loading-lg' />
+                            </div>
+                        )}
 
-            <div className='relative my-4'>
-                <Connect4Board
-                    board={board}
-                    playerStarts={playerStarts}
-                    currentTurn={currentTurn}
-                    locked={boardLocked || phase === 'terminal' || phase === 'newgame' || phase === 'resumeprompt'}
-                    winningCells={winningCells}
-                    lastDrop={lastDrop}
-                    onColumnClick={handleColumnClick}
-                    hidePieces={phase !== 'playing'}
-                />
+                        {(phase === 'newgame' || phase === 'resumeprompt') && (
+                            <GameStartOverlay
+                                canResume={phase === 'resumeprompt'}
+                                onResume={handleResume}
+                                optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as Yellow', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
 
-                {phase === 'loading' && (
-                    <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
-                        <span className='loading loading-spinner loading-lg' />
+                        {phase === 'terminal' && !showGameOverOverlay && (
+                            <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
+                                <p className='text-2xl font-bold'>
+                                    {playerResult === 'win'
+                                        ? 'You Win!'
+                                        : playerResult === 'loss'
+                                          ? 'You Lose'
+                                          : 'Draw!'}
+                                </p>
+                            </div>
+                        )}
+
+                        {phase === 'terminal' && showGameOverOverlay && (
+                            <GameStartOverlay
+                                title={
+                                    playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'
+                                }
+                                canResume={false}
+                                onResume={() => {}}
+                                optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as Yellow', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
                     </div>
-                )}
-
-                {(phase === 'newgame' || phase === 'resumeprompt') && (
-                    <GameStartOverlay
-                        canResume={phase === 'resumeprompt'}
-                        onResume={handleResume}
-                        optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
-                        optionB={{ label: 'Play as Yellow', onClick: () => handleStartGame(false) }}
+                }
+                opponent={
+                    <PlayerCard
+                        name='AI Opponent'
+                        isAi
+                        symbol={showSymbols ? aiSymbol : undefined}
+                        statusText={phase === 'playing' ? statusText : undefined}
+                        result={aiResult}
                     />
-                )}
-
-                {phase === 'terminal' && !showGameOverOverlay && (
-                    <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
-                        <p className='text-2xl font-bold'>
-                            {playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'}
-                        </p>
-                    </div>
-                )}
-
-                {phase === 'terminal' && showGameOverOverlay && (
-                    <GameStartOverlay
-                        title={playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'}
-                        canResume={false}
-                        onResume={() => {}}
-                        optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
-                        optionB={{ label: 'Play as Yellow', onClick: () => handleStartGame(false) }}
+                }
+                player={
+                    <PlayerCard
+                        name={user.displayName}
+                        avatarUrl={user.profilePicture}
+                        symbol={showSymbols ? playerSymbol : undefined}
+                        result={playerResult}
                     />
-                )}
-            </div>
-
-            <PlayerCard
-                name={user.displayName}
-                avatarUrl={user.profilePicture}
-                symbol={showSymbols ? playerSymbol : undefined}
-                result={playerResult}
+                }
+                controls={
+                    <>
+                        {phase === 'playing' && (
+                            <NewGameButtons
+                                className='flex flex-wrap justify-center gap-2'
+                                optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as Yellow', onClick: () => handleStartGame(false) }}
+                                onResign={handleResign}
+                            />
+                        )}
+                        <GameStatsPanel gameType='connect4' />
+                    </>
+                }
             />
-
-            {phase === 'playing' && (
-                <NewGameButtons
-                    className='flex justify-center mt-4'
-                    optionA={{ label: 'Play as Red', onClick: () => handleStartGame(true) }}
-                    optionB={{ label: 'Play as Yellow', onClick: () => handleStartGame(false) }}
-                    onResign={handleResign}
-                />
-            )}
-
-            <GameStatsPanel gameType='connect4' />
 
             {showAuthModal && (
                 <AuthModal
@@ -406,6 +422,6 @@ export default function Connect4Page() {
                     }}
                 />
             )}
-        </div>
+        </>
     );
 }

--- a/src/frontend/src/pages/games/DotsAndBoxesPage.tsx
+++ b/src/frontend/src/pages/games/DotsAndBoxesPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import AuthModal from '../../components/AuthModal';
 import GameStatsPanel from '../../components/games/GameStatsPanel';
 import GameStartOverlay from '../../components/games/GameStartOverlay';
+import GameLayout from '../../components/games/GameLayout';
 import NewGameButtons from '../../components/games/NewGameButtons';
 import PlayerCard from '../../components/PlayerCard';
 import DotsAndBoxesBoard from '../../components/games/DotsAndBoxesBoard';
@@ -348,82 +349,97 @@ export default function DotsAndBoxesPage() {
     void sessionId;
 
     return (
-        <div className='container mx-auto px-4 py-6 max-w-lg'>
+        <>
             <PageMeta title='Dots and Boxes' description='Compete against AI in Dots and Boxes.' noindex />
-            <h1 className='mb-4 text-4xl font-bold text-center'>Dots and Boxes</h1>
+            <GameLayout
+                aspect={1}
+                board={
+                    <div className='relative h-full w-full'>
+                        <DotsAndBoxesBoard
+                            gridSize={4}
+                            horizontalLines={horizontalLines}
+                            verticalLines={verticalLines}
+                            boxes={boxes}
+                            currentTurn={currentTurn}
+                            locked={
+                                boardLocked || phase === 'terminal' || phase === 'newgame' || phase === 'resumeprompt'
+                            }
+                            lastLine={lastLine}
+                            onLineClick={handleLineClick}
+                            hidePieces={phase !== 'playing'}
+                        />
 
-            <PlayerCard
-                name='AI Opponent'
-                isAi
-                symbol={showScores ? String(aiScore) : undefined}
-                statusText={phase === 'playing' ? statusText : undefined}
-                result={aiResult}
-            />
+                        {phase === 'loading' && (
+                            <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
+                                <span className='loading loading-spinner loading-lg' />
+                            </div>
+                        )}
 
-            <div className='relative my-4 flex justify-center'>
-                <DotsAndBoxesBoard
-                    gridSize={4}
-                    horizontalLines={horizontalLines}
-                    verticalLines={verticalLines}
-                    boxes={boxes}
-                    currentTurn={currentTurn}
-                    locked={boardLocked || phase === 'terminal' || phase === 'newgame' || phase === 'resumeprompt'}
-                    lastLine={lastLine}
-                    onLineClick={handleLineClick}
-                    hidePieces={phase !== 'playing'}
-                />
+                        {(phase === 'newgame' || phase === 'resumeprompt') && (
+                            <GameStartOverlay
+                                canResume={phase === 'resumeprompt'}
+                                onResume={handleResume}
+                                optionA={{ label: 'Go First', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Go Second', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
 
-                {phase === 'loading' && (
-                    <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
-                        <span className='loading loading-spinner loading-lg' />
+                        {phase === 'terminal' && !showGameOverOverlay && (
+                            <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
+                                <p className='text-2xl font-bold'>
+                                    {playerResult === 'win'
+                                        ? 'You Win!'
+                                        : playerResult === 'loss'
+                                          ? 'You Lose'
+                                          : 'Draw!'}
+                                </p>
+                            </div>
+                        )}
+
+                        {phase === 'terminal' && showGameOverOverlay && (
+                            <GameStartOverlay
+                                title={
+                                    playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'
+                                }
+                                canResume={false}
+                                onResume={() => {}}
+                                optionA={{ label: 'Go First', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Go Second', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
                     </div>
-                )}
-
-                {(phase === 'newgame' || phase === 'resumeprompt') && (
-                    <GameStartOverlay
-                        canResume={phase === 'resumeprompt'}
-                        onResume={handleResume}
-                        optionA={{ label: 'Go First', onClick: () => handleStartGame(true) }}
-                        optionB={{ label: 'Go Second', onClick: () => handleStartGame(false) }}
+                }
+                opponent={
+                    <PlayerCard
+                        name='AI Opponent'
+                        isAi
+                        symbol={showScores ? String(aiScore) : undefined}
+                        statusText={phase === 'playing' ? statusText : undefined}
+                        result={aiResult}
                     />
-                )}
-
-                {phase === 'terminal' && !showGameOverOverlay && (
-                    <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
-                        <p className='text-2xl font-bold'>
-                            {playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'}
-                        </p>
-                    </div>
-                )}
-
-                {phase === 'terminal' && showGameOverOverlay && (
-                    <GameStartOverlay
-                        title={playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'}
-                        canResume={false}
-                        onResume={() => {}}
-                        optionA={{ label: 'Go First', onClick: () => handleStartGame(true) }}
-                        optionB={{ label: 'Go Second', onClick: () => handleStartGame(false) }}
+                }
+                player={
+                    <PlayerCard
+                        name={user.displayName}
+                        avatarUrl={user.profilePicture}
+                        symbol={showScores ? String(playerScore) : undefined}
+                        result={playerResult}
                     />
-                )}
-            </div>
-
-            <PlayerCard
-                name={user.displayName}
-                avatarUrl={user.profilePicture}
-                symbol={showScores ? String(playerScore) : undefined}
-                result={playerResult}
+                }
+                controls={
+                    <>
+                        {phase === 'playing' && (
+                            <NewGameButtons
+                                className='flex flex-wrap justify-center gap-2'
+                                optionA={{ label: 'Go First', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Go Second', onClick: () => handleStartGame(false) }}
+                                onResign={handleResign}
+                            />
+                        )}
+                        <GameStatsPanel gameType='dots_and_boxes' />
+                    </>
+                }
             />
-
-            {phase === 'playing' && (
-                <NewGameButtons
-                    className='flex justify-center mt-4'
-                    optionA={{ label: 'Go First', onClick: () => handleStartGame(true) }}
-                    optionB={{ label: 'Go Second', onClick: () => handleStartGame(false) }}
-                    onResign={handleResign}
-                />
-            )}
-
-            <GameStatsPanel gameType='dots_and_boxes' />
 
             {showAuthModal && (
                 <AuthModal
@@ -436,6 +452,6 @@ export default function DotsAndBoxesPage() {
                     }}
                 />
             )}
-        </div>
+        </>
     );
 }

--- a/src/frontend/src/pages/games/TicTacToePage.tsx
+++ b/src/frontend/src/pages/games/TicTacToePage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import AuthModal from '../../components/AuthModal';
 import GameStatsPanel from '../../components/games/GameStatsPanel';
 import GameStartOverlay from '../../components/games/GameStartOverlay';
+import GameLayout from '../../components/games/GameLayout';
 import NewGameButtons from '../../components/games/NewGameButtons';
 import PlayerCard from '../../components/PlayerCard';
 import TicTacToeBoard from '../../components/games/TicTacToeBoard';
@@ -307,83 +308,98 @@ export default function TicTacToePage() {
     void sessionId;
 
     return (
-        <div className='container mx-auto px-4 py-6 max-w-lg'>
+        <>
             <PageMeta
                 title='Tic Tac Toe'
                 description='Play Tic Tac Toe against an AI that adapts to your strategy.'
                 noindex
             />
-            <h1 className='mb-4 text-4xl font-bold text-center'>Tic-Tac-Toe</h1>
+            <GameLayout
+                aspect={1}
+                board={
+                    <div className='relative h-full w-full'>
+                        <TicTacToeBoard
+                            board={board}
+                            winningPositions={winningPositions}
+                            lastPosition={lastPosition}
+                            locked={
+                                boardLocked || phase === 'terminal' || phase === 'newgame' || phase === 'resumeprompt'
+                            }
+                            onCellClick={handleCellClick}
+                            hidePieces={phase !== 'playing'}
+                        />
 
-            <PlayerCard
-                name='AI Opponent'
-                isAi
-                symbol={showSymbols ? aiSymbol : undefined}
-                statusText={phase === 'playing' ? statusText : undefined}
-                result={aiResult}
-            />
+                        {phase === 'loading' && (
+                            <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
+                                <span className='loading loading-spinner loading-lg' />
+                            </div>
+                        )}
 
-            <div className='relative my-4'>
-                <TicTacToeBoard
-                    board={board}
-                    winningPositions={winningPositions}
-                    lastPosition={lastPosition}
-                    locked={boardLocked || phase === 'terminal' || phase === 'newgame' || phase === 'resumeprompt'}
-                    onCellClick={handleCellClick}
-                    hidePieces={phase !== 'playing'}
-                />
+                        {(phase === 'newgame' || phase === 'resumeprompt') && (
+                            <GameStartOverlay
+                                canResume={phase === 'resumeprompt'}
+                                onResume={handleResume}
+                                optionA={{ label: 'Play as X', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as O', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
 
-                {phase === 'loading' && (
-                    <div className='absolute inset-0 flex items-center justify-center rounded-lg bg-base-100/80'>
-                        <span className='loading loading-spinner loading-lg' />
+                        {phase === 'terminal' && !showGameOverOverlay && (
+                            <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
+                                <p className='text-2xl font-bold'>
+                                    {playerResult === 'win'
+                                        ? 'You Win!'
+                                        : playerResult === 'loss'
+                                          ? 'You Lose'
+                                          : 'Draw!'}
+                                </p>
+                            </div>
+                        )}
+
+                        {phase === 'terminal' && showGameOverOverlay && (
+                            <GameStartOverlay
+                                title={
+                                    playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'
+                                }
+                                canResume={false}
+                                onResume={() => {}}
+                                optionA={{ label: 'Play as X', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as O', onClick: () => handleStartGame(false) }}
+                            />
+                        )}
                     </div>
-                )}
-
-                {(phase === 'newgame' || phase === 'resumeprompt') && (
-                    <GameStartOverlay
-                        canResume={phase === 'resumeprompt'}
-                        onResume={handleResume}
-                        optionA={{ label: 'Play as X', onClick: () => handleStartGame(true) }}
-                        optionB={{ label: 'Play as O', onClick: () => handleStartGame(false) }}
+                }
+                opponent={
+                    <PlayerCard
+                        name='AI Opponent'
+                        isAi
+                        symbol={showSymbols ? aiSymbol : undefined}
+                        statusText={phase === 'playing' ? statusText : undefined}
+                        result={aiResult}
                     />
-                )}
-
-                {phase === 'terminal' && !showGameOverOverlay && (
-                    <div className='absolute inset-0 z-30 flex items-center justify-center rounded-lg bg-base-100/90 backdrop-blur-sm'>
-                        <p className='text-2xl font-bold'>
-                            {playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'}
-                        </p>
-                    </div>
-                )}
-
-                {phase === 'terminal' && showGameOverOverlay && (
-                    <GameStartOverlay
-                        title={playerResult === 'win' ? 'You Win!' : playerResult === 'loss' ? 'You Lose' : 'Draw!'}
-                        canResume={false}
-                        onResume={() => {}}
-                        optionA={{ label: 'Play as X', onClick: () => handleStartGame(true) }}
-                        optionB={{ label: 'Play as O', onClick: () => handleStartGame(false) }}
+                }
+                player={
+                    <PlayerCard
+                        name={user.displayName}
+                        avatarUrl={user.profilePicture}
+                        symbol={showSymbols ? playerSymbol : undefined}
+                        result={playerResult}
                     />
-                )}
-            </div>
-
-            <PlayerCard
-                name={user.displayName}
-                avatarUrl={user.profilePicture}
-                symbol={showSymbols ? playerSymbol : undefined}
-                result={playerResult}
+                }
+                controls={
+                    <>
+                        {phase === 'playing' && (
+                            <NewGameButtons
+                                className='flex flex-wrap justify-center gap-2'
+                                optionA={{ label: 'Play as X', onClick: () => handleStartGame(true) }}
+                                optionB={{ label: 'Play as O', onClick: () => handleStartGame(false) }}
+                                onResign={handleResign}
+                            />
+                        )}
+                        <GameStatsPanel gameType='tic_tac_toe' />
+                    </>
+                }
             />
-
-            {phase === 'playing' && (
-                <NewGameButtons
-                    className='flex justify-center mt-4'
-                    optionA={{ label: 'Play as X', onClick: () => handleStartGame(true) }}
-                    optionB={{ label: 'Play as O', onClick: () => handleStartGame(false) }}
-                    onResign={handleResign}
-                />
-            )}
-
-            <GameStatsPanel gameType='tic_tac_toe' />
 
             {showAuthModal && (
                 <AuthModal
@@ -396,6 +412,6 @@ export default function TicTacToePage() {
                     }}
                 />
             )}
-        </div>
+        </>
     );
 }

--- a/src/frontend/src/styles.css
+++ b/src/frontend/src/styles.css
@@ -7,3 +7,16 @@
         cyberpunk,
         synthwave;
 }
+
+.game-board-box {
+    aspect-ratio: var(--board-aspect, 1);
+    width: min(100cqw, calc(100cqh * var(--board-aspect, 1)));
+    max-height: 70cqh;
+}
+
+@media (min-width: 1024px) {
+    .game-board-box {
+        width: min(calc(100cqh * var(--board-aspect, 1)), calc(100cqw - 30.5rem));
+        max-height: 100cqh;
+    }
+}


### PR DESCRIPTION
Gives the boards much more room and removes page scrolling on the 5 active game pages (tic-tac-toe, chess, checkers, connect4, dots-and-boxes). Pong and all other pages are unchanged.

- New shared `GameLayout`: framed board centered between a players column (opponent top, you bottom) and a controls panel; both flanks hug the board and the group centers (chess.com theater style).
- Game routes are locked to the viewport height with `overflow: hidden` (no scroll; wheel does nothing); the site footer is suppressed on these routes and a compact footer lives in the side panel.
- Boards are now fully fluid (dropped fixed/capped sizes). Sizing is pure CSS via container-query units in `.game-board-box`. Chess converts to a fluid square grid with corner coordinates; chess/checkers drag ghosts are portaled to `document.body` so they track the cursor inside the query container.
- On small/narrow screens the layout stacks and the board shrinks; still no scroll.

Test plan:
- Vitest 96 passing (incl. ChessBoard tests updated to a stable `data-square` hook).
- ESLint + Prettier clean.
- Verified all 5 in-browser at 1280x900 and 1920x1000: no page scroll, square boards (connect4 7:6 with round discs), eval bar glued with square chess cells, no console errors. Reviewed locally.