### PR TITLE
Add chess engine selection (consumer side of engine publishing)

### DIFF
--- a/scripts/migrations/versions/0011_add_chess_engine_version.py
+++ b/scripts/migrations/versions/0011_add_chess_engine_version.py
@@ -1,0 +1,17 @@
+from alembic import op
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "ALTER TABLE chess_games "
+        "ADD COLUMN engine_version_id BIGINT REFERENCES model_versions(id)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE chess_games DROP COLUMN engine_version_id")

--- a/src/backend/db_models.py
+++ b/src/backend/db_models.py
@@ -3,7 +3,7 @@ from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
-from sqlalchemy import CheckConstraint, Column, Index, String, text
+from sqlalchemy import BigInteger, CheckConstraint, Column, Index, String, text
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlmodel import Field, SQLModel
 
@@ -60,6 +60,10 @@ class ChessGame(GameRecord, table=True):
     )
     move_list_algebraic: list[str] = Field(
         sa_column=Column("move_list_algebraic", ARRAY(String), nullable=False, server_default="{}")
+    )
+    engine_version_id: Optional[int] = Field(
+        default=None,
+        sa_column=Column("engine_version_id", BigInteger, nullable=True),
     )
     __table_args__ = (
         CheckConstraint(

--- a/src/backend/games.py
+++ b/src/backend/games.py
@@ -1201,11 +1201,16 @@ async def chess_resume(
 
     game = await persistence_service.get_active_game(db, user["id"], "chess")
     if not game:
-        return {"id": None, "state": None}
+        return {"id": None, "state": None, "engine": None}
 
     span.set_attribute("game.id", str(game.id))
+    engine = None
+    if game.engine_version_id is not None:
+        row = await model_registry.get_engine(db, game.engine_version_id)
+        if row:
+            engine = {"id": row["id"], "difficulty": row["difficulty"], "version": row["version"]}
     state = {**game.board_state, "move_history": game.move_list or []}
-    return {"id": str(game.id), "state": state}
+    return {"id": str(game.id), "state": state, "engine": engine}
 
 
 @router.post("/game/chess/newgame")
@@ -1231,12 +1236,23 @@ async def chess_newgame(
             q.put_nowait({"__close__": True})
         await persistence_service.close_game(db, existing.id, "chess")
 
+    engine_version_id = request.engine_version_id
+    if engine_version_id is not None:
+        engine = await model_registry.get_engine(db, engine_version_id)
+        if not engine or not engine["active"] or engine["game"] != "chess":
+            raise HTTPException(status_code=422, detail="Invalid engine_version_id")
+    else:
+        engine_version_id = await model_registry.latest_active_engine_id(db, "chess")
+
     state = _chess_engine.initial_state(request.player_starts)
-    game = await persistence_service.create_game(db, user["id"], "chess", state)
+    game = await persistence_service.create_game(
+        db, user["id"], "chess", state, engine_version_id=engine_version_id
+    )
     span.set_attribute("game.id", str(game.id))
 
     if not request.player_starts:
-        strategy = _resolve_strategy(_chess_strategy, raw_request.headers)
+        base_strategy = await _resolve_chess_strategy(db, engine_version_id)
+        strategy = _resolve_strategy(base_strategy, raw_request.headers)
         if hasattr(strategy, "set_move_history"):
             strategy.set_move_history([])
         ai_state, engine_eval = _chess_processor.process_ai_turn(_chess_engine, strategy, state)

--- a/src/backend/games.py
+++ b/src/backend/games.py
@@ -81,6 +81,35 @@ else:
 _chess_processor = MoveProcessor()
 _chess_move_queues: dict[UUID, asyncio.Queue] = {}
 
+_CHESS_WEIGHTS_ROOT = os.getenv("CHESS_MODEL_WEIGHTS_ROOT", "/app/model_weights")
+_chess_engine_cache: dict[str, object] = {}
+
+
+def _strategy_for_gcs_path(gcs_path: str):
+    cached = _chess_engine_cache.get(gcs_path)
+    if cached is not None:
+        return cached
+    from game_engine.chess_model_strategy import ChessModelStrategy
+    from ml.artifact import load_chess_model_artifact
+
+    model_dir = os.path.join(_CHESS_WEIGHTS_ROOT, gcs_path)
+    strategy = ChessModelStrategy(load_chess_model_artifact(model_dir))
+    _chess_engine_cache[gcs_path] = strategy
+    return strategy
+
+
+async def _resolve_chess_strategy(db, engine_version_id):
+    if engine_version_id is None:
+        return _chess_strategy
+    engine = await model_registry.get_engine(db, engine_version_id)
+    if not engine:
+        return _chess_strategy
+    try:
+        return _strategy_for_gcs_path(engine["gcs_path"])
+    except Exception:
+        logger.exception("chess_engine_load_failed", extra={"engine_id": engine_version_id})
+        return _chess_strategy
+
 
 _is_test_env = os.getenv("ENVIRONMENT") == "test"
 _TEST_DELAY = 0.05

--- a/src/backend/games.py
+++ b/src/backend/games.py
@@ -14,6 +14,7 @@ from opentelemetry import metrics, trace
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+import model_registry
 import persistence_service
 from auth_service import AuthService
 from db import db_dependency, get_session
@@ -38,6 +39,7 @@ from models import (
     ChessNewGameRequest,
     DaBMoveRequest,
     DaBNewGameRequest,
+    EngineRegisterRequest,
     MoveRequest,
     TttMoveRequest,
     TttNewGameRequest,
@@ -1394,6 +1396,12 @@ async def chess_legal_moves(
     return {"moves": moves}
 
 
+@router.get("/game/chess/engines")
+async def chess_engines(db: AsyncSession = Depends(db_dependency)):
+    rows = await model_registry.list_active_engines(db, "chess")
+    return {"engines": model_registry.group_and_sort_engines(rows)}
+
+
 # ============================================
 # INTERNAL ENDPOINTS
 # ============================================
@@ -1431,6 +1439,27 @@ async def cleanup_sessions(
         total += count
 
     return {"cleaned": total}
+
+
+@router.post("/internal/engines")
+async def register_engine_endpoint(
+    request: EngineRegisterRequest,
+    x_internal_key: Optional[str] = Header(None, alias="X-Internal-Key"),
+    db: AsyncSession = Depends(db_dependency),
+):
+    expected = os.getenv("INTERNAL_API_KEY")
+    if not expected or x_internal_key != expected:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    engine_id = await model_registry.register_engine(
+        db,
+        game=request.game,
+        difficulty=request.difficulty,
+        version=request.version,
+        gcs_path=request.gcs_path,
+        class_count=request.class_count,
+        source_commit=request.source_commit,
+    )
+    return {"id": engine_id}
 
 
 # ============================================

--- a/src/backend/games.py
+++ b/src/backend/games.py
@@ -1338,6 +1338,8 @@ async def chess_events(
 
     broadcaster = StatusBroadcaster()
 
+    game_strategy = await _resolve_chess_strategy(db, game_record.engine_version_id)
+
     async def process_moves():
         try:
             state = game_record.board_state
@@ -1368,16 +1370,16 @@ async def chess_events(
                 broadcaster.emit(StatusEvent("player_move", payload=_chess_state_payload(player_state, "player")))
                 broadcaster.emit(StatusEvent("status", message="Thinking..."))
 
-                if hasattr(_chess_strategy, "set_move_history"):
+                if hasattr(game_strategy, "set_move_history"):
                     fresh_record = await persistence_service.get_game(db, sid, "chess")
-                    _chess_strategy.set_move_history(
+                    game_strategy.set_move_history(
                         fresh_record.move_list if fresh_record else []
                     )
 
                 with tracer.start_as_current_span("game.ai.move") as ai_span:
                     ai_span.set_attribute("game.id", session_id)
                     t0 = time.monotonic()
-                    ai_state, engine_eval = _chess_processor.process_ai_turn(_chess_engine, _chess_strategy, player_state)
+                    ai_state, engine_eval = _chess_processor.process_ai_turn(_chess_engine, game_strategy, player_state)
                     compute_ms = (time.monotonic() - t0) * 1000
                     ai_span.set_attribute("compute_duration_ms", compute_ms)
                     _ai_duration.record(compute_ms, {"game.id": "chess"})

--- a/src/backend/model_registry.py
+++ b/src/backend/model_registry.py
@@ -1,0 +1,107 @@
+import logging
+from typing import Optional
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
+
+
+def parse_semver(version: str) -> tuple[int, int, int]:
+    parts = version.split(".")
+    if len(parts) != 3:
+        raise ValueError(f"Invalid semver: {version!r}")
+    return (int(parts[0]), int(parts[1]), int(parts[2]))
+
+
+def group_and_sort_engines(rows: list[dict]) -> list[dict]:
+    by_difficulty: dict[str, list[dict]] = {}
+    for row in rows:
+        by_difficulty.setdefault(row["difficulty"], []).append(row)
+    grouped = []
+    for difficulty in sorted(by_difficulty):
+        versions = sorted(
+            by_difficulty[difficulty],
+            key=lambda r: parse_semver(r["version"]),
+            reverse=True,
+        )
+        grouped.append(
+            {
+                "difficulty": difficulty,
+                "versions": [
+                    {
+                        "id": v["id"],
+                        "version": v["version"],
+                        "class_count": v["class_count"],
+                        "created_at": v["created_at"].isoformat() if v["created_at"] else None,
+                    }
+                    for v in versions
+                ],
+            }
+        )
+    return grouped
+
+
+async def list_active_engines(session: AsyncSession, game: str) -> list[dict]:
+    result = await session.execute(
+        text(
+            "SELECT id, difficulty, version, gcs_path, class_count, created_at "
+            "FROM model_versions WHERE active AND game = :game"
+        ),
+        {"game": game},
+    )
+    return [dict(row) for row in result.mappings().all()]
+
+
+async def get_engine(session: AsyncSession, engine_id: int) -> Optional[dict]:
+    result = await session.execute(
+        text(
+            "SELECT id, game, difficulty, version, gcs_path, class_count, active "
+            "FROM model_versions WHERE id = :id"
+        ),
+        {"id": engine_id},
+    )
+    row = result.mappings().first()
+    return dict(row) if row else None
+
+
+async def latest_active_engine_id(session: AsyncSession, game: str) -> Optional[int]:
+    rows = await list_active_engines(session, game)
+    if not rows:
+        return None
+    rows.sort(key=lambda r: (parse_semver(r["version"]), r["created_at"]), reverse=True)
+    return rows[0]["id"]
+
+
+async def register_engine(
+    session: AsyncSession,
+    *,
+    game: str,
+    difficulty: str,
+    version: str,
+    gcs_path: str,
+    class_count: Optional[int],
+    source_commit: Optional[str],
+) -> int:
+    result = await session.execute(
+        text(
+            "INSERT INTO model_versions "
+            "(game, difficulty, version, gcs_path, active, class_count, source_commit) "
+            "VALUES (:game, :difficulty, :version, :gcs_path, true, :class_count, :source_commit) "
+            "ON CONFLICT (game, difficulty, version) DO UPDATE SET "
+            "gcs_path = EXCLUDED.gcs_path, active = true, "
+            "class_count = EXCLUDED.class_count, source_commit = EXCLUDED.source_commit "
+            "RETURNING id"
+        ),
+        {
+            "game": game,
+            "difficulty": difficulty,
+            "version": version,
+            "gcs_path": gcs_path,
+            "class_count": class_count,
+            "source_commit": source_commit,
+        },
+    )
+    engine_id = result.scalar_one()
+    await session.commit()
+    return engine_id

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -78,6 +78,7 @@ class ChessNewGameRequest(BaseModel):
     """Request body for starting a new Chess game."""
 
     player_starts: bool = True
+    engine_version_id: Optional[int] = None
 
 
 class ChessMoveRequest(BaseModel):

--- a/src/backend/models.py
+++ b/src/backend/models.py
@@ -88,3 +88,12 @@ class ChessMoveRequest(BaseModel):
     toRow: int
     toCol: int
     promotionPiece: Optional[str] = None
+
+
+class EngineRegisterRequest(BaseModel):
+    game: str
+    difficulty: str
+    version: str
+    gcs_path: str
+    class_count: Optional[int] = None
+    source_commit: Optional[str] = None

--- a/src/backend/persistence_service.py
+++ b/src/backend/persistence_service.py
@@ -70,7 +70,11 @@ async def get_active_game(
 
 
 async def create_game(
-    session: AsyncSession, user_id: int, game_type: str, initial_board_state: dict
+    session: AsyncSession,
+    user_id: int,
+    game_type: str,
+    initial_board_state: dict,
+    engine_version_id: Optional[int] = None,
 ) -> GameRecord:
     """Creates a new game record with empty move_list and the given initial board state.
 
@@ -98,11 +102,14 @@ async def create_game(
         span.set_attribute("user.id", user_id)
 
         Model = GAME_TYPE_TO_MODEL[game_type]
-        record = Model(
-            user_id=user_id,
-            board_state=initial_board_state,
-            move_list=[],
-        )
+        record_kwargs: dict = {
+            "user_id": user_id,
+            "board_state": initial_board_state,
+            "move_list": [],
+        }
+        if engine_version_id is not None:
+            record_kwargs["engine_version_id"] = engine_version_id
+        record = Model(**record_kwargs)
         session.add(record)
         await session.commit()
         await session.refresh(record)

--- a/src/frontend/src/api/chess.engines.test.ts
+++ b/src/frontend/src/api/chess.engines.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { chessNewGame, fetchChessEngines } from './chess';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('chess engines api', () => {
+    it('fetchChessEngines returns the engines array', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async () => ({
+                ok: true,
+                json: async () => ({ engines: [{ difficulty: 'cnn', versions: [] }] }),
+            }))
+        );
+        const engines = await fetchChessEngines();
+        expect(engines).toEqual([{ difficulty: 'cnn', versions: [] }]);
+    });
+
+    it('chessNewGame sends engine_version_id', async () => {
+        const fetchMock = vi.fn(async () => ({ ok: true, json: async () => ({ id: 'x', state: {} }) }));
+        vi.stubGlobal('fetch', fetchMock);
+        await chessNewGame(true, 7);
+        const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+        expect(body).toMatchObject({ player_starts: true, engine_version_id: 7 });
+    });
+});

--- a/src/frontend/src/api/chess.ts
+++ b/src/frontend/src/api/chess.ts
@@ -46,9 +46,28 @@ export interface ChessMoveData extends Partial<ChessGameState> {
     winner: 'player' | 'ai' | 'draw' | null;
 }
 
+export interface ChessEngineVersion {
+    id: number;
+    version: string;
+    class_count: number | null;
+    created_at: string;
+}
+
+export interface ChessEngineGroup {
+    difficulty: string;
+    versions: ChessEngineVersion[];
+}
+
+export interface ChessEngineRef {
+    id: number;
+    difficulty: string;
+    version: string;
+}
+
 export interface ChessResumeResponse {
     id: string | null;
     state: ChessGameState | null;
+    engine?: ChessEngineRef | null;
 }
 
 export interface ChessNewGameResponse {
@@ -86,10 +105,10 @@ export async function chessResume(): Promise<ChessResumeResponse> {
  * @returns New game session id and initial board state.
  * @throws {GameApiError} If the request fails.
  */
-export async function chessNewGame(playerStarts: boolean): Promise<ChessNewGameResponse> {
+export async function chessNewGame(playerStarts: boolean, engineVersionId?: number): Promise<ChessNewGameResponse> {
     return request<ChessNewGameResponse>('/api/game/chess/newgame', {
         method: 'POST',
-        body: JSON.stringify({ player_starts: playerStarts }),
+        body: JSON.stringify({ player_starts: playerStarts, engine_version_id: engineVersionId ?? null }),
     });
 }
 
@@ -181,4 +200,9 @@ export async function chessLegalMoves(fromRow: number, fromCol: number): Promise
         `/api/game/chess/legal-moves?from_row=${fromRow}&from_col=${fromCol}`
     );
     return data.moves;
+}
+
+export async function fetchChessEngines(): Promise<ChessEngineGroup[]> {
+    const data = await request<{ engines: ChessEngineGroup[] }>('/api/game/chess/engines');
+    return data.engines;
 }

--- a/src/frontend/src/components/games/ChessEngineSelect.test.tsx
+++ b/src/frontend/src/components/games/ChessEngineSelect.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ChessEngineSelect from './ChessEngineSelect';
+import * as api from '../../api/chess';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('ChessEngineSelect', () => {
+    it('loads engines and reports the selected version id', async () => {
+        vi.spyOn(api, 'fetchChessEngines').mockResolvedValue([
+            { difficulty: 'cnn', versions: [{ id: 5, version: '1.0.0', class_count: 1, created_at: '' }] },
+        ]);
+        const onChange = vi.fn();
+        render(<ChessEngineSelect onChange={onChange} />);
+        await waitFor(() => expect(onChange).toHaveBeenCalledWith(5));
+        expect(screen.getByLabelText('Model')).toBeInTheDocument();
+        expect(screen.getByLabelText('Version')).toBeInTheDocument();
+    });
+});

--- a/src/frontend/src/components/games/ChessEngineSelect.tsx
+++ b/src/frontend/src/components/games/ChessEngineSelect.tsx
@@ -44,8 +44,7 @@ export default function ChessEngineSelect({ onChange }: ChessEngineSelectProps) 
                     className='select select-bordered select-sm'
                     aria-label='Model'
                     value={model}
-                    onChange={e => setModel(e.target.value)}
-                >
+                    onChange={e => setModel(e.target.value)}>
                     {groups.map(g => (
                         <option key={g.difficulty} value={g.difficulty}>
                             {g.difficulty}
@@ -63,8 +62,7 @@ export default function ChessEngineSelect({ onChange }: ChessEngineSelectProps) 
                         const id = Number(e.target.value);
                         setVersionId(id);
                         onChange(id);
-                    }}
-                >
+                    }}>
                     {(current?.versions ?? []).map(v => (
                         <option key={v.id} value={v.id}>
                             {v.version}

--- a/src/frontend/src/components/games/ChessEngineSelect.tsx
+++ b/src/frontend/src/components/games/ChessEngineSelect.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import { fetchChessEngines, type ChessEngineGroup } from '../../api/chess';
+
+interface ChessEngineSelectProps {
+    onChange: (engineVersionId: number | null) => void;
+}
+
+export default function ChessEngineSelect({ onChange }: ChessEngineSelectProps) {
+    const [groups, setGroups] = useState<ChessEngineGroup[]>([]);
+    const [model, setModel] = useState<string>('');
+    const [versionId, setVersionId] = useState<number | null>(null);
+
+    useEffect(() => {
+        let active = true;
+        fetchChessEngines()
+            .then(data => {
+                if (!active) return;
+                setGroups(data);
+                if (data.length > 0) {
+                    setModel(data[0].difficulty);
+                }
+            })
+            .catch(() => setGroups([]));
+        return () => {
+            active = false;
+        };
+    }, []);
+
+    const current = groups.find(g => g.difficulty === model);
+
+    useEffect(() => {
+        const first = current?.versions[0]?.id ?? null;
+        setVersionId(first);
+        onChange(first);
+    }, [model, groups]);
+
+    if (groups.length === 0) return null;
+
+    return (
+        <div className='flex flex-col gap-2 w-full max-w-xs px-4'>
+            <label className='flex flex-col text-xs uppercase tracking-wider text-base-content/50'>
+                Model
+                <select
+                    className='select select-bordered select-sm'
+                    aria-label='Model'
+                    value={model}
+                    onChange={e => setModel(e.target.value)}
+                >
+                    {groups.map(g => (
+                        <option key={g.difficulty} value={g.difficulty}>
+                            {g.difficulty}
+                        </option>
+                    ))}
+                </select>
+            </label>
+            <label className='flex flex-col text-xs uppercase tracking-wider text-base-content/50'>
+                Version
+                <select
+                    className='select select-bordered select-sm'
+                    aria-label='Version'
+                    value={versionId ?? ''}
+                    onChange={e => {
+                        const id = Number(e.target.value);
+                        setVersionId(id);
+                        onChange(id);
+                    }}
+                >
+                    {(current?.versions ?? []).map(v => (
+                        <option key={v.id} value={v.id}>
+                            {v.version}
+                        </option>
+                    ))}
+                </select>
+            </label>
+        </div>
+    );
+}

--- a/src/frontend/src/components/games/GameStartOverlay.tsx
+++ b/src/frontend/src/components/games/GameStartOverlay.tsx
@@ -1,16 +1,22 @@
+import { type ReactNode } from 'react';
+
 interface GameStartOverlayProps {
     canResume: boolean;
     onResume: () => void;
     optionA: { label: string; onClick: () => void };
     optionB: { label: string; onClick: () => void };
     title?: string;
+    extra?: ReactNode;
 }
 
-/**
- * Renders an overlay with resume and new game options shown before or after a game.
- * Pass `title` to display a result heading (e.g. "You Win!") at the top.
- */
-export default function GameStartOverlay({ canResume, onResume, optionA, optionB, title }: GameStartOverlayProps) {
+export default function GameStartOverlay({
+    canResume,
+    onResume,
+    optionA,
+    optionB,
+    title,
+    extra,
+}: GameStartOverlayProps) {
     return (
         <div className='absolute inset-0 z-30 flex flex-col items-center justify-center gap-3 rounded-lg bg-base-100/90 backdrop-blur-sm'>
             {title && <p className='text-2xl font-bold'>{title}</p>}
@@ -18,6 +24,7 @@ export default function GameStartOverlay({ canResume, onResume, optionA, optionB
                 Continue Game
             </button>
 
+            {extra}
             <div className='flex flex-col items-center gap-2 w-full max-w-xs px-4'>
                 <div className='flex items-center gap-2 w-full'>
                     <div className='flex-1 h-px bg-base-content/20' />

--- a/src/frontend/src/pages/games/ChessPage.tsx
+++ b/src/frontend/src/pages/games/ChessPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import AuthModal from '../../components/AuthModal';
 import GameStatsPanel from '../../components/games/GameStatsPanel';
 import GameStartOverlay from '../../components/games/GameStartOverlay';
+import ChessEngineSelect from '../../components/games/ChessEngineSelect';
 import GameLayout from '../../components/games/GameLayout';
 import NewGameButtons from '../../components/games/NewGameButtons';
 import PlayerCard from '../../components/PlayerCard';
@@ -84,6 +85,7 @@ export default function ChessPage() {
     const [currentFen, setCurrentFen] = useState<string | null>(null);
     const [board, setBoard] = useState<(string | null)[][]>(emptyBoard());
     const [playerColor, setPlayerColor] = useState<'white' | 'black'>('white');
+    const [selectedEngineId, setSelectedEngineId] = useState<number | null>(null);
     const [currentPlayer, setCurrentPlayer] = useState<'white' | 'black'>('white');
     const [inCheck, setInCheck] = useState(false);
     const [capturedPieces, setCapturedPieces] = useState<{ player: string[]; ai: string[] }>({ player: [], ai: [] });
@@ -343,7 +345,7 @@ export default function ChessPage() {
         setBoardLocked(true);
         setPhase('playing');
         try {
-            const { id, state } = await chessNewGame(goFirst);
+            const { id, state } = await chessNewGame(goFirst, selectedEngineId ?? undefined);
             setSessionId(id);
             setCurrentFen(state.fen ?? null);
             setBoard(state.board);
@@ -650,6 +652,7 @@ export default function ChessPage() {
                                     onResume={handleResume}
                                     optionA={{ label: 'Play as White', onClick: () => handleStartGame(true) }}
                                     optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
+                                    extra={<ChessEngineSelect onChange={setSelectedEngineId} />}
                                 />
                             )}
 
@@ -678,6 +681,7 @@ export default function ChessPage() {
                                     onResume={() => {}}
                                     optionA={{ label: 'Play as White', onClick: () => handleStartGame(true) }}
                                     optionB={{ label: 'Play as Black', onClick: () => handleStartGame(false) }}
+                                    extra={<ChessEngineSelect onChange={setSelectedEngineId} />}
                                 />
                             )}
 

--- a/tests/api_tests/test_engines.py
+++ b/tests/api_tests/test_engines.py
@@ -39,3 +39,23 @@ def test_register_then_discoverable(client):
     groups = listing.json()["engines"]
     cnn = next(g for g in groups if g["difficulty"] == "cnn")
     assert any(v["id"] == engine_id and v["version"] == "1.2.0" for v in cnn["versions"])
+
+
+def test_newgame_defaults_to_latest_engine_and_resume_reports_it(auth_client):
+    new = auth_client.post("/api/game/chess/newgame", json={"player_starts": True})
+    assert new.status_code == 200
+
+    resumed = auth_client.get("/api/game/chess/resume")
+    assert resumed.status_code == 200
+    engine = resumed.json()["engine"]
+    assert engine is not None
+    assert engine["difficulty"]
+    assert engine["version"]
+
+
+def test_newgame_rejects_unknown_engine(auth_client):
+    response = auth_client.post(
+        "/api/game/chess/newgame",
+        json={"player_starts": True, "engine_version_id": 999999},
+    )
+    assert response.status_code == 422

--- a/tests/api_tests/test_engines.py
+++ b/tests/api_tests/test_engines.py
@@ -1,0 +1,41 @@
+import os
+
+
+def test_register_requires_key(client):
+    response = client.post(
+        "/api/internal/engines",
+        json={
+            "game": "chess",
+            "difficulty": "untrained",
+            "version": "9.9.9",
+            "gcs_path": "chess/untrained/9.9.9",
+            "class_count": 10,
+            "source_commit": "abc",
+        },
+    )
+    assert response.status_code == 403
+
+
+def test_register_then_discoverable(client):
+    key = os.environ["INTERNAL_API_KEY"]
+    response = client.post(
+        "/api/internal/engines",
+        headers={"X-Internal-Key": key},
+        json={
+            "game": "chess",
+            "difficulty": "cnn",
+            "version": "1.2.0",
+            "gcs_path": "chess/cnn/1.2.0",
+            "class_count": 42,
+            "source_commit": "deadbeef",
+        },
+    )
+    assert response.status_code == 200
+    engine_id = response.json()["id"]
+    assert isinstance(engine_id, int)
+
+    listing = client.get("/api/game/chess/engines")
+    assert listing.status_code == 200
+    groups = listing.json()["engines"]
+    cnn = next(g for g in groups if g["difficulty"] == "cnn")
+    assert any(v["id"] == engine_id and v["version"] == "1.2.0" for v in cnn["versions"])

--- a/tests/api_tests/test_engines.py
+++ b/tests/api_tests/test_engines.py
@@ -1,6 +1,3 @@
-import os
-
-
 def test_register_requires_key(client):
     response = client.post(
         "/api/internal/engines",
@@ -16,11 +13,11 @@ def test_register_requires_key(client):
     assert response.status_code == 403
 
 
-def test_register_then_discoverable(client):
-    key = os.environ["INTERNAL_API_KEY"]
+def test_register_then_discoverable(client, monkeypatch):
+    monkeypatch.setenv("INTERNAL_API_KEY", "test-internal-key")
     response = client.post(
         "/api/internal/engines",
-        headers={"X-Internal-Key": key},
+        headers={"X-Internal-Key": "test-internal-key"},
         json={
             "game": "chess",
             "difficulty": "cnn",

--- a/tests/unit/test_chess_engine_resolver.py
+++ b/tests/unit/test_chess_engine_resolver.py
@@ -1,0 +1,13 @@
+import os
+
+import games
+
+
+def test_strategy_for_gcs_path_loads_fixture_and_caches(monkeypatch):
+    fixtures = os.path.abspath("tests/fixtures")
+    monkeypatch.setattr(games, "_CHESS_WEIGHTS_ROOT", fixtures)
+    games._chess_engine_cache.clear()
+    first = games._strategy_for_gcs_path("chess_model_tiny")
+    second = games._strategy_for_gcs_path("chess_model_tiny")
+    assert first is second
+    assert hasattr(first, "generate_move")

--- a/tests/unit/test_model_registry.py
+++ b/tests/unit/test_model_registry.py
@@ -1,0 +1,17 @@
+import model_registry
+
+
+def test_parse_semver_orders_numerically():
+    assert model_registry.parse_semver("2.10.0") > model_registry.parse_semver("2.9.1")
+
+
+def test_group_and_sort_engines_groups_by_difficulty_and_sorts_desc():
+    rows = [
+        {"id": 1, "difficulty": "untrained", "version": "0.1.0", "class_count": 10, "created_at": None},
+        {"id": 2, "difficulty": "untrained", "version": "0.2.0", "class_count": 11, "created_at": None},
+        {"id": 3, "difficulty": "cnn", "version": "1.0.0", "class_count": 12, "created_at": None},
+    ]
+    grouped = model_registry.group_and_sort_engines(rows)
+    assert [g["difficulty"] for g in grouped] == ["cnn", "untrained"]
+    untrained = next(g for g in grouped if g["difficulty"] == "untrained")
+    assert [v["version"] for v in untrained["versions"]] == ["0.2.0", "0.1.0"]


### PR DESCRIPTION
## Summary
- Players choose a chess engine (model + version) when starting a game, alongside the color choice; the choice is stored on the game and reused on resume.
- Adds the registry the publisher targets: `POST /api/internal/engines` (X-Internal-Key) upserts a `model_versions` row; `GET /api/game/chess/engines` (public) lists active engines grouped by model, versions newest-first.
- Migration 0011 adds `chess_games.engine_version_id` (FK to `model_versions`). New games pin the chosen engine (or the latest active one); the SSE move loop loads that engine's ONNX bundle from the mounted models bucket via a per-path cache, falling back to the default strategy when the bundle is absent.
- Frontend: engines fetch, engine id on new game, and a `ChessEngineSelect` model/version dropdown wired into the new-game overlay.

## Test plan
- Backend: `tests/api_tests/test_engines.py` (register guard, discovery shape, new-game pin, resume reports engine) plus unit tests for `model_registry` semver/grouping and the per-game strategy cache. 11 API + unit tests pass locally.
- Frontend: vitest for the engines API and `ChessEngineSelect`; full suite 99 passing; lint and prettier clean.
- Pairs with the producer side in chess_CNN (calls `POST /api/internal/engines`).
