### PR TITLE
test(chess): fix stale e2e board selectors and cover engine fallback

### DIFF
--- a/src/frontend/src/components/games/ChessBoard.tsx
+++ b/src/frontend/src/components/games/ChessBoard.tsx
@@ -172,7 +172,7 @@ export default function ChessBoard({
     const getFileLabel = (c: number) => String.fromCharCode(97 + c);
 
     return (
-        <div className='grid h-full w-full select-none grid-cols-8 grid-rows-8'>
+        <div data-testid='chess-board' className='grid h-full w-full select-none grid-cols-8 grid-rows-8'>
             {rows.map((r, displayRow) =>
                 cols.map((c, displayCol) => {
                     const piece = board[r][c];

--- a/tests/e2e/chess.spec.ts
+++ b/tests/e2e/chess.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect, Page, Locator } from '@playwright/test';
 
 const BASE_API = 'http://localhost:8000/api';
 
@@ -6,6 +6,10 @@ async function loginDemoUser(page: Page) {
     await page.request.post(`${BASE_API}/auth/login`, {
         data: { email: 'demo@aigamehub.com', password: 'demo123' },
     });
+}
+
+function square(board: Locator, row: number, col: number): Locator {
+    return board.locator(`[data-square="${row}-${col}"]`);
 }
 
 test.describe('Chess — full game flows', () => {
@@ -26,75 +30,90 @@ test.describe('Chess — full game flows', () => {
 
     test('test_chess_new_game_shows_board', async ({ page }) => {
         await page.locator('button:has-text("Play as White")').click();
-        await expect(page.locator('.border-amber-900')).toBeVisible({ timeout: 5000 });
+        const board = page.getByTestId('chess-board');
+        await expect(board).toBeVisible({ timeout: 5000 });
+        await expect(board.locator('img').first()).toBeVisible({ timeout: 5000 });
     });
 
     test('test_chess_player_move_reflected_in_ui', async ({ page }) => {
         const newgameResp = page.waitForResponse(r => r.url().includes('/chess/newgame'));
         await page.locator('button:has-text("Play as White")').click();
 
-        const board = page.locator('.border-amber-900').first();
+        const board = page.getByTestId('chess-board');
         await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
+        await expect(board.locator('img').first()).toBeVisible({ timeout: 5000 });
 
-        // Click e2 pawn (row 6 col 4 = square 52 from top-left) then e4 (row 4 col 4 = square 36)
-        const squares = board.locator('> div > div');
-        await squares.nth(52).click();
+        await square(board, 6, 4).click();
         await page.waitForTimeout(300);
-        await squares.nth(36).click();
+        await square(board, 4, 4).click();
         await page.waitForTimeout(1500);
 
-        // Board should still be visible after the move
-        await expect(board).toBeVisible({ timeout: 3000 });
+        await expect(square(board, 4, 4).locator('img')).toBeVisible({ timeout: 3000 });
     });
 
     test('test_chess_game_over_overlay_available', async ({ page }) => {
         const newgameResp = page.waitForResponse(r => r.url().includes('/chess/newgame'));
         await page.locator('button:has-text("Play as White")').click();
 
-        const board = page.locator('.border-amber-900').first();
+        const board = page.getByTestId('chess-board');
         await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
+        await expect(board.locator('img').first()).toBeVisible({ timeout: 5000 });
 
-        const squares = board.locator('> div > div');
-
-        // Attempt Scholar's Mate sequence: e4, Bc4, Qh5, Qxf7
-        const moves: [number, number][] = [
-            [52, 36], // e2-e4
-            [61, 34], // Bf1-c4
-            [59, 31], // Qd1-h5
-            [31, 13], // Qh5xf7
+        const moves: [[number, number], [number, number]][] = [
+            [
+                [6, 4],
+                [4, 4],
+            ],
+            [
+                [7, 5],
+                [4, 2],
+            ],
+            [
+                [7, 3],
+                [3, 7],
+            ],
+            [
+                [3, 7],
+                [1, 5],
+            ],
         ];
 
-        for (const [from, to] of moves) {
-            await squares.nth(from).click();
+        const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
+
+        for (const [[fromRow, fromCol], [toRow, toCol]] of moves) {
+            await square(board, fromRow, fromCol).click();
             await page.waitForTimeout(300);
-            await squares.nth(to).click();
+            await square(board, toRow, toCol).click();
             await page.waitForTimeout(1500);
 
-            const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
             if ((await gameOverText.count()) > 0) break;
         }
 
-        const gameOverText = page.locator('p:has-text("You Win!"), p:has-text("You Lose"), p:has-text("Draw!")');
-        const boardVisible = await board.isVisible();
         const gameOver = (await gameOverText.count()) > 0;
 
         if (gameOver) {
             await expect(gameOverText.first()).toBeVisible();
             await expect(page.locator('button:has-text("Play as White")')).toBeVisible({ timeout: 3000 });
         } else {
-            expect(boardVisible).toBe(true);
+            await expect(board).toBeVisible();
         }
     });
 
     test('test_chess_resume_after_page_refresh', async ({ page }) => {
         const newgameResp = page.waitForResponse(r => r.url().includes('/chess/newgame'));
         await page.locator('button:has-text("Play as White")').click();
-        const board = page.locator('.border-amber-900').first();
+        const board = page.getByTestId('chess-board');
         await Promise.all([expect(board).toBeVisible({ timeout: 5000 }), newgameResp]);
+        await expect(board.locator('img').first()).toBeVisible({ timeout: 5000 });
 
         await page.reload();
         await page.waitForLoadState('networkidle');
 
+        const resumeButton = page.locator('button:has-text("Continue Game")');
+        await expect(resumeButton).toBeEnabled({ timeout: 5000 });
+        await resumeButton.click();
+
         await expect(board).toBeVisible({ timeout: 5000 });
+        await expect(board.locator('img').first()).toBeVisible({ timeout: 5000 });
     });
 });

--- a/tests/unit/test_chess_engine_resolver.py
+++ b/tests/unit/test_chess_engine_resolver.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 import games
@@ -11,3 +12,45 @@ def test_strategy_for_gcs_path_loads_fixture_and_caches(monkeypatch):
     second = games._strategy_for_gcs_path("chess_model_tiny")
     assert first is second
     assert hasattr(first, "generate_move")
+
+
+def test_resolve_chess_strategy_no_engine_returns_scripted():
+    result = asyncio.run(games._resolve_chess_strategy(None, None))
+    assert result is games._chess_strategy
+
+
+def test_resolve_chess_strategy_unknown_engine_returns_scripted(monkeypatch):
+    async def fake_get_engine(db, engine_id):
+        return None
+
+    monkeypatch.setattr(games.model_registry, "get_engine", fake_get_engine)
+    result = asyncio.run(games._resolve_chess_strategy(object(), 999))
+    assert result is games._chess_strategy
+
+
+def test_resolve_chess_strategy_loads_model_when_artifact_present(monkeypatch):
+    fixtures = os.path.abspath("tests/fixtures")
+    monkeypatch.setattr(games, "_CHESS_WEIGHTS_ROOT", fixtures)
+    games._chess_engine_cache.clear()
+
+    async def fake_get_engine(db, engine_id):
+        return {"gcs_path": "chess_model_tiny"}
+
+    monkeypatch.setattr(games.model_registry, "get_engine", fake_get_engine)
+    result = asyncio.run(games._resolve_chess_strategy(object(), 1))
+    assert result is not games._chess_strategy
+    assert result is games._strategy_for_gcs_path("chess_model_tiny")
+    assert hasattr(result, "generate_move")
+
+
+def test_resolve_chess_strategy_falls_back_when_artifact_missing(monkeypatch):
+    fixtures = os.path.abspath("tests/fixtures")
+    monkeypatch.setattr(games, "_CHESS_WEIGHTS_ROOT", fixtures)
+    games._chess_engine_cache.clear()
+
+    async def fake_get_engine(db, engine_id):
+        return {"gcs_path": "chess/does_not_exist/9.9.9"}
+
+    monkeypatch.setattr(games.model_registry, "get_engine", fake_get_engine)
+    result = asyncio.run(games._resolve_chess_strategy(object(), 1))
+    assert result is games._chess_strategy


### PR DESCRIPTION
## What

The nightly Cross-Browser E2E has failed since 06-08. Cause: the board-centric layout (#253) replaced the `.border-amber-900` board wrapper, but `tests/e2e/chess.spec.ts` still selected it, so every board-dependent chess test timed out. PR CI stayed green because its e2e job does not run `tests/e2e/chess.spec.ts` (only smoke + an explicit `tests/api/*` list); the full Playwright suite runs only in the nightly.

## Changes

- `chess.spec.ts`: retarget the board to `data-testid="chess-board"` and squares to their existing `data-square="row-col"` coords (drops the brittle `> div > div` / `nth()` logic); resume test now drives the "Continue Game" prompt explicitly.
- `ChessBoard.tsx`: add `data-testid="chess-board"` to the board root (one stable test hook).
- `test_chess_engine_resolver.py`: cover both branches of `_resolve_chess_strategy` — model loaded via the `chess_model_tiny` fixture, and fallback to the scripted strategy when the engine is unknown or the artifact is missing.

The chess e2e runs against a server with no model bundle, so it exercises the scripted-fallback path end to end.

## Test plan

- `tests/unit/test_chess_engine_resolver.py`: 5 passed.
- `tests/e2e/chess.spec.ts`: 15 passed (chromium, firefox, webkit), `--workers=1`, against a real backend on the fallback path.
- `vite build`, `prettier --check`, `eslint` clean on changed files.

Note: the underlying engine-bundle gap (an active engine is seeded but no bundle is deployed, so `chess_engine_load_failed` is logged on every game before falling back) is intentionally out of scope here and tracked separately.