### PR TITLE
fix(deps): override shell-quote to ^1.8.4 for critical advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4276,9 +4276,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-            "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -66,5 +66,8 @@
         "typescript": "^6.0.2",
         "vite": "^8.0.3",
         "vitest": "^4.1.2"
+    },
+    "overrides": {
+        "shell-quote": "^1.8.4"
     }
 }


### PR DESCRIPTION
## What

`npm audit --audit-level=high` (the Code Quality gate) flags a critical advisory in `shell-quote <=1.8.3` (GHSA-w7jw-789q-3m8p), pulled in transitively via the `concurrently` devDependency. `concurrently` is already at the latest `^9.2.1` and still resolves the vulnerable `shell-quote`, so there is no version bump that fixes it; this fails Code Quality on every PR (and main's next run).

## Change

Add an `overrides` entry pinning `shell-quote` to `^1.8.4` (a patch release outside the affected range). No production dependencies change.

## Test plan

- `npm install` then `npm audit --audit-level=high` -> `found 0 vulnerabilities`.
- Installed `shell-quote` resolves to `1.8.4`.