### PR TITLE
fix(chess): deliver player_move SSE events to the move list

### DIFF
--- a/src/backend/game_engine/base.py
+++ b/src/backend/game_engine/base.py
@@ -232,8 +232,8 @@ class StatusEvent:
             return 'data: {"type": "heartbeat"}\n\n'
         if self.type == "status":
             return f'data: {json.dumps({"type": "status", "message": self.data["message"]})}\n\n'
-        if self.type == "move":
-            return f'data: {json.dumps({"type": "move", "data": self.data["payload"]})}\n\n'
+        if self.type in ("move", "player_move"):
+            return f'data: {json.dumps({"type": self.type, "data": self.data["payload"]})}\n\n'
         if self.type == "error":
             return f'data: {json.dumps({"type": "error", "code": self.data.get("code"), "message": self.data.get("message")})}\n\n'
         return f'data: {json.dumps({"type": self.type})}\n\n'
@@ -287,7 +287,9 @@ class StatusBroadcaster:
                     last_sent = time.monotonic()
                 continue
 
-            if event.type in ("move", "error"):
+            if event.type == "player_move":
+                yield event.to_sse()
+            elif event.type in ("move", "error"):
                 if pending is not None:
                     remaining = self.MIN_INTERVAL - (time.monotonic() - last_sent)
                     if remaining > 0:

--- a/tests/unit/test_ai_delay_config.py
+++ b/tests/unit/test_ai_delay_config.py
@@ -1,3 +1,4 @@
+import asyncio
 import importlib
 import os
 
@@ -50,3 +51,20 @@ def test_status_broadcaster_min_interval(monkeypatch):
 def test_status_broadcaster_test_env_override(monkeypatch):
     b = reload_base(monkeypatch, {"GAME_SERVER_MIN_EVENT_INTERVAL_MS": "5000", "ENVIRONMENT": "test"})
     assert b.StatusBroadcaster.MIN_INTERVAL <= 0.05
+
+
+def test_status_broadcaster_delivers_player_move_with_payload(monkeypatch):
+    b = reload_base(monkeypatch, {"ENVIRONMENT": "test"})
+    broadcaster = b.StatusBroadcaster()
+    broadcaster.emit(b.StatusEvent("player_move", payload={"notation": "e5", "player": "player"}))
+    broadcaster.emit(b.StatusEvent("move", payload={"notation": "Nf3", "status": "complete"}))
+
+    async def collect():
+        chunks = []
+        async for chunk in broadcaster.stream():
+            chunks.append(chunk)
+        return chunks
+
+    out = "".join(asyncio.run(collect()))
+    assert '"type": "player_move"' in out
+    assert '"notation": "e5"' in out


### PR DESCRIPTION
The chess move list only showed the bot's moves; the player's moves never appeared (e.g. playing the Sicilian as black showed `1. e4 Nf3` instead of `1. e4 e5 / 2. Nf3 Nc6`).

Root cause, both in `StatusBroadcaster` (`game_engine/base.py`):
- `stream()` had no branch for the `player_move` event type, so it was pulled off the queue and silently discarded (only `move`/`error`/`status`/heartbeat were handled).
- `to_sse()` had no `player_move` case either, so even if yielded it serialized to `{"type":"player_move"}` with no `data` payload, which the frontend ignores.

Fix: yield `player_move` immediately (it's the player's own move echo and bypasses the AI-move cadence) and serialize it with its payload. Only chess emits `player_move`, so other games are unaffected.

Test plan:
- New unit test drives a `player_move` through `stream()` + `to_sse()` and asserts the payload (notation) is delivered.
- 250 python unit tests + 7 chess API tests pass.
- Verified live: playing black, the list now shows `1. Nf3 e5 / 2. Nxe5` (both player and bot moves).